### PR TITLE
[#32] Bump jsx to 3.0.0 which returns maps by default

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,5 +2,5 @@
 {edoc_opts, [{dir, "edoc"}]}.
 {deps, [{erlware_commons, "1.3.1"},
         {hackney, "1.15.2"},
-        {jsx, "2.10.0"}
+        {jsx, "3.0.0"}
        ]}.


### PR DESCRIPTION
Fixes #32