### PR TITLE
Send body as binary for some services

### DIFF
--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -421,8 +421,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -417,7 +417,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -734,7 +734,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -738,8 +738,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -2386,7 +2386,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -2390,8 +2390,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -95,8 +95,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -91,7 +91,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_apigatewayv2.erl
+++ b/src/aws_apigatewayv2.erl
@@ -1381,8 +1381,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -911,8 +911,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -907,7 +907,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -837,8 +837,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -833,7 +833,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -427,7 +427,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -431,8 +431,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -816,7 +816,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -820,8 +820,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -1116,8 +1116,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -1112,7 +1112,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -505,8 +505,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -501,7 +501,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -196,8 +196,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -192,7 +192,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -3872,8 +3872,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -3868,7 +3868,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -1513,8 +1513,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -1509,7 +1509,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -2565,8 +2565,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -2561,7 +2561,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"text/xml">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_cloudsearchdomain.erl
+++ b/src/aws_cloudsearchdomain.erl
@@ -177,7 +177,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_cloudsearchdomain.erl
+++ b/src/aws_cloudsearchdomain.erl
@@ -181,8 +181,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -1138,8 +1138,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -1134,7 +1134,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -368,7 +368,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -372,8 +372,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -619,8 +619,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -615,7 +615,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -336,8 +336,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -332,7 +332,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_cognitosync.erl
+++ b/src/aws_cognitosync.erl
@@ -471,7 +471,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_cognitosync.erl
+++ b/src/aws_cognitosync.erl
@@ -475,8 +475,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -1697,8 +1697,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -1693,7 +1693,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -169,7 +169,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -173,8 +173,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -787,8 +787,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -783,7 +783,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -451,7 +451,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -455,8 +455,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_detective.erl
+++ b/src/aws_detective.erl
@@ -387,7 +387,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_detective.erl
+++ b/src/aws_detective.erl
@@ -391,8 +391,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -202,8 +202,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -198,7 +198,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -245,8 +245,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -241,7 +241,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_efs.erl
+++ b/src/aws_efs.erl
@@ -914,8 +914,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_efs.erl
+++ b/src/aws_efs.erl
@@ -910,7 +910,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_eks.erl
+++ b/src/aws_eks.erl
@@ -646,7 +646,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_eks.erl
+++ b/src/aws_eks.erl
@@ -650,8 +650,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_elastic_inference.erl
+++ b/src/aws_elastic_inference.erl
@@ -145,8 +145,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_elastic_inference.erl
+++ b/src/aws_elastic_inference.erl
@@ -141,7 +141,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_elastic_transcoder.erl
+++ b/src/aws_elastic_transcoder.erl
@@ -430,8 +430,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_elastic_transcoder.erl
+++ b/src/aws_elastic_transcoder.erl
@@ -426,7 +426,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -840,8 +840,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -836,7 +836,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -1500,7 +1500,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -1504,8 +1504,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -1907,8 +1907,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -1903,7 +1903,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -530,8 +530,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -526,7 +526,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -1212,7 +1212,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -1216,8 +1216,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_honeycode.erl
+++ b/src/aws_honeycode.erl
@@ -80,7 +80,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_honeycode.erl
+++ b/src/aws_honeycode.erl
@@ -84,8 +84,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -874,8 +874,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -870,7 +870,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -4523,7 +4523,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -4527,8 +4527,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_1click_devices.erl
+++ b/src/aws_iot_1click_devices.erl
@@ -310,7 +310,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot_1click_devices.erl
+++ b/src/aws_iot_1click_devices.erl
@@ -314,8 +314,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_1click_projects.erl
+++ b/src/aws_iot_1click_projects.erl
@@ -351,8 +351,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_1click_projects.erl
+++ b/src/aws_iot_1click_projects.erl
@@ -347,7 +347,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -158,7 +158,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -162,8 +162,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_events.erl
+++ b/src/aws_iot_events.erl
@@ -366,8 +366,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_events.erl
+++ b/src/aws_iot_events.erl
@@ -362,7 +362,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -122,7 +122,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -126,8 +126,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -129,8 +129,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -125,7 +125,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iotanalytics.erl
+++ b/src/aws_iotanalytics.erl
@@ -745,7 +745,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_iotanalytics.erl
+++ b/src/aws_iotanalytics.erl
@@ -749,8 +749,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -1349,8 +1349,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -1345,7 +1345,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -632,7 +632,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -636,8 +636,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -599,7 +599,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -603,8 +603,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -516,8 +516,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -512,7 +512,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -545,7 +545,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -549,8 +549,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -106,7 +106,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -110,8 +110,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -94,7 +94,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -98,8 +98,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -1535,7 +1535,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -1539,8 +1539,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_lex_model_building.erl
+++ b/src/aws_lex_model_building.erl
@@ -1151,8 +1151,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_lex_model_building.erl
+++ b/src/aws_lex_model_building.erl
@@ -1147,7 +1147,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -318,8 +318,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -314,7 +314,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -1005,8 +1005,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -1001,7 +1001,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -450,7 +450,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -454,8 +454,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -184,8 +184,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -180,7 +180,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -593,8 +593,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -589,7 +589,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -545,7 +545,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -549,8 +549,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -1116,8 +1116,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -1112,7 +1112,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -389,7 +389,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -393,8 +393,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -339,7 +339,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -343,8 +343,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -164,7 +164,7 @@ put_object(Client, Path, Input0, Options) ->
     Query_ = [],
     Input = Input1,
 
-    request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode).
+    request(Client, Method, Path, Query_, Headers, Input, Options ++ [{should_send_body_as_binary, true}], SuccessStatusCode).
 
 %%====================================================================
 %% Internal functions
@@ -186,7 +186,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -190,8 +190,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -184,7 +184,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -188,8 +188,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mobile.erl
+++ b/src/aws_mobile.erl
@@ -219,7 +219,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mobile.erl
+++ b/src/aws_mobile.erl
@@ -223,8 +223,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mobileanalytics.erl
+++ b/src/aws_mobileanalytics.erl
@@ -61,8 +61,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mobileanalytics.erl
+++ b/src/aws_mobileanalytics.erl
@@ -57,7 +57,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -466,7 +466,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -470,8 +470,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -243,8 +243,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -239,7 +239,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -643,7 +643,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -647,8 +647,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_outposts.erl
+++ b/src/aws_outposts.erl
@@ -174,7 +174,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_outposts.erl
+++ b/src/aws_outposts.erl
@@ -178,8 +178,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -99,8 +99,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -95,7 +95,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -83,7 +83,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -87,8 +87,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -2240,8 +2240,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -2236,7 +2236,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -1060,8 +1060,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -1056,7 +1056,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -192,8 +192,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -188,7 +188,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -291,8 +291,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -287,7 +287,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_qldb.erl
+++ b/src/aws_qldb.erl
@@ -493,8 +493,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_qldb.erl
+++ b/src/aws_qldb.erl
@@ -489,7 +489,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -2217,7 +2217,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -2221,8 +2221,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -498,7 +498,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -502,8 +502,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -181,7 +181,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -185,8 +185,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -373,7 +373,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -377,8 +377,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_robomaker.erl
+++ b/src/aws_robomaker.erl
@@ -1105,7 +1105,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_robomaker.erl
+++ b/src/aws_robomaker.erl
@@ -1109,8 +1109,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -2029,7 +2029,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"text/xml">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -2033,8 +2033,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -5272,7 +5272,7 @@ put_object(Client, Bucket, Key, Input0, Options) ->
     Query_ = [],
     Input = Input1,
 
-    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options ++ [{should_send_body_as_binary, true}], SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [
@@ -6241,7 +6241,7 @@ upload_part(Client, Bucket, Key, Input0, Options) ->
                      {<<"uploadId">>, <<"UploadId">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input1),
-    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options ++ [{should_send_body_as_binary, true}], SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [
@@ -6449,7 +6449,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"text/xml">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -6453,8 +6453,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -1723,8 +1723,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -1719,7 +1719,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"text/xml">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -134,7 +134,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -138,8 +138,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -165,7 +165,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -169,8 +169,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_sagemaker_runtime.erl
+++ b/src/aws_sagemaker_runtime.erl
@@ -55,7 +55,7 @@ invoke_endpoint(Client, EndpointName, Input0, Options) ->
     Query_ = [],
     Input = Input1,
 
-    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options ++ [{should_send_body_as_binary, true}], SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [
@@ -95,7 +95,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_sagemaker_runtime.erl
+++ b/src/aws_sagemaker_runtime.erl
@@ -99,8 +99,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -203,8 +203,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -199,7 +199,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -636,7 +636,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -640,8 +640,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -1229,7 +1229,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -1233,8 +1233,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -351,7 +351,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -355,8 +355,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -380,7 +380,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -384,8 +384,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -1895,7 +1895,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -1899,8 +1899,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -456,7 +456,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -460,8 +460,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -155,7 +155,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -159,8 +159,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -113,7 +113,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -117,8 +117,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -367,7 +367,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -371,8 +371,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -160,8 +160,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -156,7 +156,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -1095,8 +1095,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -1091,7 +1091,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_worklink.erl
+++ b/src/aws_worklink.erl
@@ -666,8 +666,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_worklink.erl
+++ b/src/aws_worklink.erl
@@ -662,7 +662,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -54,8 +54,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -50,7 +50,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -622,7 +622,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -626,8 +626,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 


### PR DESCRIPTION
This is useful for services that work with files, like `S3` or
`MediaStoreData`. They require us to send the body as it is, without
encode it (they are binaries).

This is related to https://github.com/aws-beam/aws-codegen/pull/62