### PR TITLE
Update generated modules as per aws-sdk-go sha: 2582633

### DIFF
--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -1,23 +1,30 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS IAM Access Analyzer helps identify potential resource-access
-%% risks by enabling you to identify any policies that grant access to an
-%% external principal.
+%% @doc Identity and Access Management Access Analyzer helps identify
+%% potential resource-access risks by enabling you to identify any policies
+%% that grant access to an external principal.
 %%
 %% It does this by using logic-based reasoning to analyze resource-based
-%% policies in your AWS environment. An external principal can be another AWS
-%% account, a root user, an IAM user or role, a federated user, an AWS
-%% service, or an anonymous user. This guide describes the AWS IAM Access
+%% policies in your Amazon Web Services environment. An external principal
+%% can be another Amazon Web Services account, a root user, an IAM user or
+%% role, a federated user, an Amazon Web Services service, or an anonymous
+%% user. You can also use IAM Access Analyzer to preview and validate public
+%% and cross-account access to your resources before deploying permissions
+%% changes. This guide describes the Identity and Access Management Access
 %% Analyzer operations that you can call programmatically. For general
-%% information about Access Analyzer, see AWS IAM Access Analyzer in the IAM
-%% User Guide.
+%% information about IAM Access Analyzer, see Identity and Access Management
+%% Access Analyzer in the IAM User Guide.
 %%
-%% To start using Access Analyzer, you first need to create an analyzer.
+%% To start using IAM Access Analyzer, you first need to create an analyzer.
 -module(aws_accessanalyzer).
 
 -export([apply_archive_rule/2,
          apply_archive_rule/3,
+         cancel_policy_generation/3,
+         cancel_policy_generation/4,
+         create_access_preview/2,
+         create_access_preview/3,
          create_analyzer/2,
          create_analyzer/3,
          create_archive_rule/3,
@@ -26,6 +33,9 @@
          delete_analyzer/4,
          delete_archive_rule/4,
          delete_archive_rule/5,
+         get_access_preview/3,
+         get_access_preview/5,
+         get_access_preview/6,
          get_analyzed_resource/3,
          get_analyzed_resource/5,
          get_analyzed_resource/6,
@@ -38,6 +48,14 @@
          get_finding/3,
          get_finding/5,
          get_finding/6,
+         get_generated_policy/2,
+         get_generated_policy/4,
+         get_generated_policy/5,
+         list_access_preview_findings/3,
+         list_access_preview_findings/4,
+         list_access_previews/2,
+         list_access_previews/4,
+         list_access_previews/5,
          list_analyzed_resources/2,
          list_analyzed_resources/3,
          list_analyzers/1,
@@ -48,9 +66,14 @@
          list_archive_rules/5,
          list_findings/2,
          list_findings/3,
+         list_policy_generations/1,
+         list_policy_generations/3,
+         list_policy_generations/4,
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
+         start_policy_generation/2,
+         start_policy_generation/3,
          start_resource_scan/2,
          start_resource_scan/3,
          tag_resource/3,
@@ -60,7 +83,9 @@
          update_archive_rule/4,
          update_archive_rule/5,
          update_findings/2,
-         update_findings/3]).
+         update_findings/3,
+         validate_policy/2,
+         validate_policy/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -75,6 +100,53 @@ apply_archive_rule(Client, Input) ->
 apply_archive_rule(Client, Input0, Options0) ->
     Method = put,
     Path = ["/archive-rule"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Cancels the requested policy generation.
+cancel_policy_generation(Client, JobId, Input) ->
+    cancel_policy_generation(Client, JobId, Input, []).
+cancel_policy_generation(Client, JobId, Input0, Options0) ->
+    Method = put,
+    Path = ["/policy/generation/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an access preview that allows you to preview IAM Access
+%% Analyzer findings for your resource before deploying resource permissions.
+create_access_preview(Client, Input) ->
+    create_access_preview(Client, Input, []).
+create_access_preview(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/access-preview"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -119,6 +191,9 @@ create_analyzer(Client, Input0, Options0) ->
 %%
 %% Archive rules automatically archive new findings that meet the criteria
 %% you define when you create the rule.
+%%
+%% To learn about filter keys that you can use to create an archive rule, see
+%% IAM Access Analyzer filter keys in the IAM User Guide.
 create_archive_rule(Client, AnalyzerName, Input) ->
     create_archive_rule(Client, AnalyzerName, Input, []).
 create_archive_rule(Client, AnalyzerName, Input0, Options0) ->
@@ -143,9 +218,10 @@ create_archive_rule(Client, AnalyzerName, Input0, Options0) ->
 
 %% @doc Deletes the specified analyzer.
 %%
-%% When you delete an analyzer, Access Analyzer is disabled for the account
-%% or organization in the current or specific Region. All findings that were
-%% generated by the analyzer are deleted. You cannot undo this action.
+%% When you delete an analyzer, IAM Access Analyzer is disabled for the
+%% account or organization in the current or specific Region. All findings
+%% that were generated by the analyzer are deleted. You cannot undo this
+%% action.
 delete_analyzer(Client, AnalyzerName, Input) ->
     delete_analyzer(Client, AnalyzerName, Input, []).
 delete_analyzer(Client, AnalyzerName, Input0, Options0) ->
@@ -192,6 +268,34 @@ delete_archive_rule(Client, AnalyzerName, RuleName, Input0, Options0) ->
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about an access preview for the specified
+%% analyzer.
+get_access_preview(Client, AccessPreviewId, AnalyzerArn)
+  when is_map(Client) ->
+    get_access_preview(Client, AccessPreviewId, AnalyzerArn, #{}, #{}).
+
+get_access_preview(Client, AccessPreviewId, AnalyzerArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_access_preview(Client, AccessPreviewId, AnalyzerArn, QueryMap, HeadersMap, []).
+
+get_access_preview(Client, AccessPreviewId, AnalyzerArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/access-preview/", aws_util:encode_uri(AccessPreviewId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"analyzerArn">>, AnalyzerArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves information about a resource that was analyzed.
 get_analyzed_resource(Client, AnalyzerArn, ResourceArn)
@@ -247,7 +351,7 @@ get_analyzer(Client, AnalyzerName, QueryMap, HeadersMap, Options0)
 %% @doc Retrieves information about an archive rule.
 %%
 %% To learn about filter keys that you can use to create an archive rule, see
-%% Access Analyzer filter keys in the IAM User Guide.
+%% IAM Access Analyzer filter keys in the IAM User Guide.
 get_archive_rule(Client, AnalyzerName, RuleName)
   when is_map(Client) ->
     get_archive_rule(Client, AnalyzerName, RuleName, #{}, #{}).
@@ -292,6 +396,88 @@ get_finding(Client, Id, AnalyzerArn, QueryMap, HeadersMap, Options0)
     Query0_ =
       [
         {<<"analyzerArn">>, AnalyzerArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the policy that was generated using
+%% `StartPolicyGeneration'.
+get_generated_policy(Client, JobId)
+  when is_map(Client) ->
+    get_generated_policy(Client, JobId, #{}, #{}).
+
+get_generated_policy(Client, JobId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_generated_policy(Client, JobId, QueryMap, HeadersMap, []).
+
+get_generated_policy(Client, JobId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/policy/generation/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"includeResourcePlaceholders">>, maps:get(<<"includeResourcePlaceholders">>, QueryMap, undefined)},
+        {<<"includeServiceLevelTemplate">>, maps:get(<<"includeServiceLevelTemplate">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves a list of access preview findings generated by the
+%% specified access preview.
+list_access_preview_findings(Client, AccessPreviewId, Input) ->
+    list_access_preview_findings(Client, AccessPreviewId, Input, []).
+list_access_preview_findings(Client, AccessPreviewId, Input0, Options0) ->
+    Method = post,
+    Path = ["/access-preview/", aws_util:encode_uri(AccessPreviewId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves a list of access previews for the specified analyzer.
+list_access_previews(Client, AnalyzerArn)
+  when is_map(Client) ->
+    list_access_previews(Client, AnalyzerArn, #{}, #{}).
+
+list_access_previews(Client, AnalyzerArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_access_previews(Client, AnalyzerArn, QueryMap, HeadersMap, []).
+
+list_access_previews(Client, AnalyzerArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/access-preview"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"analyzerArn">>, AnalyzerArn},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -380,8 +566,8 @@ list_archive_rules(Client, AnalyzerName, QueryMap, HeadersMap, Options0)
 
 %% @doc Retrieves a list of findings generated by the specified analyzer.
 %%
-%% To learn about filter keys that you can use to create an archive rule, see
-%% Access Analyzer filter keys in the IAM User Guide.
+%% To learn about filter keys that you can use to retrieve a list of
+%% findings, see IAM Access Analyzer filter keys in the IAM User Guide.
 list_findings(Client, Input) ->
     list_findings(Client, Input, []).
 list_findings(Client, Input0, Options0) ->
@@ -403,6 +589,35 @@ list_findings(Client, Input0, Options0) ->
     Input = Input2,
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all of the policy generations requested in the last seven days.
+list_policy_generations(Client)
+  when is_map(Client) ->
+    list_policy_generations(Client, #{}, #{}).
+
+list_policy_generations(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_policy_generations(Client, QueryMap, HeadersMap, []).
+
+list_policy_generations(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/policy/generation"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"principalArn">>, maps:get(<<"principalArn">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves a list of tags applied to the specified resource.
 list_tags_for_resource(Client, ResourceArn)
@@ -426,6 +641,29 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
     Query_ = [],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Starts the policy generation request.
+start_policy_generation(Client, Input) ->
+    start_policy_generation(Client, Input, []).
+start_policy_generation(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/policy/generation"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Immediately starts a scan of the policies applied to the specified
 %% resource.
@@ -544,6 +782,35 @@ update_findings(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Requests the validation of a policy and returns a list of findings.
+%%
+%% The findings help you identify issues and provide actionable
+%% recommendations to resolve the issue and enable you to author functional
+%% policies that meet security best practices.
+validate_policy(Client, Input) ->
+    validate_policy(Client, Input, []).
+validate_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/policy/validation"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"maxResults">>, <<"maxResults">>},
+                     {<<"nextToken">>, <<"nextToken">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -579,6 +846,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_account.erl
+++ b/src/aws_account.erl
@@ -1,0 +1,185 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Operations for Amazon Web Services Account Management
+-module(aws_account).
+
+-export([delete_alternate_contact/2,
+         delete_alternate_contact/3,
+         get_alternate_contact/2,
+         get_alternate_contact/3,
+         put_alternate_contact/2,
+         put_alternate_contact/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Deletes the specified alternate contact from an Amazon Web Services
+%% account.
+%%
+%% For complete details about how to use the alternate contact operations,
+%% see Access or updating the alternate contacts.
+delete_alternate_contact(Client, Input) ->
+    delete_alternate_contact(Client, Input, []).
+delete_alternate_contact(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteAlternateContact"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves the specified alternate contact attached to an Amazon Web
+%% Services account.
+%%
+%% For complete details about how to use the alternate contact operations,
+%% see Access or updating the alternate contacts.
+get_alternate_contact(Client, Input) ->
+    get_alternate_contact(Client, Input, []).
+get_alternate_contact(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/getAlternateContact"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Modifies the specified alternate contact attached to an Amazon Web
+%% Services account.
+%%
+%% For complete details about how to use the alternate contact operations,
+%% see Access or updating the alternate contacts.
+put_alternate_contact(Client, Input) ->
+    put_alternate_contact(Client, Input, []).
+put_alternate_contact(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/putAlternateContact"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"account">>,
+                      region => <<"us-east-1">>},
+    Host = build_host(<<"account">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_acm.erl
+++ b/src/aws_acm.erl
@@ -1,13 +1,14 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Certificate Manager
+%% @doc Amazon Web Services Certificate Manager
 %%
-%% You can use AWS Certificate Manager (ACM) to manage SSL/TLS certificates
-%% for your AWS-based websites and applications.
+%% You can use Amazon Web Services Certificate Manager (ACM) to manage
+%% SSL/TLS certificates for your Amazon Web Services-based websites and
+%% applications.
 %%
-%% For more information about using ACM, see the AWS Certificate Manager User
-%% Guide.
+%% For more information about using ACM, see the Amazon Web Services
+%% Certificate Manager User Guide.
 -module(aws_acm).
 
 -export([add_tags_to_certificate/2,
@@ -49,10 +50,10 @@
 
 %% @doc Adds one or more tags to an ACM certificate.
 %%
-%% Tags are labels that you can use to identify and organize your AWS
-%% resources. Each tag consists of a `key' and an optional `value'. You
-%% specify the certificate on input by its Amazon Resource Name (ARN). You
-%% specify the tag by using a key-value pair.
+%% Tags are labels that you can use to identify and organize your Amazon Web
+%% Services resources. Each tag consists of a `key' and an optional `value'.
+%% You specify the certificate on input by its Amazon Resource Name (ARN).
+%% You specify the tag by using a key-value pair.
 %%
 %% You can apply a tag to just one certificate if you want to identify a
 %% specific characteristic of that certificate, or you can apply the same tag
@@ -79,11 +80,11 @@ add_tags_to_certificate(Client, Input, Options)
 %% If this action succeeds, the certificate no longer appears in the list
 %% that can be displayed by calling the `ListCertificates' action or be
 %% retrieved by calling the `GetCertificate' action. The certificate will not
-%% be available for use by AWS services integrated with ACM.
+%% be available for use by Amazon Web Services services integrated with ACM.
 %%
-%% You cannot delete an ACM certificate that is being used by another AWS
-%% service. To delete a certificate that is in use, the certificate
-%% association must first be removed.
+%% You cannot delete an ACM certificate that is being used by another Amazon
+%% Web Services service. To delete a certificate that is in use, the
+%% certificate association must first be removed.
 delete_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_certificate(Client, Input, []).
@@ -116,8 +117,8 @@ export_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ExportCertificate">>, Input, Options).
 
-%% @doc Returns the account configuration options associated with an AWS
-%% account.
+%% @doc Returns the account configuration options associated with an Amazon
+%% Web Services account.
 get_account_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_account_configuration(Client, Input, []).
@@ -138,15 +139,15 @@ get_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetCertificate">>, Input, Options).
 
-%% @doc Imports a certificate into AWS Certificate Manager (ACM) to use with
-%% services that are integrated with ACM.
+%% @doc Imports a certificate into Amazon Web Services Certificate Manager
+%% (ACM) to use with services that are integrated with ACM.
 %%
 %% Note that integrated services allow only certificate types and keys they
 %% support to be associated with their resources. Further, their support
 %% differs depending on whether the certificate is imported into IAM or into
 %% ACM. For more information, see the documentation for each service. For
 %% more information about importing certificates into ACM, see Importing
-%% Certificates in the AWS Certificate Manager User Guide.
+%% Certificates in the Amazon Web Services Certificate Manager User Guide.
 %%
 %% ACM does not provide managed renewal for certificates that you import.
 %%
@@ -275,7 +276,8 @@ renew_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RenewCertificate">>, Input, Options).
 
-%% @doc Requests an ACM certificate for use with other AWS services.
+%% @doc Requests an ACM certificate for use with other Amazon Web Services
+%% services.
 %%
 %% To request an ACM certificate, you must specify a fully qualified domain
 %% name (FQDN) in the `DomainName' parameter. You can also specify additional
@@ -287,6 +289,11 @@ renew_certificate(Client, Input, Options)
 %% domain. You can use DNS validation or email validation. We recommend that
 %% you use DNS validation. ACM issues public certificates after receiving
 %% approval from the domain owner.
+%%
+%% ACM behavior differs from the
+%% [https://tools.ietf.org/html/rfc6125#appendix-B.2]RFC 6125 specification
+%% of the certificate validation process. first checks for a subject
+%% alternative name, and, if it finds one, ignores the common name (CN)
 request_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     request_certificate(Client, Input, []).

--- a/src/aws_acm_pca.erl
+++ b/src/aws_acm_pca.erl
@@ -12,9 +12,18 @@
 %% access an API that's tailored to the programming language or platform that
 %% you're using. For more information, see AWS SDKs.
 %%
-%% Each ACM Private CA API action has a quota that determines the number of
-%% times the action can be called per second. For more information, see API
-%% Rate Quotas in ACM Private CA in the ACM Private CA user guide.
+%% Each ACM Private CA API operation has a quota that determines the number
+%% of times the operation can be called per second. ACM Private CA throttles
+%% API requests at different rates depending on the operation. Throttling
+%% means that ACM Private CA rejects an otherwise valid request because the
+%% request exceeds the operation's quota for the number of requests per
+%% second. When a request is throttled, ACM Private CA returns a
+%% ThrottlingException error. ACM Private CA does not guarantee a minimum
+%% request rate for APIs.
+%%
+%% To see an up-to-date list of your ACM Private CA quotas, or to request a
+%% quota increase, log into your AWS account and visit the Service Quotas
+%% console.
 -module(aws_acm_pca).
 
 -export([create_certificate_authority/2,
@@ -72,18 +81,20 @@
 
 %% @doc Creates a root or subordinate private certificate authority (CA).
 %%
-%% You must specify the CA configuration, the certificate revocation list
-%% (CRL) configuration, the CA type, and an optional idempotency token to
-%% avoid accidental creation of multiple CAs. The CA configuration specifies
-%% the name of the algorithm and key size to be used to create the CA private
+%% You must specify the CA configuration, an optional configuration for
+%% Online Certificate Status Protocol (OCSP) and/or a certificate revocation
+%% list (CRL), the CA type, and an optional idempotency token to avoid
+%% accidental creation of multiple CAs. The CA configuration specifies the
+%% name of the algorithm and key size to be used to create the CA private
 %% key, the type of signing algorithm that the CA uses, and X.500 subject
-%% information. The CRL configuration specifies the CRL expiration period in
-%% days (the validity period of the CRL), the Amazon S3 bucket that will
-%% contain the CRL, and a CNAME alias for the S3 bucket that is included in
-%% certificates issued by the CA. If successful, this action returns the
+%% information. The OCSP configuration can optionally specify a custom URL
+%% for the OCSP responder. The CRL configuration specifies the CRL expiration
+%% period in days (the validity period of the CRL), the Amazon S3 bucket that
+%% will contain the CRL, and a CNAME alias for the S3 bucket that is included
+%% in certificates issued by the CA. If successful, this action returns the
 %% Amazon Resource Name (ARN) of the CA.
 %%
-%% ACM Private CAA assets that are stored in Amazon S3 can be protected with
+%% ACM Private CA assets that are stored in Amazon S3 can be protected with
 %% encryption. For more information, see Encrypting Your CRLs.
 %%
 %% Both PCA and the IAM principal must have permission to write to the S3
@@ -108,7 +119,7 @@ create_certificate_authority(Client, Input, Options)
 %% have permission to write to the bucket, then an exception is thrown. For
 %% more information, see Configure Access to ACM Private CA.
 %%
-%% ACM Private CAA assets that are stored in Amazon S3 can be protected with
+%% ACM Private CA assets that are stored in Amazon S3 can be protected with
 %% encryption. For more information, see Encrypting Your Audit Reports.
 create_certificate_authority_audit_report(Client, Input)
   when is_map(Client), is_map(Input) ->

--- a/src/aws_amp.erl
+++ b/src/aws_amp.erl
@@ -4,16 +4,44 @@
 %% @doc Amazon Managed Service for Prometheus
 -module(aws_amp).
 
--export([create_workspace/2,
+-export([create_alert_manager_definition/3,
+         create_alert_manager_definition/4,
+         create_rule_groups_namespace/3,
+         create_rule_groups_namespace/4,
+         create_workspace/2,
          create_workspace/3,
+         delete_alert_manager_definition/3,
+         delete_alert_manager_definition/4,
+         delete_rule_groups_namespace/4,
+         delete_rule_groups_namespace/5,
          delete_workspace/3,
          delete_workspace/4,
+         describe_alert_manager_definition/2,
+         describe_alert_manager_definition/4,
+         describe_alert_manager_definition/5,
+         describe_rule_groups_namespace/3,
+         describe_rule_groups_namespace/5,
+         describe_rule_groups_namespace/6,
          describe_workspace/2,
          describe_workspace/4,
          describe_workspace/5,
+         list_rule_groups_namespaces/2,
+         list_rule_groups_namespaces/4,
+         list_rule_groups_namespaces/5,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
          list_workspaces/1,
          list_workspaces/3,
          list_workspaces/4,
+         put_alert_manager_definition/3,
+         put_alert_manager_definition/4,
+         put_rule_groups_namespace/4,
+         put_rule_groups_namespace/5,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
          update_workspace_alias/3,
          update_workspace_alias/4]).
 
@@ -22,6 +50,52 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Create an alert manager definition.
+create_alert_manager_definition(Client, WorkspaceId, Input) ->
+    create_alert_manager_definition(Client, WorkspaceId, Input, []).
+create_alert_manager_definition(Client, WorkspaceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/alertmanager/definition"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Create a rule group namespace.
+create_rule_groups_namespace(Client, WorkspaceId, Input) ->
+    create_rule_groups_namespace(Client, WorkspaceId, Input, []).
+create_rule_groups_namespace(Client, WorkspaceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/rulegroupsnamespaces"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a new AMP workspace.
 create_workspace(Client, Input) ->
@@ -44,6 +118,54 @@ create_workspace(Client, Input0, Options0) ->
     Query_ = [],
     Input = Input2,
 
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an alert manager definition.
+delete_alert_manager_definition(Client, WorkspaceId, Input) ->
+    delete_alert_manager_definition(Client, WorkspaceId, Input, []).
+delete_alert_manager_definition(Client, WorkspaceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/alertmanager/definition"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"clientToken">>, <<"clientToken">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete a rule groups namespace.
+delete_rule_groups_namespace(Client, Name, WorkspaceId, Input) ->
+    delete_rule_groups_namespace(Client, Name, WorkspaceId, Input, []).
+delete_rule_groups_namespace(Client, Name, WorkspaceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/rulegroupsnamespaces/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"clientToken">>, <<"clientToken">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes an AMP workspace.
@@ -70,6 +192,52 @@ delete_workspace(Client, WorkspaceId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Describes an alert manager definition.
+describe_alert_manager_definition(Client, WorkspaceId)
+  when is_map(Client) ->
+    describe_alert_manager_definition(Client, WorkspaceId, #{}, #{}).
+
+describe_alert_manager_definition(Client, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_alert_manager_definition(Client, WorkspaceId, QueryMap, HeadersMap, []).
+
+describe_alert_manager_definition(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/alertmanager/definition"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describe a rule groups namespace.
+describe_rule_groups_namespace(Client, Name, WorkspaceId)
+  when is_map(Client) ->
+    describe_rule_groups_namespace(Client, Name, WorkspaceId, #{}, #{}).
+
+describe_rule_groups_namespace(Client, Name, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_rule_groups_namespace(Client, Name, WorkspaceId, QueryMap, HeadersMap, []).
+
+describe_rule_groups_namespace(Client, Name, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/rulegroupsnamespaces/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Describes an existing AMP workspace.
 describe_workspace(Client, WorkspaceId)
   when is_map(Client) ->
@@ -82,6 +250,58 @@ describe_workspace(Client, WorkspaceId, QueryMap, HeadersMap)
 describe_workspace(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists rule groups namespaces.
+list_rule_groups_namespaces(Client, WorkspaceId)
+  when is_map(Client) ->
+    list_rule_groups_namespaces(Client, WorkspaceId, #{}, #{}).
+
+list_rule_groups_namespaces(Client, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_rule_groups_namespaces(Client, WorkspaceId, QueryMap, HeadersMap, []).
+
+list_rule_groups_namespaces(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/rulegroupsnamespaces"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"name">>, maps:get(<<"name">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags you have assigned to the resource.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -122,6 +342,99 @@ list_workspaces(Client, QueryMap, HeadersMap, Options0)
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Update an alert manager definition.
+put_alert_manager_definition(Client, WorkspaceId, Input) ->
+    put_alert_manager_definition(Client, WorkspaceId, Input, []).
+put_alert_manager_definition(Client, WorkspaceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/alertmanager/definition"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a rule groups namespace.
+put_rule_groups_namespace(Client, Name, WorkspaceId, Input) ->
+    put_rule_groups_namespace(Client, Name, WorkspaceId, Input, []).
+put_rule_groups_namespace(Client, Name, WorkspaceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/rulegroupsnamespaces/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates tags for the specified resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes tags from the specified resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates an AMP workspace alias.
 update_workspace_alias(Client, WorkspaceId, Input) ->
@@ -181,6 +494,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -1038,6 +1038,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_amplifybackend.erl
+++ b/src/aws_amplifybackend.erl
@@ -40,6 +40,8 @@
          get_token/3,
          get_token/5,
          get_token/6,
+         import_backend_auth/4,
+         import_backend_auth/5,
          list_backend_jobs/4,
          list_backend_jobs/5,
          remove_all_backends/3,
@@ -386,7 +388,7 @@ get_backend_api_models(Client, AppId, BackendEnvironmentName, Input0, Options0) 
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Gets backend auth details.
+%% @doc Gets a backend auth details.
 get_backend_auth(Client, AppId, BackendEnvironmentName, Input) ->
     get_backend_auth(Client, AppId, BackendEnvironmentName, Input, []).
 get_backend_auth(Client, AppId, BackendEnvironmentName, Input0, Options0) ->
@@ -455,6 +457,29 @@ get_token(Client, AppId, SessionId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Imports an existing backend authentication resource.
+import_backend_auth(Client, AppId, BackendEnvironmentName, Input) ->
+    import_backend_auth(Client, AppId, BackendEnvironmentName, Input, []).
+import_backend_auth(Client, AppId, BackendEnvironmentName, Input0, Options0) ->
+    Method = post,
+    Path = ["/backend/", aws_util:encode_uri(AppId), "/auth/", aws_util:encode_uri(BackendEnvironmentName), "/import"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Lists the jobs for the backend of an Amplify app.
 list_backend_jobs(Client, AppId, BackendEnvironmentName, Input) ->
     list_backend_jobs(Client, AppId, BackendEnvironmentName, Input, []).
@@ -501,8 +526,7 @@ remove_all_backends(Client, AppId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes the AWS resources that are required to access the Amplify
-%% Admin UI.
+%% @doc Removes the AWS resources required to access the Amplify Admin UI.
 remove_backend_config(Client, AppId, Input) ->
     remove_backend_config(Client, AppId, Input, []).
 remove_backend_config(Client, AppId, Input0, Options0) ->
@@ -571,8 +595,7 @@ update_backend_auth(Client, AppId, BackendEnvironmentName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the AWS resources that are required to access the Amplify
-%% Admin UI.
+%% @doc Updates the AWS resources required to access the Amplify Admin UI.
 update_backend_config(Client, AppId, Input) ->
     update_backend_config(Client, AppId, Input, []).
 update_backend_config(Client, AppId, Input0, Options0) ->
@@ -653,6 +676,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -3333,6 +3333,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -129,6 +129,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_apigatewayv2.erl
+++ b/src/aws_apigatewayv2.erl
@@ -1950,6 +1950,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -1,7 +1,7 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS App Mesh is a service mesh based on the Envoy proxy that makes it
+%% @doc App Mesh is a service mesh based on the Envoy proxy that makes it
 %% easy to monitor and control microservices.
 %%
 %% App Mesh standardizes how your microservices communicate, giving you
@@ -9,8 +9,9 @@
 %% applications.
 %%
 %% App Mesh gives you consistent visibility and network traffic controls for
-%% every microservice in an application. You can use App Mesh with AWS
-%% Fargate, Amazon ECS, Amazon EKS, Kubernetes on AWS, and Amazon EC2.
+%% every microservice in an application. You can use App Mesh with Amazon Web
+%% Services Fargate, Amazon ECS, Amazon EKS, Kubernetes on Amazon Web
+%% Services, and Amazon EC2.
 %%
 %% App Mesh supports microservice applications that use service discovery
 %% naming for their components. For more information about service discovery
@@ -266,12 +267,10 @@ create_virtual_gateway(Client, MeshName, Input0, Options0) ->
 %% traces. You can override this behavior by setting the
 %% `APPMESH_RESOURCE_CLUSTER' environment variable with your own name.
 %%
-%% AWS Cloud Map is not available in the eu-south-1 Region.
-%%
 %% For more information about virtual nodes, see Virtual nodes. You must be
 %% using `1.15.0' or later of the Envoy image when setting these variables.
-%% For more information about App Mesh Envoy variables, see Envoy image in
-%% the AWS App Mesh User Guide.
+%% For more information aboutApp Mesh Envoy variables, see Envoy image in the
+%% AWS App Mesh User Guide.
 create_virtual_node(Client, MeshName, Input) ->
     create_virtual_node(Client, MeshName, Input, []).
 create_virtual_node(Client, MeshName, Input0, Options0) ->
@@ -1218,6 +1217,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -1107,6 +1107,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -8,8 +8,8 @@
 %%
 %% Amazon AppFlow is a fully managed integration service that enables you to
 %% securely transfer data between software as a service (SaaS) applications
-%% like Salesforce, Marketo, Slack, and ServiceNow, and AWS services like
-%% Amazon S3 and Amazon Redshift.
+%% like Salesforce, Marketo, Slack, and ServiceNow, and Amazon Web Services
+%% like Amazon S3 and Amazon Redshift.
 %%
 %% Use the following links to get started on the Amazon AppFlow API:
 %%
@@ -80,12 +80,13 @@
 %% API
 %%====================================================================
 
-%% @doc Creates a new connector profile associated with your AWS account.
+%% @doc Creates a new connector profile associated with your Amazon Web
+%% Services account.
 %%
-%% There is a soft quota of 100 connector profiles per AWS account. If you
-%% need more connector profiles than this quota allows, you can submit a
-%% request to the Amazon AppFlow team through the Amazon AppFlow support
-%% channel.
+%% There is a soft quota of 100 connector profiles per Amazon Web Services
+%% account. If you need more connector profiles than this quota allows, you
+%% can submit a request to the Amazon AppFlow team through the Amazon AppFlow
+%% support channel.
 create_connector_profile(Client, Input) ->
     create_connector_profile(Client, Input, []).
 create_connector_profile(Client, Input0, Options0) ->
@@ -570,6 +571,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_appintegrations.erl
+++ b/src/aws_appintegrations.erl
@@ -1,24 +1,35 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
-%%
-%% The Amazon AppIntegrations service enables you to configure and reuse
+%% @doc The Amazon AppIntegrations service enables you to configure and reuse
 %% connections to external applications.
 %%
 %% For information about how you can use external applications with Amazon
-%% Connect, see Set up pre-built integrations in the Amazon Connect
-%% Administrator Guide.
+%% Connect, see Set up pre-built integrations and Deliver information to
+%% agents using Amazon Connect Wisdom in the Amazon Connect Administrator
+%% Guide.
 -module(aws_appintegrations).
 
--export([create_event_integration/2,
+-export([create_data_integration/2,
+         create_data_integration/3,
+         create_event_integration/2,
          create_event_integration/3,
+         delete_data_integration/3,
+         delete_data_integration/4,
          delete_event_integration/3,
          delete_event_integration/4,
+         get_data_integration/2,
+         get_data_integration/4,
+         get_data_integration/5,
          get_event_integration/2,
          get_event_integration/4,
          get_event_integration/5,
+         list_data_integration_associations/2,
+         list_data_integration_associations/4,
+         list_data_integration_associations/5,
+         list_data_integrations/1,
+         list_data_integrations/3,
+         list_data_integrations/4,
          list_event_integration_associations/2,
          list_event_integration_associations/4,
          list_event_integration_associations/5,
@@ -32,6 +43,8 @@
          tag_resource/4,
          untag_resource/3,
          untag_resource/4,
+         update_data_integration/3,
+         update_data_integration/4,
          update_event_integration/3,
          update_event_integration/4]).
 
@@ -41,14 +54,39 @@
 %% API
 %%====================================================================
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
+%% @doc Creates and persists a DataIntegration resource.
 %%
-%% Creates an EventIntegration, given a specified name, description, and a
-%% reference to an Amazon Eventbridge bus in your account and a partner event
-%% source that will push events to that bus. No objects are created in the
-%% your account, only metadata that is persisted on the EventIntegration
-%% control plane.
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the `CreateDataIntegration' API.
+create_data_integration(Client, Input) ->
+    create_data_integration(Client, Input, []).
+create_data_integration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/dataIntegrations"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an EventIntegration, given a specified name, description, and
+%% a reference to an Amazon EventBridge bus in your account and a partner
+%% event source that pushes events to that bus.
+%%
+%% No objects are created in the your account, only metadata that is
+%% persisted on the EventIntegration control plane.
 create_event_integration(Client, Input) ->
     create_event_integration(Client, Input, []).
 create_event_integration(Client, Input0, Options0) ->
@@ -71,11 +109,41 @@ create_event_integration(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
+%% @doc Deletes the DataIntegration.
 %%
-%% Deletes the specified existing event integration. If the event integration
-%% is associated with clients, the request is rejected.
+%% Only DataIntegrations that don't have any DataIntegrationAssociations can
+%% be deleted. Deleting a DataIntegration also deletes the underlying Amazon
+%% AppFlow flow and service linked role.
+%%
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the CreateDataIntegration API.
+delete_data_integration(Client, DataIntegrationIdentifier, Input) ->
+    delete_data_integration(Client, DataIntegrationIdentifier, Input, []).
+delete_data_integration(Client, DataIntegrationIdentifier, Input0, Options0) ->
+    Method = delete,
+    Path = ["/dataIntegrations/", aws_util:encode_uri(DataIntegrationIdentifier), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified existing event integration.
+%%
+%% If the event integration is associated with clients, the request is
+%% rejected.
 delete_event_integration(Client, Name, Input) ->
     delete_event_integration(Client, Name, Input, []).
 delete_event_integration(Client, Name, Input0, Options0) ->
@@ -98,10 +166,34 @@ delete_event_integration(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
+%% @doc Returns information about the DataIntegration.
 %%
-%% Return information about the event integration.
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the CreateDataIntegration API.
+get_data_integration(Client, Identifier)
+  when is_map(Client) ->
+    get_data_integration(Client, Identifier, #{}, #{}).
+
+get_data_integration(Client, Identifier, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_data_integration(Client, Identifier, QueryMap, HeadersMap, []).
+
+get_data_integration(Client, Identifier, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/dataIntegrations/", aws_util:encode_uri(Identifier), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about the event integration.
 get_event_integration(Client, Name)
   when is_map(Client) ->
     get_event_integration(Client, Name, #{}, #{}).
@@ -124,10 +216,73 @@ get_event_integration(Client, Name, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
+%% @doc Returns a paginated list of DataIntegration associations in the
+%% account.
 %%
-%% Returns a paginated list of event integration associations in the account.
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the CreateDataIntegration API.
+list_data_integration_associations(Client, DataIntegrationIdentifier)
+  when is_map(Client) ->
+    list_data_integration_associations(Client, DataIntegrationIdentifier, #{}, #{}).
+
+list_data_integration_associations(Client, DataIntegrationIdentifier, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_data_integration_associations(Client, DataIntegrationIdentifier, QueryMap, HeadersMap, []).
+
+list_data_integration_associations(Client, DataIntegrationIdentifier, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/dataIntegrations/", aws_util:encode_uri(DataIntegrationIdentifier), "/associations"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a paginated list of DataIntegrations in the account.
+%%
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the CreateDataIntegration API.
+list_data_integrations(Client)
+  when is_map(Client) ->
+    list_data_integrations(Client, #{}, #{}).
+
+list_data_integrations(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_data_integrations(Client, QueryMap, HeadersMap, []).
+
+list_data_integrations(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/dataIntegrations"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a paginated list of event integration associations in the
+%% account.
 list_event_integration_associations(Client, EventIntegrationName)
   when is_map(Client) ->
     list_event_integration_associations(Client, EventIntegrationName, #{}, #{}).
@@ -155,10 +310,7 @@ list_event_integration_associations(Client, EventIntegrationName, QueryMap, Head
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
-%%
-%% Returns a paginated list of event integrations in the account.
+%% @doc Returns a paginated list of event integrations in the account.
 list_event_integrations(Client)
   when is_map(Client) ->
     list_event_integrations(Client, #{}, #{}).
@@ -186,10 +338,7 @@ list_event_integrations(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
-%%
-%% Lists the tags for the specified resource.
+%% @doc Lists the tags for the specified resource.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -212,10 +361,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
-%%
-%% Adds the specified tags to the specified resource.
+%% @doc Adds the specified tags to the specified resource.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -238,10 +384,7 @@ tag_resource(Client, ResourceArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
-%%
-%% Removes the specified tags from the specified resource.
+%% @doc Removes the specified tags from the specified resource.
 untag_resource(Client, ResourceArn, Input) ->
     untag_resource(Client, ResourceArn, Input, []).
 untag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -265,10 +408,34 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc The Amazon AppIntegrations APIs are in preview release and are
-%% subject to change.
+%% @doc Updates the description of a DataIntegration.
 %%
-%% Updates the description of an event integration.
+%% You cannot create a DataIntegration association for a DataIntegration that
+%% has been previously associated. Use a different DataIntegration, or
+%% recreate the DataIntegration using the CreateDataIntegration API.
+update_data_integration(Client, Identifier, Input) ->
+    update_data_integration(Client, Identifier, Input, []).
+update_data_integration(Client, Identifier, Input0, Options0) ->
+    Method = patch,
+    Path = ["/dataIntegrations/", aws_util:encode_uri(Identifier), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the description of an event integration.
 update_event_integration(Client, Name, Input) ->
     update_event_integration(Client, Name, Input, []).
 update_event_integration(Client, Name, Input0, Options0) ->
@@ -326,6 +493,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_application_auto_scaling.erl
+++ b/src/aws_application_auto_scaling.erl
@@ -4,41 +4,45 @@
 %% @doc With Application Auto Scaling, you can configure automatic scaling
 %% for the following resources:
 %%
-%% <ul> <li> Amazon ECS services
-%%
-%% </li> <li> Amazon EC2 Spot Fleet requests
-%%
-%% </li> <li> Amazon EMR clusters
-%%
-%% </li> <li> Amazon AppStream 2.0 fleets
-%%
-%% </li> <li> Amazon DynamoDB tables and global secondary indexes throughput
-%% capacity
+%% <ul> <li> Amazon AppStream 2.0 fleets
 %%
 %% </li> <li> Amazon Aurora Replicas
-%%
-%% </li> <li> Amazon SageMaker endpoint variants
-%%
-%% </li> <li> Custom resources provided by your own applications or services
 %%
 %% </li> <li> Amazon Comprehend document classification and entity recognizer
 %% endpoints
 %%
-%% </li> <li> AWS Lambda function provisioned concurrency
+%% </li> <li> Amazon DynamoDB tables and global secondary indexes throughput
+%% capacity
+%%
+%% </li> <li> Amazon ECS services
+%%
+%% </li> <li> Amazon ElastiCache for Redis clusters (replication groups)
+%%
+%% </li> <li> Amazon EMR clusters
 %%
 %% </li> <li> Amazon Keyspaces (for Apache Cassandra) tables
 %%
+%% </li> <li> Lambda function provisioned concurrency
+%%
 %% </li> <li> Amazon Managed Streaming for Apache Kafka broker storage
+%%
+%% </li> <li> Amazon Neptune clusters
+%%
+%% </li> <li> Amazon SageMaker endpoint variants
+%%
+%% </li> <li> Spot Fleets (Amazon EC2)
+%%
+%% </li> <li> Custom resources provided by your own applications or services
 %%
 %% </li> </ul> API Summary
 %%
 %% The Application Auto Scaling service API includes three key sets of
 %% actions:
 %%
-%% <ul> <li> Register and manage scalable targets - Register AWS or custom
-%% resources as scalable targets (a resource that Application Auto Scaling
-%% can scale), set minimum and maximum capacity limits, and retrieve
-%% information on existing scalable targets.
+%% <ul> <li> Register and manage scalable targets - Register Amazon Web
+%% Services or custom resources as scalable targets (a resource that
+%% Application Auto Scaling can scale), set minimum and maximum capacity
+%% limits, and retrieve information on existing scalable targets.
 %%
 %% </li> <li> Configure and manage automatic scaling - Define scaling
 %% policies to dynamically scale your resources in response to CloudWatch
@@ -269,6 +273,13 @@ put_scheduled_action(Client, Input, Options)
 %% change. Include the parameters that identify the scalable target: resource
 %% ID, scalable dimension, and namespace. Any parameters that you don't
 %% specify are not changed by this update request.
+%%
+%% If you call the `RegisterScalableTarget' API to update an existing
+%% scalable target, Application Auto Scaling retrieves the current capacity
+%% of the resource. If it is below the minimum capacity or above the maximum
+%% capacity, Application Auto Scaling adjusts the capacity of the scalable
+%% target to place it within these bounds, even if you don't include the
+%% `MinCapacity' or `MaxCapacity' request parameters.
 register_scalable_target(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_scalable_target(Client, Input, []).

--- a/src/aws_applicationcostprofiler.erl
+++ b/src/aws_applicationcostprofiler.erl
@@ -1,0 +1,276 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc This reference provides descriptions of the AWS Application Cost
+%% Profiler API.
+%%
+%% The AWS Application Cost Profiler API provides programmatic access to
+%% view, create, update, and delete application cost report definitions, as
+%% well as to import your usage data into the Application Cost Profiler
+%% service.
+%%
+%% For more information about using this service, see the AWS Application
+%% Cost Profiler User Guide.
+-module(aws_applicationcostprofiler).
+
+-export([delete_report_definition/3,
+         delete_report_definition/4,
+         get_report_definition/2,
+         get_report_definition/4,
+         get_report_definition/5,
+         import_application_usage/2,
+         import_application_usage/3,
+         list_report_definitions/1,
+         list_report_definitions/3,
+         list_report_definitions/4,
+         put_report_definition/2,
+         put_report_definition/3,
+         update_report_definition/3,
+         update_report_definition/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Deletes the specified report definition in AWS Application Cost
+%% Profiler.
+%%
+%% This stops the report from being generated.
+delete_report_definition(Client, ReportId, Input) ->
+    delete_report_definition(Client, ReportId, Input, []).
+delete_report_definition(Client, ReportId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/reportDefinition/", aws_util:encode_uri(ReportId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves the definition of a report already configured in AWS
+%% Application Cost Profiler.
+get_report_definition(Client, ReportId)
+  when is_map(Client) ->
+    get_report_definition(Client, ReportId, #{}, #{}).
+
+get_report_definition(Client, ReportId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_report_definition(Client, ReportId, QueryMap, HeadersMap, []).
+
+get_report_definition(Client, ReportId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/reportDefinition/", aws_util:encode_uri(ReportId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Ingests application usage data from Amazon Simple Storage Service
+%% (Amazon S3).
+%%
+%% The data must already exist in the S3 location. As part of the action, AWS
+%% Application Cost Profiler copies the object from your S3 bucket to an S3
+%% bucket owned by Amazon for processing asynchronously.
+import_application_usage(Client, Input) ->
+    import_application_usage(Client, Input, []).
+import_application_usage(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/importApplicationUsage"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves a list of all reports and their configurations for your AWS
+%% account.
+%%
+%% The maximum number of reports is one.
+list_report_definitions(Client)
+  when is_map(Client) ->
+    list_report_definitions(Client, #{}, #{}).
+
+list_report_definitions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_report_definitions(Client, QueryMap, HeadersMap, []).
+
+list_report_definitions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/reportDefinition"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Creates the report definition for a report in Application Cost
+%% Profiler.
+put_report_definition(Client, Input) ->
+    put_report_definition(Client, Input, []).
+put_report_definition(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/reportDefinition"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates existing report in AWS Application Cost Profiler.
+update_report_definition(Client, ReportId, Input) ->
+    update_report_definition(Client, ReportId, Input, []).
+update_report_definition(Client, ReportId, Input0, Options0) ->
+    Method = put,
+    Path = ["/reportDefinition/", aws_util:encode_uri(ReportId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"application-cost-profiler">>},
+    Host = build_host(<<"application-cost-profiler">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_apprunner.erl
+++ b/src/aws_apprunner.erl
@@ -1,0 +1,424 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc App Runner
+%%
+%% App Runner is an application service that provides a fast, simple, and
+%% cost-effective way to go directly from an existing container image or
+%% source code to a running service in the Amazon Web Services Cloud in
+%% seconds.
+%%
+%% You don't need to learn new technologies, decide which compute service to
+%% use, or understand how to provision and configure Amazon Web Services
+%% resources.
+%%
+%% App Runner connects directly to your container registry or source code
+%% repository. It provides an automatic delivery pipeline with fully managed
+%% operations, high performance, scalability, and security.
+%%
+%% For more information about App Runner, see the App Runner Developer Guide.
+%% For release information, see the App Runner Release Notes.
+%%
+%% To install the Software Development Kits (SDKs), Integrated Development
+%% Environment (IDE) Toolkits, and command line tools that you can use to
+%% access the API, see Tools for Amazon Web Services.
+%%
+%% Endpoints
+%%
+%% For a list of Region-specific endpoints that App Runner supports, see App
+%% Runner endpoints and quotas in the Amazon Web Services General Reference.
+-module(aws_apprunner).
+
+-export([associate_custom_domain/2,
+         associate_custom_domain/3,
+         create_auto_scaling_configuration/2,
+         create_auto_scaling_configuration/3,
+         create_connection/2,
+         create_connection/3,
+         create_service/2,
+         create_service/3,
+         delete_auto_scaling_configuration/2,
+         delete_auto_scaling_configuration/3,
+         delete_connection/2,
+         delete_connection/3,
+         delete_service/2,
+         delete_service/3,
+         describe_auto_scaling_configuration/2,
+         describe_auto_scaling_configuration/3,
+         describe_custom_domains/2,
+         describe_custom_domains/3,
+         describe_service/2,
+         describe_service/3,
+         disassociate_custom_domain/2,
+         disassociate_custom_domain/3,
+         list_auto_scaling_configurations/2,
+         list_auto_scaling_configurations/3,
+         list_connections/2,
+         list_connections/3,
+         list_operations/2,
+         list_operations/3,
+         list_services/2,
+         list_services/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         pause_service/2,
+         pause_service/3,
+         resume_service/2,
+         resume_service/3,
+         start_deployment/2,
+         start_deployment/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_service/2,
+         update_service/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Associate your own domain name with the App Runner subdomain URL of
+%% your App Runner service.
+%%
+%% After you call `AssociateCustomDomain' and receive a successful response,
+%% use the information in the `CustomDomain' record that's returned to add
+%% CNAME records to your Domain Name System (DNS). For each mapped domain
+%% name, add a mapping to the target App Runner subdomain and one or more
+%% certificate validation records. App Runner then performs DNS validation to
+%% verify that you own or control the domain name that you associated. App
+%% Runner tracks domain validity in a certificate stored in AWS Certificate
+%% Manager (ACM).
+associate_custom_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    associate_custom_domain(Client, Input, []).
+associate_custom_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AssociateCustomDomain">>, Input, Options).
+
+%% @doc Create an App Runner automatic scaling configuration resource.
+%%
+%% App Runner requires this resource when you create App Runner services that
+%% require non-default auto scaling settings. You can share an auto scaling
+%% configuration across multiple services.
+%%
+%% Create multiple revisions of a configuration by using the same
+%% `AutoScalingConfigurationName' and different
+%% `AutoScalingConfigurationRevision' values. When you create a service, you
+%% can set it to use the latest active revision of an auto scaling
+%% configuration or a specific revision.
+%%
+%% Configure a higher `MinSize' to increase the spread of your App Runner
+%% service over more Availability Zones in the Amazon Web Services Region.
+%% The tradeoff is a higher minimal cost.
+%%
+%% Configure a lower `MaxSize' to control your cost. The tradeoff is lower
+%% responsiveness during peak demand.
+create_auto_scaling_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_auto_scaling_configuration(Client, Input, []).
+create_auto_scaling_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateAutoScalingConfiguration">>, Input, Options).
+
+%% @doc Create an App Runner connection resource.
+%%
+%% App Runner requires a connection resource when you create App Runner
+%% services that access private repositories from certain third-party
+%% providers. You can share a connection across multiple services.
+%%
+%% A connection resource is needed to access GitHub repositories. GitHub
+%% requires a user interface approval process through the App Runner console
+%% before you can use the connection.
+create_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_connection(Client, Input, []).
+create_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateConnection">>, Input, Options).
+
+%% @doc Create an App Runner service.
+%%
+%% After the service is created, the action also automatically starts a
+%% deployment.
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the ListOperations call to track the
+%% operation's progress.
+create_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_service(Client, Input, []).
+create_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateService">>, Input, Options).
+
+%% @doc Delete an App Runner automatic scaling configuration resource.
+%%
+%% You can delete a specific revision or the latest active revision. You
+%% can't delete a configuration that's used by one or more App Runner
+%% services.
+delete_auto_scaling_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_auto_scaling_configuration(Client, Input, []).
+delete_auto_scaling_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteAutoScalingConfiguration">>, Input, Options).
+
+%% @doc Delete an App Runner connection.
+%%
+%% You must first ensure that there are no running App Runner services that
+%% use this connection. If there are any, the `DeleteConnection' action
+%% fails.
+delete_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_connection(Client, Input, []).
+delete_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteConnection">>, Input, Options).
+
+%% @doc Delete an App Runner service.
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the `ListOperations' call to track the
+%% operation's progress.
+delete_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_service(Client, Input, []).
+delete_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteService">>, Input, Options).
+
+%% @doc Return a full description of an App Runner automatic scaling
+%% configuration resource.
+describe_auto_scaling_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_auto_scaling_configuration(Client, Input, []).
+describe_auto_scaling_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeAutoScalingConfiguration">>, Input, Options).
+
+%% @doc Return a description of custom domain names that are associated with
+%% an App Runner service.
+describe_custom_domains(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_custom_domains(Client, Input, []).
+describe_custom_domains(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeCustomDomains">>, Input, Options).
+
+%% @doc Return a full description of an App Runner service.
+describe_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_service(Client, Input, []).
+describe_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeService">>, Input, Options).
+
+%% @doc Disassociate a custom domain name from an App Runner service.
+%%
+%% Certificates tracking domain validity are associated with a custom domain
+%% and are stored in AWS Certificate Manager (ACM). These certificates aren't
+%% deleted as part of this action. App Runner delays certificate deletion for
+%% 30 days after a domain is disassociated from your service.
+disassociate_custom_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    disassociate_custom_domain(Client, Input, []).
+disassociate_custom_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DisassociateCustomDomain">>, Input, Options).
+
+%% @doc Returns a list of App Runner automatic scaling configurations in your
+%% Amazon Web Services account.
+%%
+%% You can query the revisions for a specific configuration name or the
+%% revisions for all configurations in your account. You can optionally query
+%% only the latest revision of each requested name.
+list_auto_scaling_configurations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_auto_scaling_configurations(Client, Input, []).
+list_auto_scaling_configurations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListAutoScalingConfigurations">>, Input, Options).
+
+%% @doc Returns a list of App Runner connections that are associated with
+%% your Amazon Web Services account.
+list_connections(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_connections(Client, Input, []).
+list_connections(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListConnections">>, Input, Options).
+
+%% @doc Return a list of operations that occurred on an App Runner service.
+%%
+%% The resulting list of `OperationSummary' objects is sorted in reverse
+%% chronological order. The first object on the list represents the last
+%% started operation.
+list_operations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_operations(Client, Input, []).
+list_operations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListOperations">>, Input, Options).
+
+%% @doc Returns a list of running App Runner services in your Amazon Web
+%% Services account.
+list_services(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_services(Client, Input, []).
+list_services(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListServices">>, Input, Options).
+
+%% @doc List tags that are associated with for an App Runner resource.
+%%
+%% The response contains a list of tag key-value pairs.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc Pause an active App Runner service.
+%%
+%% App Runner reduces compute capacity for the service to zero and loses
+%% state (for example, ephemeral storage is removed).
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the `ListOperations' call to track the
+%% operation's progress.
+pause_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    pause_service(Client, Input, []).
+pause_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PauseService">>, Input, Options).
+
+%% @doc Resume an active App Runner service.
+%%
+%% App Runner provisions compute capacity for the service.
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the `ListOperations' call to track the
+%% operation's progress.
+resume_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    resume_service(Client, Input, []).
+resume_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ResumeService">>, Input, Options).
+
+%% @doc Initiate a manual deployment of the latest commit in a source code
+%% repository or the latest image in a source image repository to an App
+%% Runner service.
+%%
+%% For a source code repository, App Runner retrieves the commit and builds a
+%% Docker image. For a source image repository, App Runner retrieves the
+%% latest Docker image. In both cases, App Runner then deploys the new image
+%% to your service and starts a new container instance.
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the `ListOperations' call to track the
+%% operation's progress.
+start_deployment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_deployment(Client, Input, []).
+start_deployment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartDeployment">>, Input, Options).
+
+%% @doc Add tags to, or update the tag values of, an App Runner resource.
+%%
+%% A tag is a key-value pair.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Remove tags from an App Runner resource.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Update an App Runner service.
+%%
+%% You can update the source configuration and instance configuration of the
+%% service. You can also update the ARN of the auto scaling configuration
+%% resource that's associated with the service. However, you can't change the
+%% name or the encryption configuration of the service. These can be set only
+%% when you create the service.
+%%
+%% To update the tags applied to your service, use the separate actions
+%% `TagResource' and `UntagResource'.
+%%
+%% This is an asynchronous operation. On a successful call, you can use the
+%% returned `OperationId' and the `ListOperations' call to track the
+%% operation's progress.
+update_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service(Client, Input, []).
+update_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateService">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"apprunner">>},
+    Host = build_host(<<"apprunner">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"AppRunner.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_appstream.erl
+++ b/src/aws_appstream.erl
@@ -47,6 +47,8 @@
          create_stack/3,
          create_streaming_url/2,
          create_streaming_url/3,
+         create_updated_image/2,
+         create_updated_image/3,
          create_usage_report_subscription/2,
          create_usage_report_subscription/3,
          create_user/2,
@@ -230,6 +232,19 @@ create_streaming_url(Client, Input)
 create_streaming_url(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateStreamingURL">>, Input, Options).
+
+%% @doc Creates a new image with the latest Windows operating system updates,
+%% driver updates, and AppStream 2.0 agent software.
+%%
+%% For more information, see the "Update an Image by Using Managed AppStream
+%% 2.0 Image Updates" section in Administer Your AppStream 2.0 Images, in the
+%% Amazon AppStream 2.0 Administration Guide.
+create_updated_image(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_updated_image(Client, Input, []).
+create_updated_image(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateUpdatedImage">>, Input, Options).
 
 %% @doc Creates a usage report subscription.
 %%

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -1,8 +1,8 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS AppSync provides API actions for creating and interacting with
-%% data sources using GraphQL from your application.
+%% @doc AppSync provides API actions for creating and interacting with data
+%% sources using GraphQL from your application.
 -module(aws_appsync).
 
 -export([create_api_cache/3,
@@ -1150,6 +1150,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_athena.erl
+++ b/src/aws_athena.erl
@@ -16,8 +16,8 @@
 %% support the API. For more information and to download the driver, see
 %% Accessing Amazon Athena with JDBC.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 -module(aws_athena).
 
 -export([batch_get_named_query/2,
@@ -28,12 +28,16 @@
          create_data_catalog/3,
          create_named_query/2,
          create_named_query/3,
+         create_prepared_statement/2,
+         create_prepared_statement/3,
          create_work_group/2,
          create_work_group/3,
          delete_data_catalog/2,
          delete_data_catalog/3,
          delete_named_query/2,
          delete_named_query/3,
+         delete_prepared_statement/2,
+         delete_prepared_statement/3,
          delete_work_group/2,
          delete_work_group/3,
          get_data_catalog/2,
@@ -42,6 +46,8 @@
          get_database/3,
          get_named_query/2,
          get_named_query/3,
+         get_prepared_statement/2,
+         get_prepared_statement/3,
          get_query_execution/2,
          get_query_execution/3,
          get_query_results/2,
@@ -58,6 +64,8 @@
          list_engine_versions/3,
          list_named_queries/2,
          list_named_queries/3,
+         list_prepared_statements/2,
+         list_prepared_statements/3,
          list_query_executions/2,
          list_query_executions/3,
          list_table_metadata/2,
@@ -76,6 +84,8 @@
          untag_resource/3,
          update_data_catalog/2,
          update_data_catalog/3,
+         update_prepared_statement/2,
+         update_prepared_statement/3,
          update_work_group/2,
          update_work_group/3]).
 
@@ -122,7 +132,8 @@ batch_get_query_execution(Client, Input, Options)
 %% @doc Creates (registers) a data catalog with the specified name and
 %% properties.
 %%
-%% Catalogs created are visible to all users of the same AWS account.
+%% Catalogs created are visible to all users of the same Amazon Web Services
+%% account.
 create_data_catalog(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_data_catalog(Client, Input, []).
@@ -134,14 +145,22 @@ create_data_catalog(Client, Input, Options)
 %%
 %% Requires that you have access to the workgroup.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 create_named_query(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_named_query(Client, Input, []).
 create_named_query(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateNamedQuery">>, Input, Options).
+
+%% @doc Creates a prepared statement for use with SQL queries in Athena.
+create_prepared_statement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_prepared_statement(Client, Input, []).
+create_prepared_statement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreatePreparedStatement">>, Input, Options).
 
 %% @doc Creates a workgroup with the specified name.
 create_work_group(Client, Input)
@@ -162,14 +181,23 @@ delete_data_catalog(Client, Input, Options)
 %% @doc Deletes the named query if you have access to the workgroup in which
 %% the query was saved.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 delete_named_query(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_named_query(Client, Input, []).
 delete_named_query(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteNamedQuery">>, Input, Options).
+
+%% @doc Deletes the prepared statement with the specified name from the
+%% specified workgroup.
+delete_prepared_statement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_prepared_statement(Client, Input, []).
+delete_prepared_statement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeletePreparedStatement">>, Input, Options).
 
 %% @doc Deletes the workgroup with the specified name.
 %%
@@ -208,6 +236,15 @@ get_named_query(Client, Input)
 get_named_query(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetNamedQuery">>, Input, Options).
+
+%% @doc Retrieves the prepared statement with the specified name from the
+%% specified workgroup.
+get_prepared_statement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_prepared_statement(Client, Input, []).
+get_prepared_statement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetPreparedStatement">>, Input, Options).
 
 %% @doc Returns information about a single execution of a query if you have
 %% access to the workgroup in which the query ran.
@@ -261,7 +298,7 @@ get_work_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetWorkGroup">>, Input, Options).
 
-%% @doc Lists the data catalogs in the current AWS account.
+%% @doc Lists the data catalogs in the current Amazon Web Services account.
 list_data_catalogs(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_data_catalogs(Client, Input, []).
@@ -292,14 +329,22 @@ list_engine_versions(Client, Input, Options)
 %% Requires that you have access to the specified workgroup. If a workgroup
 %% is not specified, lists the saved queries for the primary workgroup.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 list_named_queries(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_named_queries(Client, Input, []).
 list_named_queries(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListNamedQueries">>, Input, Options).
+
+%% @doc Lists the prepared statements in the specfied workgroup.
+list_prepared_statements(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_prepared_statements(Client, Input, []).
+list_prepared_statements(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListPreparedStatements">>, Input, Options).
 
 %% @doc Provides a list of available query execution IDs for the queries in
 %% the specified workgroup.
@@ -308,8 +353,8 @@ list_named_queries(Client, Input, Options)
 %% the primary workgroup. Requires you to have access to the workgroup in
 %% which the queries ran.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 list_query_executions(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_query_executions(Client, Input, []).
@@ -347,8 +392,9 @@ list_work_groups(Client, Input, Options)
 %%
 %% Requires you to have access to the workgroup in which the query ran.
 %% Running queries against an external catalog requires `GetDataCatalog'
-%% permission to the catalog. For code samples using the AWS SDK for Java,
-%% see Examples and Code Samples in the Amazon Athena User Guide.
+%% permission to the catalog. For code samples using the Amazon Web Services
+%% SDK for Java, see Examples and Code Samples in the Amazon Athena User
+%% Guide.
 start_query_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_query_execution(Client, Input, []).
@@ -360,8 +406,8 @@ start_query_execution(Client, Input, Options)
 %%
 %% Requires you to have access to the workgroup in which the query ran.
 %%
-%% For code samples using the AWS SDK for Java, see Examples and Code Samples
-%% in the Amazon Athena User Guide.
+%% For code samples using the Amazon Web Services SDK for Java, see Examples
+%% and Code Samples in the Amazon Athena User Guide.
 stop_query_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_query_execution(Client, Input, []).
@@ -405,6 +451,14 @@ update_data_catalog(Client, Input)
 update_data_catalog(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateDataCatalog">>, Input, Options).
+
+%% @doc Updates a prepared statement.
+update_prepared_statement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_prepared_statement(Client, Input, []).
+update_prepared_statement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdatePreparedStatement">>, Input, Options).
 
 %% @doc Updates the workgroup with the specified name.
 %%

--- a/src/aws_auditmanager.erl
+++ b/src/aws_auditmanager.erl
@@ -1,29 +1,29 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Welcome to the AWS Audit Manager API reference.
+%% @doc Welcome to the Audit Manager API reference.
 %%
-%% This guide is for developers who need detailed information about the AWS
-%% Audit Manager API operations, data types, and errors.
+%% This guide is for developers who need detailed information about the Audit
+%% Manager API operations, data types, and errors.
 %%
-%% AWS Audit Manager is a service that provides automated evidence collection
-%% so that you can continuously audit your AWS usage, and assess the
-%% effectiveness of your controls to better manage risk and simplify
+%% Audit Manager is a service that provides automated evidence collection so
+%% that you can continually audit your Amazon Web Services usage. You can use
+%% it to assess the effectiveness of your controls, manage risk, and simplify
 %% compliance.
 %%
-%% AWS Audit Manager provides pre-built frameworks that structure and
-%% automate assessments for a given compliance standard. Frameworks include a
-%% pre-built collection of controls with descriptions and testing procedures,
-%% which are grouped according to the requirements of the specified
+%% Audit Manager provides prebuilt frameworks that structure and automate
+%% assessments for a given compliance standard. Frameworks include a prebuilt
+%% collection of controls with descriptions and testing procedures. These
+%% controls are grouped according to the requirements of the specified
 %% compliance standard or regulation. You can also customize frameworks and
-%% controls to support internal audits with unique requirements.
+%% controls to support internal audits with specific requirements.
 %%
-%% Use the following links to get started with the AWS Audit Manager API:
+%% Use the following links to get started with the Audit Manager API:
 %%
-%% <ul> <li> Actions: An alphabetical list of all AWS Audit Manager API
+%% <ul> <li> Actions: An alphabetical list of all Audit Manager API
 %% operations.
 %%
-%% </li> <li> Data types: An alphabetical list of all AWS Audit Manager data
+%% </li> <li> Data types: An alphabetical list of all Audit Manager data
 %% types.
 %%
 %% </li> <li> Common parameters: Parameters that all Query operations can
@@ -32,8 +32,8 @@
 %% </li> <li> Common errors: Client and server errors that all operations can
 %% return.
 %%
-%% </li> </ul> If you're new to AWS Audit Manager, we recommend that you
-%% review the AWS Audit Manager User Guide.
+%% </li> </ul> If you're new to Audit Manager, we recommend that you review
+%% the Audit Manager User Guide.
 -module(aws_auditmanager).
 
 -export([associate_assessment_report_evidence_folder/3,
@@ -60,6 +60,8 @@
          delete_assessment/4,
          delete_assessment_framework/3,
          delete_assessment_framework/4,
+         delete_assessment_framework_share/3,
+         delete_assessment_framework_share/4,
          delete_assessment_report/4,
          delete_assessment_report/5,
          delete_control/3,
@@ -115,6 +117,9 @@
          get_settings/2,
          get_settings/4,
          get_settings/5,
+         list_assessment_framework_share_requests/2,
+         list_assessment_framework_share_requests/4,
+         list_assessment_framework_share_requests/5,
          list_assessment_frameworks/2,
          list_assessment_frameworks/4,
          list_assessment_frameworks/5,
@@ -140,6 +145,8 @@
          register_account/3,
          register_organization_admin_account/2,
          register_organization_admin_account/3,
+         start_assessment_framework_share/3,
+         start_assessment_framework_share/4,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
@@ -152,6 +159,8 @@
          update_assessment_control_set_status/5,
          update_assessment_framework/3,
          update_assessment_framework/4,
+         update_assessment_framework_share/3,
+         update_assessment_framework_share/4,
          update_assessment_status/3,
          update_assessment_status/4,
          update_control/3,
@@ -167,8 +176,8 @@
 %% API
 %%====================================================================
 
-%% @doc Associates an evidence folder to the specified assessment report in
-%% AWS Audit Manager.
+%% @doc Associates an evidence folder to an assessment report in a Audit
+%% Manager assessment.
 associate_assessment_report_evidence_folder(Client, AssessmentId, Input) ->
     associate_assessment_report_evidence_folder(Client, AssessmentId, Input, []).
 associate_assessment_report_evidence_folder(Client, AssessmentId, Input0, Options0) ->
@@ -191,7 +200,7 @@ associate_assessment_report_evidence_folder(Client, AssessmentId, Input0, Option
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Associates a list of evidence to an assessment report in an AWS Audit
+%% @doc Associates a list of evidence to an assessment report in an Audit
 %% Manager assessment.
 batch_associate_assessment_report_evidence(Client, AssessmentId, Input) ->
     batch_associate_assessment_report_evidence(Client, AssessmentId, Input, []).
@@ -215,8 +224,7 @@ batch_associate_assessment_report_evidence(Client, AssessmentId, Input0, Options
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Create a batch of delegations for a specified assessment in AWS Audit
-%% Manager.
+%% @doc Creates a batch of delegations for an assessment in Audit Manager.
 batch_create_delegation_by_assessment(Client, AssessmentId, Input) ->
     batch_create_delegation_by_assessment(Client, AssessmentId, Input, []).
 batch_create_delegation_by_assessment(Client, AssessmentId, Input0, Options0) ->
@@ -239,8 +247,7 @@ batch_create_delegation_by_assessment(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes the delegations in the specified AWS Audit Manager
-%% assessment.
+%% @doc Deletes a batch of delegations for an assessment in Audit Manager.
 batch_delete_delegation_by_assessment(Client, AssessmentId, Input) ->
     batch_delete_delegation_by_assessment(Client, AssessmentId, Input, []).
 batch_delete_delegation_by_assessment(Client, AssessmentId, Input0, Options0) ->
@@ -263,8 +270,8 @@ batch_delete_delegation_by_assessment(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Disassociates a list of evidence from the specified assessment report
-%% in AWS Audit Manager.
+%% @doc Disassociates a list of evidence from an assessment report in Audit
+%% Manager.
 batch_disassociate_assessment_report_evidence(Client, AssessmentId, Input) ->
     batch_disassociate_assessment_report_evidence(Client, AssessmentId, Input, []).
 batch_disassociate_assessment_report_evidence(Client, AssessmentId, Input0, Options0) ->
@@ -287,8 +294,8 @@ batch_disassociate_assessment_report_evidence(Client, AssessmentId, Input0, Opti
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Uploads one or more pieces of evidence to the specified control in
-%% the assessment in AWS Audit Manager.
+%% @doc Uploads one or more pieces of evidence to a control in an Audit
+%% Manager assessment.
 batch_import_evidence_to_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input) ->
     batch_import_evidence_to_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input, []).
 batch_import_evidence_to_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input0, Options0) ->
@@ -311,7 +318,7 @@ batch_import_evidence_to_assessment_control(Client, AssessmentId, ControlId, Con
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an assessment in AWS Audit Manager.
+%% @doc Creates an assessment in Audit Manager.
 create_assessment(Client, Input) ->
     create_assessment(Client, Input, []).
 create_assessment(Client, Input0, Options0) ->
@@ -334,7 +341,7 @@ create_assessment(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a custom framework in AWS Audit Manager.
+%% @doc Creates a custom framework in Audit Manager.
 create_assessment_framework(Client, Input) ->
     create_assessment_framework(Client, Input, []).
 create_assessment_framework(Client, Input0, Options0) ->
@@ -380,7 +387,7 @@ create_assessment_report(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a new custom control in AWS Audit Manager.
+%% @doc Creates a new custom control in Audit Manager.
 create_control(Client, Input) ->
     create_control(Client, Input, []).
 create_control(Client, Input0, Options0) ->
@@ -403,7 +410,7 @@ create_control(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an assessment in AWS Audit Manager.
+%% @doc Deletes an assessment in Audit Manager.
 delete_assessment(Client, AssessmentId, Input) ->
     delete_assessment(Client, AssessmentId, Input, []).
 delete_assessment(Client, AssessmentId, Input0, Options0) ->
@@ -426,7 +433,7 @@ delete_assessment(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a custom framework in AWS Audit Manager.
+%% @doc Deletes a custom framework in Audit Manager.
 delete_assessment_framework(Client, FrameworkId, Input) ->
     delete_assessment_framework(Client, FrameworkId, Input, []).
 delete_assessment_framework(Client, FrameworkId, Input0, Options0) ->
@@ -449,7 +456,31 @@ delete_assessment_framework(Client, FrameworkId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an assessment report from an assessment in AWS Audit Manager.
+%% @doc Deletes a share request for a custom framework in Audit Manager.
+delete_assessment_framework_share(Client, RequestId, Input) ->
+    delete_assessment_framework_share(Client, RequestId, Input, []).
+delete_assessment_framework_share(Client, RequestId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/assessmentFrameworkShareRequests/", aws_util:encode_uri(RequestId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"requestType">>, <<"requestType">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an assessment report from an assessment in Audit Manager.
 delete_assessment_report(Client, AssessmentId, AssessmentReportId, Input) ->
     delete_assessment_report(Client, AssessmentId, AssessmentReportId, Input, []).
 delete_assessment_report(Client, AssessmentId, AssessmentReportId, Input0, Options0) ->
@@ -472,7 +503,7 @@ delete_assessment_report(Client, AssessmentId, AssessmentReportId, Input0, Optio
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a custom control in AWS Audit Manager.
+%% @doc Deletes a custom control in Audit Manager.
 delete_control(Client, ControlId, Input) ->
     delete_control(Client, ControlId, Input, []).
 delete_control(Client, ControlId, Input0, Options0) ->
@@ -495,7 +526,7 @@ delete_control(Client, ControlId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deregisters an account in AWS Audit Manager.
+%% @doc Deregisters an account in Audit Manager.
 deregister_account(Client, Input) ->
     deregister_account(Client, Input, []).
 deregister_account(Client, Input0, Options0) ->
@@ -518,8 +549,15 @@ deregister_account(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deregisters the delegated AWS administrator account from the AWS
-%% organization.
+%% @doc Removes the specified member Amazon Web Services account as a
+%% delegated administrator for Audit Manager.
+%%
+%% When you remove a delegated administrator from your Audit Manager
+%% settings, you continue to have access to the evidence that you previously
+%% collected under that account. This is also the case when you deregister a
+%% delegated administrator from Audit Manager. However, Audit Manager will
+%% stop collecting and attaching evidence to that delegated administrator
+%% account moving forward.
 deregister_organization_admin_account(Client, Input) ->
     deregister_organization_admin_account(Client, Input, []).
 deregister_organization_admin_account(Client, Input0, Options0) ->
@@ -543,7 +581,7 @@ deregister_organization_admin_account(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Disassociates an evidence folder from the specified assessment report
-%% in AWS Audit Manager.
+%% in Audit Manager.
 disassociate_assessment_report_evidence_folder(Client, AssessmentId, Input) ->
     disassociate_assessment_report_evidence_folder(Client, AssessmentId, Input, []).
 disassociate_assessment_report_evidence_folder(Client, AssessmentId, Input0, Options0) ->
@@ -566,7 +604,7 @@ disassociate_assessment_report_evidence_folder(Client, AssessmentId, Input0, Opt
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns the registration status of an account in AWS Audit Manager.
+%% @doc Returns the registration status of an account in Audit Manager.
 get_account_status(Client)
   when is_map(Client) ->
     get_account_status(Client, #{}, #{}).
@@ -589,7 +627,7 @@ get_account_status(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns an assessment from AWS Audit Manager.
+%% @doc Returns an assessment from Audit Manager.
 get_assessment(Client, AssessmentId)
   when is_map(Client) ->
     get_assessment(Client, AssessmentId, #{}, #{}).
@@ -612,7 +650,7 @@ get_assessment(Client, AssessmentId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a framework from AWS Audit Manager.
+%% @doc Returns a framework from Audit Manager.
 get_assessment_framework(Client, FrameworkId)
   when is_map(Client) ->
     get_assessment_framework(Client, FrameworkId, #{}, #{}).
@@ -635,8 +673,7 @@ get_assessment_framework(Client, FrameworkId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the URL of a specified assessment report in AWS Audit
-%% Manager.
+%% @doc Returns the URL of an assessment report in Audit Manager.
 get_assessment_report_url(Client, AssessmentId, AssessmentReportId)
   when is_map(Client) ->
     get_assessment_report_url(Client, AssessmentId, AssessmentReportId, #{}, #{}).
@@ -659,7 +696,7 @@ get_assessment_report_url(Client, AssessmentId, AssessmentReportId, QueryMap, He
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of changelogs from AWS Audit Manager.
+%% @doc Returns a list of changelogs from Audit Manager.
 get_change_logs(Client, AssessmentId)
   when is_map(Client) ->
     get_change_logs(Client, AssessmentId, #{}, #{}).
@@ -689,7 +726,7 @@ get_change_logs(Client, AssessmentId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a control from AWS Audit Manager.
+%% @doc Returns a control from Audit Manager.
 get_control(Client, ControlId)
   when is_map(Client) ->
     get_control(Client, ControlId, #{}, #{}).
@@ -740,7 +777,7 @@ get_delegations(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns evidence from AWS Audit Manager.
+%% @doc Returns evidence from Audit Manager.
 get_evidence(Client, AssessmentId, ControlSetId, EvidenceFolderId, EvidenceId)
   when is_map(Client) ->
     get_evidence(Client, AssessmentId, ControlSetId, EvidenceFolderId, EvidenceId, #{}, #{}).
@@ -763,7 +800,7 @@ get_evidence(Client, AssessmentId, ControlSetId, EvidenceFolderId, EvidenceId, Q
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns all evidence from a specified evidence folder in AWS Audit
+%% @doc Returns all evidence from a specified evidence folder in Audit
 %% Manager.
 get_evidence_by_evidence_folder(Client, AssessmentId, ControlSetId, EvidenceFolderId)
   when is_map(Client) ->
@@ -792,7 +829,7 @@ get_evidence_by_evidence_folder(Client, AssessmentId, ControlSetId, EvidenceFold
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns an evidence folder from the specified assessment in AWS Audit
+%% @doc Returns an evidence folder from the specified assessment in Audit
 %% Manager.
 get_evidence_folder(Client, AssessmentId, ControlSetId, EvidenceFolderId)
   when is_map(Client) ->
@@ -816,7 +853,7 @@ get_evidence_folder(Client, AssessmentId, ControlSetId, EvidenceFolderId, QueryM
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the evidence folders from a specified assessment in AWS Audit
+%% @doc Returns the evidence folders from a specified assessment in Audit
 %% Manager.
 get_evidence_folders_by_assessment(Client, AssessmentId)
   when is_map(Client) ->
@@ -845,8 +882,8 @@ get_evidence_folders_by_assessment(Client, AssessmentId, QueryMap, HeadersMap, O
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of evidence folders associated with a specified
-%% control of an assessment in AWS Audit Manager.
+%% @doc Returns a list of evidence folders that are associated with a
+%% specified control of an assessment in Audit Manager.
 get_evidence_folders_by_assessment_control(Client, AssessmentId, ControlId, ControlSetId)
   when is_map(Client) ->
     get_evidence_folders_by_assessment_control(Client, AssessmentId, ControlId, ControlSetId, #{}, #{}).
@@ -874,8 +911,8 @@ get_evidence_folders_by_assessment_control(Client, AssessmentId, ControlId, Cont
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the name of the delegated AWS administrator account for the
-%% AWS organization.
+%% @doc Returns the name of the delegated Amazon Web Services administrator
+%% account for the organization.
 get_organization_admin_account(Client)
   when is_map(Client) ->
     get_organization_admin_account(Client, #{}, #{}).
@@ -898,8 +935,8 @@ get_organization_admin_account(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of the in-scope AWS services for the specified
-%% assessment.
+%% @doc Returns a list of the in-scope Amazon Web Services services for the
+%% specified assessment.
 get_services_in_scope(Client)
   when is_map(Client) ->
     get_services_in_scope(Client, #{}, #{}).
@@ -922,7 +959,7 @@ get_services_in_scope(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the settings for the specified AWS account.
+%% @doc Returns the settings for the specified Amazon Web Services account.
 get_settings(Client, Attribute)
   when is_map(Client) ->
     get_settings(Client, Attribute, #{}, #{}).
@@ -945,8 +982,38 @@ get_settings(Client, Attribute, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of the frameworks available in the AWS Audit Manager
-%% framework library.
+%% @doc Returns a list of sent or received share requests for custom
+%% frameworks in Audit Manager.
+list_assessment_framework_share_requests(Client, RequestType)
+  when is_map(Client) ->
+    list_assessment_framework_share_requests(Client, RequestType, #{}, #{}).
+
+list_assessment_framework_share_requests(Client, RequestType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_assessment_framework_share_requests(Client, RequestType, QueryMap, HeadersMap, []).
+
+list_assessment_framework_share_requests(Client, RequestType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assessmentFrameworkShareRequests"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"requestType">>, RequestType}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of the frameworks that are available in the Audit
+%% Manager framework library.
 list_assessment_frameworks(Client, FrameworkType)
   when is_map(Client) ->
     list_assessment_frameworks(Client, FrameworkType, #{}, #{}).
@@ -975,7 +1042,7 @@ list_assessment_frameworks(Client, FrameworkType, QueryMap, HeadersMap, Options0
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of assessment reports created in AWS Audit Manager.
+%% @doc Returns a list of assessment reports created in Audit Manager.
 list_assessment_reports(Client)
   when is_map(Client) ->
     list_assessment_reports(Client, #{}, #{}).
@@ -1003,8 +1070,7 @@ list_assessment_reports(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of current and past assessments from AWS Audit
-%% Manager.
+%% @doc Returns a list of current and past assessments from Audit Manager.
 list_assessments(Client)
   when is_map(Client) ->
     list_assessments(Client, #{}, #{}).
@@ -1032,7 +1098,7 @@ list_assessments(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of controls from AWS Audit Manager.
+%% @doc Returns a list of controls from Audit Manager.
 list_controls(Client, ControlType)
   when is_map(Client) ->
     list_controls(Client, ControlType, #{}, #{}).
@@ -1061,8 +1127,8 @@ list_controls(Client, ControlType, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of keywords that pre-mapped to the specified control
-%% data source.
+%% @doc Returns a list of keywords that are pre-mapped to the specified
+%% control data source.
 list_keywords_for_data_source(Client, Source)
   when is_map(Client) ->
     list_keywords_for_data_source(Client, Source, #{}, #{}).
@@ -1091,7 +1157,7 @@ list_keywords_for_data_source(Client, Source, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of all AWS Audit Manager notifications.
+%% @doc Returns a list of all Audit Manager notifications.
 list_notifications(Client)
   when is_map(Client) ->
     list_notifications(Client, #{}, #{}).
@@ -1119,8 +1185,7 @@ list_notifications(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of tags for the specified resource in AWS Audit
-%% Manager.
+%% @doc Returns a list of tags for the specified resource in Audit Manager.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -1143,7 +1208,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Enables AWS Audit Manager for the specified AWS account.
+%% @doc Enables Audit Manager for the specified Amazon Web Services account.
 register_account(Client, Input) ->
     register_account(Client, Input, []).
 register_account(Client, Input0, Options0) ->
@@ -1166,8 +1231,8 @@ register_account(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Enables an AWS account within the organization as the delegated
-%% administrator for AWS Audit Manager.
+%% @doc Enables an Amazon Web Services account within the organization as the
+%% delegated administrator for Audit Manager.
 register_organization_admin_account(Client, Input) ->
     register_organization_admin_account(Client, Input, []).
 register_organization_admin_account(Client, Input0, Options0) ->
@@ -1190,7 +1255,43 @@ register_organization_admin_account(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Tags the specified resource in AWS Audit Manager.
+%% @doc Creates a share request for a custom framework in Audit Manager.
+%%
+%% The share request specifies a recipient and notifies them that a custom
+%% framework is available. Recipients have 120 days to accept or decline the
+%% request. If no action is taken, the share request expires.
+%%
+%% When you invoke the `StartAssessmentFrameworkShare' API, you are about to
+%% share a custom framework with another Amazon Web Services account. You may
+%% not share a custom framework that is derived from a standard framework if
+%% the standard framework is designated as not eligible for sharing by Amazon
+%% Web Services, unless you have obtained permission to do so from the owner
+%% of the standard framework. To learn more about which standard frameworks
+%% are eligible for sharing, see Framework sharing eligibility in the Audit
+%% Manager User Guide.
+start_assessment_framework_share(Client, FrameworkId, Input) ->
+    start_assessment_framework_share(Client, FrameworkId, Input, []).
+start_assessment_framework_share(Client, FrameworkId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assessmentFrameworks/", aws_util:encode_uri(FrameworkId), "/shareRequests"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Tags the specified resource in Audit Manager.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -1213,7 +1314,7 @@ tag_resource(Client, ResourceArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes a tag from a resource in AWS Audit Manager.
+%% @doc Removes a tag from a resource in Audit Manager.
 untag_resource(Client, ResourceArn, Input) ->
     untag_resource(Client, ResourceArn, Input, []).
 untag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -1237,7 +1338,7 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Edits an AWS Audit Manager assessment.
+%% @doc Edits an Audit Manager assessment.
 update_assessment(Client, AssessmentId, Input) ->
     update_assessment(Client, AssessmentId, Input, []).
 update_assessment(Client, AssessmentId, Input0, Options0) ->
@@ -1260,7 +1361,7 @@ update_assessment(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates a control within an assessment in AWS Audit Manager.
+%% @doc Updates a control within an assessment in Audit Manager.
 update_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input) ->
     update_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input, []).
 update_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input0, Options0) ->
@@ -1283,8 +1384,7 @@ update_assessment_control(Client, AssessmentId, ControlId, ControlSetId, Input0,
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the status of a control set in an AWS Audit Manager
-%% assessment.
+%% @doc Updates the status of a control set in an Audit Manager assessment.
 update_assessment_control_set_status(Client, AssessmentId, ControlSetId, Input) ->
     update_assessment_control_set_status(Client, AssessmentId, ControlSetId, Input, []).
 update_assessment_control_set_status(Client, AssessmentId, ControlSetId, Input0, Options0) ->
@@ -1307,7 +1407,7 @@ update_assessment_control_set_status(Client, AssessmentId, ControlSetId, Input0,
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates a custom framework in AWS Audit Manager.
+%% @doc Updates a custom framework in Audit Manager.
 update_assessment_framework(Client, FrameworkId, Input) ->
     update_assessment_framework(Client, FrameworkId, Input, []).
 update_assessment_framework(Client, FrameworkId, Input0, Options0) ->
@@ -1330,7 +1430,30 @@ update_assessment_framework(Client, FrameworkId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the status of an assessment in AWS Audit Manager.
+%% @doc Updates a share request for a custom framework in Audit Manager.
+update_assessment_framework_share(Client, RequestId, Input) ->
+    update_assessment_framework_share(Client, RequestId, Input, []).
+update_assessment_framework_share(Client, RequestId, Input0, Options0) ->
+    Method = put,
+    Path = ["/assessmentFrameworkShareRequests/", aws_util:encode_uri(RequestId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the status of an assessment in Audit Manager.
 update_assessment_status(Client, AssessmentId, Input) ->
     update_assessment_status(Client, AssessmentId, Input, []).
 update_assessment_status(Client, AssessmentId, Input0, Options0) ->
@@ -1353,7 +1476,7 @@ update_assessment_status(Client, AssessmentId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates a custom control in AWS Audit Manager.
+%% @doc Updates a custom control in Audit Manager.
 update_control(Client, ControlId, Input) ->
     update_control(Client, ControlId, Input, []).
 update_control(Client, ControlId, Input0, Options0) ->
@@ -1376,7 +1499,7 @@ update_control(Client, ControlId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates AWS Audit Manager settings for the current user account.
+%% @doc Updates Audit Manager settings for the current user account.
 update_settings(Client, Input) ->
     update_settings(Client, Input, []).
 update_settings(Client, Input0, Options0) ->
@@ -1399,7 +1522,7 @@ update_settings(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Validates the integrity of an assessment report in AWS Audit Manager.
+%% @doc Validates the integrity of an assessment report in Audit Manager.
 validate_assessment_report_integrity(Client, Input) ->
     validate_assessment_report_integrity(Client, Input, []).
 validate_assessment_report_integrity(Client, Input0, Options0) ->
@@ -1457,6 +1580,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -1,13 +1,13 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Backup
+%% @doc Backup
 %%
-%% AWS Backup is a unified backup service designed to protect AWS services
-%% and their associated data.
+%% Backup is a unified backup service designed to protect Amazon Web Services
+%% services and their associated data.
 %%
-%% AWS Backup simplifies the creation, migration, restoration, and deletion
-%% of backups, while also providing reporting and auditing.
+%% Backup simplifies the creation, migration, restoration, and deletion of
+%% backups, while also providing reporting and auditing.
 -module(aws_backup).
 
 -export([create_backup_plan/2,
@@ -16,6 +16,10 @@
          create_backup_selection/4,
          create_backup_vault/3,
          create_backup_vault/4,
+         create_framework/2,
+         create_framework/3,
+         create_report_plan/2,
+         create_report_plan/3,
          delete_backup_plan/3,
          delete_backup_plan/4,
          delete_backup_selection/4,
@@ -24,10 +28,16 @@
          delete_backup_vault/4,
          delete_backup_vault_access_policy/3,
          delete_backup_vault_access_policy/4,
+         delete_backup_vault_lock_configuration/3,
+         delete_backup_vault_lock_configuration/4,
          delete_backup_vault_notifications/3,
          delete_backup_vault_notifications/4,
+         delete_framework/3,
+         delete_framework/4,
          delete_recovery_point/4,
          delete_recovery_point/5,
+         delete_report_plan/3,
+         delete_report_plan/4,
          describe_backup_job/2,
          describe_backup_job/4,
          describe_backup_job/5,
@@ -37,6 +47,9 @@
          describe_copy_job/2,
          describe_copy_job/4,
          describe_copy_job/5,
+         describe_framework/2,
+         describe_framework/4,
+         describe_framework/5,
          describe_global_settings/1,
          describe_global_settings/3,
          describe_global_settings/4,
@@ -49,9 +62,17 @@
          describe_region_settings/1,
          describe_region_settings/3,
          describe_region_settings/4,
+         describe_report_job/2,
+         describe_report_job/4,
+         describe_report_job/5,
+         describe_report_plan/2,
+         describe_report_plan/4,
+         describe_report_plan/5,
          describe_restore_job/2,
          describe_restore_job/4,
          describe_restore_job/5,
+         disassociate_recovery_point/4,
+         disassociate_recovery_point/5,
          export_backup_plan_template/2,
          export_backup_plan_template/4,
          export_backup_plan_template/5,
@@ -99,6 +120,9 @@
          list_copy_jobs/1,
          list_copy_jobs/3,
          list_copy_jobs/4,
+         list_frameworks/1,
+         list_frameworks/3,
+         list_frameworks/4,
          list_protected_resources/1,
          list_protected_resources/3,
          list_protected_resources/4,
@@ -108,6 +132,12 @@
          list_recovery_points_by_resource/2,
          list_recovery_points_by_resource/4,
          list_recovery_points_by_resource/5,
+         list_report_jobs/1,
+         list_report_jobs/3,
+         list_report_jobs/4,
+         list_report_plans/1,
+         list_report_plans/3,
+         list_report_plans/4,
          list_restore_jobs/1,
          list_restore_jobs/3,
          list_restore_jobs/4,
@@ -116,12 +146,16 @@
          list_tags/5,
          put_backup_vault_access_policy/3,
          put_backup_vault_access_policy/4,
+         put_backup_vault_lock_configuration/3,
+         put_backup_vault_lock_configuration/4,
          put_backup_vault_notifications/3,
          put_backup_vault_notifications/4,
          start_backup_job/2,
          start_backup_job/3,
          start_copy_job/2,
          start_copy_job/3,
+         start_report_job/3,
+         start_report_job/4,
          start_restore_job/2,
          start_restore_job/3,
          stop_backup_job/3,
@@ -132,12 +166,16 @@
          untag_resource/4,
          update_backup_plan/3,
          update_backup_plan/4,
+         update_framework/3,
+         update_framework/4,
          update_global_settings/2,
          update_global_settings/3,
          update_recovery_point_lifecycle/4,
          update_recovery_point_lifecycle/5,
          update_region_settings/2,
-         update_region_settings/3]).
+         update_region_settings/3,
+         update_report_plan/3,
+         update_report_plan/4]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -147,11 +185,11 @@
 
 %% @doc Creates a backup plan using a backup plan name and backup rules.
 %%
-%% A backup plan is a document that contains information that AWS Backup uses
-%% to schedule tasks that create recovery points for resources.
+%% A backup plan is a document that contains information that Backup uses to
+%% schedule tasks that create recovery points for resources.
 %%
-%% If you call `CreateBackupPlan' with a plan that already exists, an
-%% `AlreadyExistsException' is returned.
+%% If you call `CreateBackupPlan' with a plan that already exists, you
+%% receive an `AlreadyExistsException' exception.
 create_backup_plan(Client, Input) ->
     create_backup_plan(Client, Input, []).
 create_backup_plan(Client, Input0, Options0) ->
@@ -233,13 +271,70 @@ create_backup_selection(Client, BackupPlanId, Input0, Options0) ->
 %% A `CreateBackupVault' request includes a name, optionally one or more
 %% resource tags, an encryption key, and a request ID.
 %%
-%% Sensitive data, such as passport numbers, should not be included the name
-%% of a backup vault.
+%% Do not include sensitive data, such as passport numbers, in the name of a
+%% backup vault.
 create_backup_vault(Client, BackupVaultName, Input) ->
     create_backup_vault(Client, BackupVaultName, Input, []).
 create_backup_vault(Client, BackupVaultName, Input0, Options0) ->
     Method = put,
     Path = ["/backup-vaults/", aws_util:encode_uri(BackupVaultName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a framework with one or more controls.
+%%
+%% A framework is a collection of controls that you can use to evaluate your
+%% backup practices. By using pre-built customizable controls to define your
+%% policies, you can evaluate whether your backup practices comply with your
+%% policies and which resources are not yet in compliance.
+create_framework(Client, Input) ->
+    create_framework(Client, Input, []).
+create_framework(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/audit/frameworks"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a report plan.
+%%
+%% A report plan is a document that contains information about the contents
+%% of the report and where Backup will deliver it.
+%%
+%% If you call `CreateReportPlan' with a plan that already exists, you
+%% receive an `AlreadyExistsException' exception.
+create_report_plan(Client, Input) ->
+    create_report_plan(Client, Input, []).
+create_report_plan(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/audit/report-plans"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -357,6 +452,35 @@ delete_backup_vault_access_policy(Client, BackupVaultName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes Backup Vault Lock from a backup vault specified by a backup
+%% vault name.
+%%
+%% If the Vault Lock configuration is immutable, then you cannot delete Vault
+%% Lock using API operations, and you will receive an
+%% `InvalidRequestException' if you attempt to do so. For more information,
+%% see Vault Lock in the Backup Developer Guide.
+delete_backup_vault_lock_configuration(Client, BackupVaultName, Input) ->
+    delete_backup_vault_lock_configuration(Client, BackupVaultName, Input, []).
+delete_backup_vault_lock_configuration(Client, BackupVaultName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/backup-vaults/", aws_util:encode_uri(BackupVaultName), "/vault-lock"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes event notifications for the specified backup vault.
 delete_backup_vault_notifications(Client, BackupVaultName, Input) ->
     delete_backup_vault_notifications(Client, BackupVaultName, Input, []).
@@ -380,12 +504,62 @@ delete_backup_vault_notifications(Client, BackupVaultName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes the framework specified by a framework name.
+delete_framework(Client, FrameworkName, Input) ->
+    delete_framework(Client, FrameworkName, Input, []).
+delete_framework(Client, FrameworkName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/audit/frameworks/", aws_util:encode_uri(FrameworkName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes the recovery point specified by a recovery point ID.
+%%
+%% If the recovery point ID belongs to a continuous backup, calling this
+%% endpoint deletes the existing continuous backup and stops future
+%% continuous backup.
 delete_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input) ->
     delete_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input, []).
 delete_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input0, Options0) ->
     Method = delete,
     Path = ["/backup-vaults/", aws_util:encode_uri(BackupVaultName), "/recovery-points/", aws_util:encode_uri(RecoveryPointArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the report plan specified by a report plan name.
+delete_report_plan(Client, ReportPlanName, Input) ->
+    delete_report_plan(Client, ReportPlanName, Input, []).
+delete_report_plan(Client, ReportPlanName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/audit/report-plans/", aws_util:encode_uri(ReportPlanName), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -472,8 +646,34 @@ describe_copy_job(Client, CopyJobId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Describes the global settings of the AWS account, including whether
-%% it is opted in to cross-account backup.
+%% @doc Returns the framework details for the specified `FrameworkName'.
+describe_framework(Client, FrameworkName)
+  when is_map(Client) ->
+    describe_framework(Client, FrameworkName, #{}, #{}).
+
+describe_framework(Client, FrameworkName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_framework(Client, FrameworkName, QueryMap, HeadersMap, []).
+
+describe_framework(Client, FrameworkName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/frameworks/", aws_util:encode_uri(FrameworkName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describes whether the Amazon Web Services account is opted in to
+%% cross-account backup.
+%%
+%% Returns an error if the account is not a member of an Organizations
+%% organization. Example: `describe-global-settings --region us-west-2'
 describe_global_settings(Client)
   when is_map(Client) ->
     describe_global_settings(Client, #{}, #{}).
@@ -497,8 +697,8 @@ describe_global_settings(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns information about a saved resource, including the last time
-%% it was backed up, its Amazon Resource Name (ARN), and the AWS service type
-%% of the saved resource.
+%% it was backed up, its Amazon Resource Name (ARN), and the Amazon Web
+%% Services service type of the saved resource.
 describe_protected_resource(Client, ResourceArn)
   when is_map(Client) ->
     describe_protected_resource(Client, ResourceArn, #{}, #{}).
@@ -547,11 +747,10 @@ describe_recovery_point(Client, BackupVaultName, RecoveryPointArn, QueryMap, Hea
 
 %% @doc Returns the current service opt-in settings for the Region.
 %%
-%% If service-opt-in is enabled for a service, AWS Backup tries to protect
-%% that service's resources in this Region, when the resource is included in
-%% an on-demand backup or scheduled backup plan. Otherwise, AWS Backup does
-%% not try to protect that service's resources in this Region, AWS Backup
-%% does not try to protect that service's resources in this Region.
+%% If service opt-in is enabled for a service, Backup tries to protect that
+%% service's resources in this Region, when the resource is included in an
+%% on-demand backup or scheduled backup plan. Otherwise, Backup does not try
+%% to protect that service's resources in this Region.
 describe_region_settings(Client)
   when is_map(Client) ->
     describe_region_settings(Client, #{}, #{}).
@@ -563,6 +762,54 @@ describe_region_settings(Client, QueryMap, HeadersMap)
 describe_region_settings(Client, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/account-settings"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the details associated with creating a report as specified by
+%% its `ReportJobId'.
+describe_report_job(Client, ReportJobId)
+  when is_map(Client) ->
+    describe_report_job(Client, ReportJobId, #{}, #{}).
+
+describe_report_job(Client, ReportJobId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_report_job(Client, ReportJobId, QueryMap, HeadersMap, []).
+
+describe_report_job(Client, ReportJobId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/report-jobs/", aws_util:encode_uri(ReportJobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of all report plans for an Amazon Web Services account
+%% and Amazon Web Services Region.
+describe_report_plan(Client, ReportPlanName)
+  when is_map(Client) ->
+    describe_report_plan(Client, ReportPlanName, #{}, #{}).
+
+describe_report_plan(Client, ReportPlanName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_report_plan(Client, ReportPlanName, QueryMap, HeadersMap, []).
+
+describe_report_plan(Client, ReportPlanName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/report-plans/", aws_util:encode_uri(ReportPlanName), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -598,6 +845,36 @@ describe_restore_job(Client, RestoreJobId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Deletes the specified continuous backup recovery point from Backup
+%% and releases control of that continuous backup to the source service, such
+%% as Amazon RDS.
+%%
+%% The source service will continue to create and retain continuous backups
+%% using the lifecycle that you specified in your original backup plan.
+%%
+%% Does not support snapshot backup recovery points.
+disassociate_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input) ->
+    disassociate_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input, []).
+disassociate_recovery_point(Client, BackupVaultName, RecoveryPointArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/backup-vaults/", aws_util:encode_uri(BackupVaultName), "/recovery-points/", aws_util:encode_uri(RecoveryPointArn), "/disassociate"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Returns the backup plan that is specified by the plan ID as a backup
 %% template.
 export_backup_plan_template(Client, BackupPlanId)
@@ -624,8 +901,8 @@ export_backup_plan_template(Client, BackupPlanId, QueryMap, HeadersMap, Options0
 
 %% @doc Returns `BackupPlan' details for the specified `BackupPlanId'.
 %%
-%% Returns the body of a backup plan in JSON format, in addition to plan
-%% metadata.
+%% The details are the body of a backup plan in JSON format, in addition to
+%% plan metadata.
 get_backup_plan(Client, BackupPlanId)
   when is_map(Client) ->
     get_backup_plan(Client, BackupPlanId, #{}, #{}).
@@ -793,7 +1070,7 @@ get_recovery_point_restore_metadata(Client, BackupVaultName, RecoveryPointArn, Q
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the AWS resource types supported by AWS Backup.
+%% @doc Returns the Amazon Web Services resource types supported by Backup.
 get_supported_resource_types(Client)
   when is_map(Client) ->
     get_supported_resource_types(Client, #{}, #{}).
@@ -816,7 +1093,10 @@ get_supported_resource_types(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of existing backup jobs for an authenticated account.
+%% @doc Returns a list of existing backup jobs for an authenticated account
+%% for the last 30 days.
+%%
+%% For a longer period of time, consider using these monitoring tools.
 list_backup_jobs(Client)
   when is_map(Client) ->
     list_backup_jobs(Client, #{}, #{}).
@@ -910,12 +1190,12 @@ list_backup_plan_versions(Client, BackupPlanId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of existing backup plans for an authenticated account.
+%% @doc Returns a list of all active backup plans for an authenticated
+%% account.
 %%
-%% The list is populated only if the advanced option is set for the backup
-%% plan. The list contains information such as Amazon Resource Names (ARNs),
-%% plan IDs, creation and deletion dates, version IDs, plan names, and
-%% creator request IDs.
+%% The list contains information such as Amazon Resource Names (ARNs), plan
+%% IDs, creation and deletion dates, version IDs, plan names, and creator
+%% request IDs.
 list_backup_plans(Client)
   when is_map(Client) ->
     list_backup_plans(Client, #{}, #{}).
@@ -1037,7 +1317,36 @@ list_copy_jobs(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns an array of resources successfully backed up by AWS Backup,
+%% @doc Returns a list of all frameworks for an Amazon Web Services account
+%% and Amazon Web Services Region.
+list_frameworks(Client)
+  when is_map(Client) ->
+    list_frameworks(Client, #{}, #{}).
+
+list_frameworks(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_frameworks(Client, QueryMap, HeadersMap, []).
+
+list_frameworks(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/frameworks"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns an array of resources successfully backed up by Backup,
 %% including the time the resource was saved, an Amazon Resource Name (ARN)
 %% of the resource, and a resource type.
 list_protected_resources(Client)
@@ -1101,8 +1410,11 @@ list_recovery_points_by_backup_vault(Client, BackupVaultName, QueryMap, HeadersM
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns detailed information about recovery points of the type
-%% specified by a resource Amazon Resource Name (ARN).
+%% @doc Returns detailed information about all the recovery points of the
+%% type specified by a resource Amazon Resource Name (ARN).
+%%
+%% For Amazon EFS and Amazon EC2, this action only lists recovery points
+%% created by Backup.
 list_recovery_points_by_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_recovery_points_by_resource(Client, ResourceArn, #{}, #{}).
@@ -1130,8 +1442,71 @@ list_recovery_points_by_resource(Client, ResourceArn, QueryMap, HeadersMap, Opti
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of jobs that AWS Backup initiated to restore a saved
-%% resource, including metadata about the recovery process.
+%% @doc Returns details about your report jobs.
+list_report_jobs(Client)
+  when is_map(Client) ->
+    list_report_jobs(Client, #{}, #{}).
+
+list_report_jobs(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_report_jobs(Client, QueryMap, HeadersMap, []).
+
+list_report_jobs(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/report-jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"CreationAfter">>, maps:get(<<"CreationAfter">>, QueryMap, undefined)},
+        {<<"CreationBefore">>, maps:get(<<"CreationBefore">>, QueryMap, undefined)},
+        {<<"ReportPlanName">>, maps:get(<<"ReportPlanName">>, QueryMap, undefined)},
+        {<<"Status">>, maps:get(<<"Status">>, QueryMap, undefined)},
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of your report plans.
+%%
+%% For detailed information about a single report plan, use
+%% `DescribeReportPlan'.
+list_report_plans(Client)
+  when is_map(Client) ->
+    list_report_plans(Client, #{}, #{}).
+
+list_report_plans(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_report_plans(Client, QueryMap, HeadersMap, []).
+
+list_report_plans(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/audit/report-plans"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of jobs that Backup initiated to restore a saved
+%% resource, including details about the recovery process.
 list_restore_jobs(Client)
   when is_map(Client) ->
     list_restore_jobs(Client, #{}, #{}).
@@ -1220,6 +1595,36 @@ put_backup_vault_access_policy(Client, BackupVaultName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Applies Backup Vault Lock to a backup vault, preventing attempts to
+%% delete any recovery point stored in or created in a backup vault.
+%%
+%% Vault Lock also prevents attempts to update the lifecycle policy that
+%% controls the retention period of any recovery point currently stored in a
+%% backup vault. If specified, Vault Lock enforces a minimum and maximum
+%% retention period for future backup and copy jobs that target a backup
+%% vault.
+put_backup_vault_lock_configuration(Client, BackupVaultName, Input) ->
+    put_backup_vault_lock_configuration(Client, BackupVaultName, Input, []).
+put_backup_vault_lock_configuration(Client, BackupVaultName, Input0, Options0) ->
+    Method = put,
+    Path = ["/backup-vaults/", aws_util:encode_uri(BackupVaultName), "/vault-lock"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Turns on notifications on a backup vault for the specified topic and
 %% events.
 put_backup_vault_notifications(Client, BackupVaultName, Input) ->
@@ -1268,11 +1673,36 @@ start_backup_job(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Starts a job to create a one-time copy of the specified resource.
+%%
+%% Does not support continuous backups.
 start_copy_job(Client, Input) ->
     start_copy_job(Client, Input, []).
 start_copy_job(Client, Input0, Options0) ->
     Method = put,
     Path = ["/copy-jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts an on-demand report job for the specified report plan.
+start_report_job(Client, ReportPlanName, Input) ->
+    start_report_job(Client, ReportPlanName, Input, []).
+start_report_job(Client, ReportPlanName, Input0, Options0) ->
+    Method = post,
+    Path = ["/audit/report-jobs/", aws_util:encode_uri(ReportPlanName), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1411,9 +1841,36 @@ update_backup_plan(Client, BackupPlanId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the current global settings for the AWS account.
+%% @doc Updates an existing framework identified by its `FrameworkName' with
+%% the input document in JSON format.
+update_framework(Client, FrameworkName, Input) ->
+    update_framework(Client, FrameworkName, Input, []).
+update_framework(Client, FrameworkName, Input0, Options0) ->
+    Method = put,
+    Path = ["/audit/frameworks/", aws_util:encode_uri(FrameworkName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates whether the Amazon Web Services account is opted in to
+%% cross-account backup.
 %%
-%% Use the `DescribeGlobalSettings' API to determine the current settings.
+%% Returns an error if the account is not an Organizations management
+%% account. Use the `DescribeGlobalSettings' API to determine the current
+%% settings.
 update_global_settings(Client, Input) ->
     update_global_settings(Client, Input, []).
 update_global_settings(Client, Input0, Options0) ->
@@ -1439,7 +1896,7 @@ update_global_settings(Client, Input0, Options0) ->
 %% @doc Sets the transition lifecycle of a recovery point.
 %%
 %% The lifecycle defines when a protected resource is transitioned to cold
-%% storage and when it expires. AWS Backup transitions and expires backups
+%% storage and when it expires. Backup transitions and expires backups
 %% automatically according to the lifecycle that you define.
 %%
 %% Backups transitioned to cold storage must be stored in cold storage for a
@@ -1449,6 +1906,8 @@ update_global_settings(Client, Input0, Options0) ->
 %% has been transitioned to cold.
 %%
 %% Only Amazon EFS file system backups can be transitioned to cold storage.
+%%
+%% Does not support continuous backups.
 update_recovery_point_lifecycle(Client, BackupVaultName, RecoveryPointArn, Input) ->
     update_recovery_point_lifecycle(Client, BackupVaultName, RecoveryPointArn, Input, []).
 update_recovery_point_lifecycle(Client, BackupVaultName, RecoveryPointArn, Input0, Options0) ->
@@ -1473,10 +1932,10 @@ update_recovery_point_lifecycle(Client, BackupVaultName, RecoveryPointArn, Input
 
 %% @doc Updates the current service opt-in settings for the Region.
 %%
-%% If service-opt-in is enabled for a service, AWS Backup tries to protect
-%% that service's resources in this Region, when the resource is included in
-%% an on-demand backup or scheduled backup plan. Otherwise, AWS Backup does
-%% not try to protect that service's resources in this Region. Use the
+%% If service-opt-in is enabled for a service, Backup tries to protect that
+%% service's resources in this Region, when the resource is included in an
+%% on-demand backup or scheduled backup plan. Otherwise, Backup does not try
+%% to protect that service's resources in this Region. Use the
 %% `DescribeRegionSettings' API to determine the resource types that are
 %% supported.
 update_region_settings(Client, Input) ->
@@ -1484,6 +1943,30 @@ update_region_settings(Client, Input) ->
 update_region_settings(Client, Input0, Options0) ->
     Method = put,
     Path = ["/account-settings"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an existing report plan identified by its `ReportPlanName'
+%% with the input document in JSON format.
+update_report_plan(Client, ReportPlanName, Input) ->
+    update_report_plan(Client, ReportPlanName, Input, []).
+update_report_plan(Client, ReportPlanName, Input0, Options0) ->
+    Method = put,
+    Path = ["/audit/report-plans/", aws_util:encode_uri(ReportPlanName), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1536,6 +2019,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -1,24 +1,26 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Using AWS Batch, you can run batch computing workloads on the AWS
-%% Cloud.
+%% @doc Batch
+%%
+%% Using Batch, you can run batch computing workloads on the Cloud.
 %%
 %% Batch computing is a common means for developers, scientists, and
-%% engineers to access large amounts of compute resources. AWS Batch utilizes
-%% the advantages of this computing workload to remove the undifferentiated
-%% heavy lifting of configuring and managing required infrastructure, while
-%% also adopting a familiar batch computing software approach. Given these
-%% advantages, AWS Batch can help you to efficiently provision resources in
-%% response to jobs submitted, thus effectively helping to eliminate capacity
-%% constraints, reduce compute costs, and deliver your results more quickly.
+%% engineers to access large amounts of compute resources. Batch uses the
+%% advantages of this computing workload to remove the undifferentiated heavy
+%% lifting of configuring and managing required infrastructure. At the same
+%% time, it also adopts a familiar batch computing software approach. Given
+%% these advantages, Batch can help you to efficiently provision resources in
+%% response to jobs submitted, thus effectively helping you to eliminate
+%% capacity constraints, reduce compute costs, and deliver your results more
+%% quickly.
 %%
-%% As a fully managed service, AWS Batch can run batch computing workloads of
-%% any scale. AWS Batch automatically provisions compute resources and
-%% optimizes workload distribution based on the quantity and scale of your
-%% specific workloads. With AWS Batch, there's no need to install or manage
-%% batch computing software. This means that you can focus your time and
-%% energy on analyzing results and solving your specific problems.
+%% As a fully managed service, Batch can run batch computing workloads of any
+%% scale. Batch automatically provisions compute resources and optimizes
+%% workload distribution based on the quantity and scale of your specific
+%% workloads. With Batch, there's no need to install or manage batch
+%% computing software. This means that you can focus your time and energy on
+%% analyzing results and solving your specific problems.
 -module(aws_batch).
 
 -export([cancel_job/2,
@@ -67,13 +69,12 @@
 %% API
 %%====================================================================
 
-%% @doc Cancels a job in an AWS Batch job queue.
+%% @doc Cancels a job in an Batch job queue.
 %%
 %% Jobs that are in the `SUBMITTED', `PENDING', or `RUNNABLE' state are
-%% canceled. Jobs that have progressed to `STARTING' or `RUNNING' are not
-%% canceled (but the API operation still succeeds, even if no job is
-%% canceled); these jobs must be terminated with the `TerminateJob'
-%% operation.
+%% canceled. Jobs that have progressed to `STARTING' or `RUNNING' aren't
+%% canceled, but the API operation still succeeds, even if no job is
+%% canceled. These jobs must be terminated with the `TerminateJob' operation.
 cancel_job(Client, Input) ->
     cancel_job(Client, Input, []).
 cancel_job(Client, Input0, Options0) ->
@@ -96,44 +97,44 @@ cancel_job(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an AWS Batch compute environment.
+%% @doc Creates an Batch compute environment.
 %%
 %% You can create `MANAGED' or `UNMANAGED' compute environments. `MANAGED'
-%% compute environments can use Amazon EC2 or AWS Fargate resources.
-%% `UNMANAGED' compute environments can only use EC2 resources.
+%% compute environments can use Amazon EC2 or Fargate resources. `UNMANAGED'
+%% compute environments can only use EC2 resources.
 %%
-%% In a managed compute environment, AWS Batch manages the capacity and
-%% instance types of the compute resources within the environment. This is
-%% based on the compute resource specification that you define or the launch
-%% template that you specify when you create the compute environment. You can
-%% choose either to use EC2 On-Demand Instances and EC2 Spot Instances, or to
+%% In a managed compute environment, Batch manages the capacity and instance
+%% types of the compute resources within the environment. This is based on
+%% the compute resource specification that you define or the launch template
+%% that you specify when you create the compute environment. Either, you can
+%% choose to use EC2 On-Demand Instances and EC2 Spot Instances. Or, you can
 %% use Fargate and Fargate Spot capacity in your managed compute environment.
 %% You can optionally set a maximum price so that Spot Instances only launch
 %% when the Spot Instance price is less than a specified percentage of the
 %% On-Demand price.
 %%
-%% Multi-node parallel jobs are not supported on Spot Instances.
+%% Multi-node parallel jobs aren't supported on Spot Instances.
 %%
 %% In an unmanaged compute environment, you can manage your own EC2 compute
 %% resources and have a lot of flexibility with how you configure your
-%% compute resources. For example, you can use custom AMI. However, you need
-%% to verify that your AMI meets the Amazon ECS container instance AMI
+%% compute resources. For example, you can use custom AMIs. However, you must
+%% verify that each of your AMIs meet the Amazon ECS container instance AMI
 %% specification. For more information, see container instance AMIs in the
-%% Amazon Elastic Container Service Developer Guide. After you have created
-%% your unmanaged compute environment, you can use the
+%% Amazon Elastic Container Service Developer Guide. After you created your
+%% unmanaged compute environment, you can use the
 %% `DescribeComputeEnvironments' operation to find the Amazon ECS cluster
-%% that's associated with it. Then, manually launch your container instances
-%% into that Amazon ECS cluster. For more information, see Launching an
-%% Amazon ECS container instance in the Amazon Elastic Container Service
-%% Developer Guide.
+%% that's associated with it. Then, launch your container instances into that
+%% Amazon ECS cluster. For more information, see Launching an Amazon ECS
+%% container instance in the Amazon Elastic Container Service Developer
+%% Guide.
 %%
-%% AWS Batch doesn't upgrade the AMIs in a compute environment after it's
-%% created. For example, it doesn't update the AMIs when a newer version of
-%% the Amazon ECS-optimized AMI is available. Therefore, you're responsible
-%% for the management of the guest operating system (including updates and
-%% security patches) and any additional application software or utilities
-%% that you install on the compute resources. To use a new AMI for your AWS
-%% Batch jobs, complete these steps:
+%% Batch doesn't upgrade the AMIs in a compute environment after the
+%% environment is created. For example, it doesn't update the AMIs when a
+%% newer version of the Amazon ECS optimized AMI is available. Therefore,
+%% you're responsible for managing the guest operating system (including its
+%% updates and security patches) and any additional application software or
+%% utilities that you install on the compute resources. To use a new AMI for
+%% your Batch jobs, complete these steps:
 %%
 %% Create a new compute environment with the new AMI.
 %%
@@ -164,17 +165,17 @@ create_compute_environment(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an AWS Batch job queue.
+%% @doc Creates an Batch job queue.
 %%
 %% When you create a job queue, you associate one or more compute
 %% environments to the queue and assign an order of preference for the
 %% compute environments.
 %%
-%% You also set a priority to the job queue that determines the order in
-%% which the AWS Batch scheduler places jobs onto its associated compute
-%% environments. For example, if a compute environment is associated with
-%% more than one job queue, the job queue with a higher priority is given
-%% preference for scheduling jobs to that compute environment.
+%% You also set a priority to the job queue that determines the order that
+%% the Batch scheduler places jobs onto its associated compute environments.
+%% For example, if a compute environment is associated with more than one job
+%% queue, the job queue with a higher priority is given preference for
+%% scheduling jobs to that compute environment.
 create_job_queue(Client, Input) ->
     create_job_queue(Client, Input, []).
 create_job_queue(Client, Input0, Options0) ->
@@ -197,15 +198,15 @@ create_job_queue(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an AWS Batch compute environment.
+%% @doc Deletes an Batch compute environment.
 %%
 %% Before you can delete a compute environment, you must set its state to
 %% `DISABLED' with the `UpdateComputeEnvironment' API operation and
 %% disassociate it from any job queues with the `UpdateJobQueue' API
-%% operation. Compute environments that use AWS Fargate resources must
-%% terminate all active jobs on that compute environment before deleting the
-%% compute environment. If this isn't done, the compute environment will end
-%% up in an invalid state.
+%% operation. Compute environments that use Fargate resources must terminate
+%% all active jobs on that compute environment before deleting the compute
+%% environment. If this isn't done, the compute environment enters an invalid
+%% state.
 delete_compute_environment(Client, Input) ->
     delete_compute_environment(Client, Input, []).
 delete_compute_environment(Client, Input0, Options0) ->
@@ -259,7 +260,7 @@ delete_job_queue(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deregisters an AWS Batch job definition.
+%% @doc Deregisters an Batch job definition.
 %%
 %% Job definitions are permanently deleted after 180 days.
 deregister_job_definition(Client, Input) ->
@@ -360,7 +361,7 @@ describe_job_queues(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Describes a list of AWS Batch jobs.
+%% @doc Describes a list of Batch jobs.
 describe_jobs(Client, Input) ->
     describe_jobs(Client, Input, []).
 describe_jobs(Client, Input0, Options0) ->
@@ -383,16 +384,16 @@ describe_jobs(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of AWS Batch jobs.
+%% @doc Returns a list of Batch jobs.
 %%
 %% You must specify only one of the following items:
 %%
 %% <ul> <li> A job queue ID to return a list of jobs in that job queue
 %%
-%% </li> <li> A multi-node parallel job ID to return a list of that job's
-%% nodes
+%% </li> <li> A multi-node parallel job ID to return a list of nodes for that
+%% job
 %%
-%% </li> <li> An array job ID to return a list of that job's children
+%% </li> <li> An array job ID to return a list of the children for that job
 %%
 %% </li> </ul> You can filter the results by job status with the `jobStatus'
 %% parameter. If you don't specify a status, only `RUNNING' jobs are
@@ -419,9 +420,9 @@ list_jobs(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Lists the tags for an AWS Batch resource.
+%% @doc Lists the tags for an Batch resource.
 %%
-%% AWS Batch resources that support tags are compute environments, jobs, job
+%% Batch resources that support tags are compute environments, jobs, job
 %% definitions, and job queues. ARNs for child jobs of array and multi-node
 %% parallel (MNP) jobs are not supported.
 list_tags_for_resource(Client, ResourceArn)
@@ -446,7 +447,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Registers an AWS Batch job definition.
+%% @doc Registers an Batch job definition.
 register_job_definition(Client, Input) ->
     register_job_definition(Client, Input, []).
 register_job_definition(Client, Input0, Options0) ->
@@ -469,14 +470,19 @@ register_job_definition(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Submits an AWS Batch job from a job definition.
+%% @doc Submits an Batch job from a job definition.
 %%
-%% Parameters specified during `SubmitJob' override parameters defined in the
-%% job definition.
+%% Parameters that are specified during `SubmitJob' override parameters
+%% defined in the job definition. vCPU and memory requirements that are
+%% specified in the `ResourceRequirements' objects in the job definition are
+%% the exception. They can't be overridden this way using the `memory' and
+%% `vcpus' parameters. Rather, you must specify updates to job definition
+%% parameters in a `ResourceRequirements' object that's included in the
+%% `containerOverrides' parameter.
 %%
-%% Jobs run on Fargate resources don't run for more than 14 days. After 14
-%% days, the Fargate resources might no longer be available and the job is
-%% terminated.
+%% Jobs that run on Fargate resources can't be guaranteed to run for more
+%% than 14 days. This is because, after 14 days, Fargate resources might
+%% become unavailable and job might be terminated.
 submit_job(Client, Input) ->
     submit_job(Client, Input, []).
 submit_job(Client, Input0, Options0) ->
@@ -503,10 +509,11 @@ submit_job(Client, Input0, Options0) ->
 %% `resourceArn'.
 %%
 %% If existing tags on a resource aren't specified in the request parameters,
-%% they aren't changed. When a resource is deleted, the tags associated with
-%% that resource are deleted as well. AWS Batch resources that support tags
-%% are compute environments, jobs, job definitions, and job queues. ARNs for
-%% child jobs of array and multi-node parallel (MNP) jobs are not supported.
+%% they aren't changed. When a resource is deleted, the tags that are
+%% associated with that resource are deleted as well. Batch resources that
+%% support tags are compute environments, jobs, job definitions, and job
+%% queues. ARNs for child jobs of array and multi-node parallel (MNP) jobs
+%% are not supported.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -556,7 +563,7 @@ terminate_job(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes specified tags from an AWS Batch resource.
+%% @doc Deletes specified tags from an Batch resource.
 untag_resource(Client, ResourceArn, Input) ->
     untag_resource(Client, ResourceArn, Input, []).
 untag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -580,7 +587,7 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates an AWS Batch compute environment.
+%% @doc Updates an Batch compute environment.
 update_compute_environment(Client, Input) ->
     update_compute_environment(Client, Input, []).
 update_compute_environment(Client, Input0, Options0) ->
@@ -661,6 +668,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -276,6 +276,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -50,6 +50,8 @@
          associate_signin_delegate_groups_with_account/4,
          batch_create_attendee/3,
          batch_create_attendee/4,
+         batch_create_channel_membership/3,
+         batch_create_channel_membership/4,
          batch_create_room_membership/4,
          batch_create_room_membership/5,
          batch_delete_phone_number/2,
@@ -82,6 +84,8 @@
          create_channel_membership/4,
          create_channel_moderator/3,
          create_channel_moderator/4,
+         create_media_capture_pipeline/2,
+         create_media_capture_pipeline/3,
          create_meeting/2,
          create_meeting/3,
          create_meeting_dial_out/3,
@@ -132,6 +136,8 @@
          delete_channel_moderator/5,
          delete_events_configuration/4,
          delete_events_configuration/5,
+         delete_media_capture_pipeline/3,
+         delete_media_capture_pipeline/4,
          delete_meeting/3,
          delete_meeting/4,
          delete_phone_number/3,
@@ -224,6 +230,9 @@
          get_global_settings/1,
          get_global_settings/3,
          get_global_settings/4,
+         get_media_capture_pipeline/2,
+         get_media_capture_pipeline/4,
+         get_media_capture_pipeline/5,
          get_meeting/2,
          get_meeting/4,
          get_meeting/5,
@@ -334,6 +343,9 @@
          list_channels_moderated_by_app_instance_user/1,
          list_channels_moderated_by_app_instance_user/3,
          list_channels_moderated_by_app_instance_user/4,
+         list_media_capture_pipelines/1,
+         list_media_capture_pipelines/3,
+         list_media_capture_pipelines/4,
          list_meeting_tags/2,
          list_meeting_tags/4,
          list_meeting_tags/5,
@@ -361,6 +373,9 @@
          list_sip_rules/1,
          list_sip_rules/3,
          list_sip_rules/4,
+         list_supported_phone_number_countries/2,
+         list_supported_phone_number_countries/4,
+         list_supported_phone_number_countries/5,
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
@@ -419,6 +434,10 @@
          search_available_phone_numbers/4,
          send_channel_message/3,
          send_channel_message/4,
+         start_meeting_transcription/3,
+         start_meeting_transcription/4,
+         stop_meeting_transcription/3,
+         stop_meeting_transcription/4,
          tag_attendee/4,
          tag_attendee/5,
          tag_meeting/3,
@@ -461,6 +480,8 @@
          update_room_membership/6,
          update_sip_media_application/3,
          update_sip_media_application/4,
+         update_sip_media_application_call/4,
+         update_sip_media_application_call/5,
          update_sip_rule/3,
          update_sip_rule/4,
          update_user/4,
@@ -600,6 +621,31 @@ batch_create_attendee(Client, MeetingId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Adds a specified number of users to a channel.
+batch_create_channel_membership(Client, ChannelArn, Input) ->
+    batch_create_channel_membership(Client, ChannelArn, Input, []).
+batch_create_channel_membership(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships?operation=batch-create"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Adds up to 50 members to a chat room in an Amazon Chime Enterprise
 %% account.
 %%
@@ -700,7 +746,8 @@ batch_suspend_user(Client, AccountId, Input0, Options0) ->
 %%
 %% Only users on `EnterpriseLWA' accounts can be unsuspended using this
 %% action. For more information about different account types, see Managing
-%% Your Amazon Chime Accounts in the Amazon Chime Administration Guide.
+%% Your Amazon Chime Accounts in the account types, in the Amazon Chime
+%% Administration Guide.
 %%
 %% Previously suspended users who are unsuspended using this action are
 %% returned to `Registered' status. Users who are not previously suspended
@@ -730,12 +777,12 @@ batch_unsuspend_user(Client, AccountId, Input0, Options0) ->
 %% @doc Updates phone number product types or calling names.
 %%
 %% You can update one attribute at a time for each
-%% `UpdatePhoneNumberRequestItem' . For example, you can update either the
-%% product type or the calling name.
+%% `UpdatePhoneNumberRequestItem'. For example, you can update the product
+%% type or the calling name.
 %%
-%% For product types, choose from Amazon Chime Business Calling and Amazon
-%% Chime Voice Connector. For toll-free numbers, you must use the Amazon
-%% Chime Voice Connector product type.
+%% For toll-free numbers, you cannot use the Amazon Chime Business Calling
+%% product type. For numbers outside the U.S., you must use the Amazon Chime
+%% SIP Media Application Dial-In product type.
 %%
 %% Updates to outbound calling names can take up to 72 hours to complete.
 %% Pending updates to outbound calling names must be complete before you can
@@ -1109,6 +1156,29 @@ create_channel_moderator(Client, ChannelArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates a media capture pipeline.
+create_media_capture_pipeline(Client, Input) ->
+    create_media_capture_pipeline(Client, Input, []).
+create_media_capture_pipeline(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/media-capture-pipelines"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a new Amazon Chime SDK meeting in the specified media Region
 %% with no initial attendees.
 %%
@@ -1200,9 +1270,9 @@ create_meeting_with_attendees(Client, Input0, Options0) ->
 
 %% @doc Creates an order for phone numbers to be provisioned.
 %%
-%% Choose from Amazon Chime Business Calling and Amazon Chime Voice Connector
-%% product types. For toll-free numbers, you must use the Amazon Chime Voice
-%% Connector product type.
+%% For toll-free numbers, you cannot use the Amazon Chime Business Calling
+%% product type. For numbers outside the U.S., you must use the Amazon Chime
+%% SIP Media Application Dial-In product type.
 create_phone_number_order(Client, Input) ->
     create_phone_number_order(Client, Input, []).
 create_phone_number_order(Client, Input0, Options0) ->
@@ -1589,11 +1659,11 @@ delete_app_instance_user(Client, AppInstanceUserArn, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes an attendee from the specified Amazon Chime SDK meeting and
-%% deletes their `JoinToken' .
+%% deletes their `JoinToken'.
 %%
 %% Attendees are automatically deleted when a Amazon Chime SDK meeting is
 %% deleted. For more information about the Amazon Chime SDK, see Using the
-%% Amazon Chime SDK in the Amazon Chime Developer Guide .
+%% Amazon Chime SDK in the Amazon Chime Developer Guide.
 delete_attendee(Client, AttendeeId, MeetingId, Input) ->
     delete_attendee(Client, AttendeeId, MeetingId, Input, []).
 delete_attendee(Client, AttendeeId, MeetingId, Input0, Options0) ->
@@ -1792,12 +1862,35 @@ delete_events_configuration(Client, AccountId, BotId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes the media capture pipeline.
+delete_media_capture_pipeline(Client, MediaPipelineId, Input) ->
+    delete_media_capture_pipeline(Client, MediaPipelineId, Input, []).
+delete_media_capture_pipeline(Client, MediaPipelineId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/media-capture-pipelines/", aws_util:encode_uri(MediaPipelineId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes the specified Amazon Chime SDK meeting.
 %%
-%% When a meeting is deleted, its attendees are also deleted, clients
-%% connected to the meeting are disconnected, and clients can no longer join
-%% the meeting. For more information about the Amazon Chime SDK, see Using
-%% the Amazon Chime SDK in the Amazon Chime Developer Guide.
+%% The operation deletes all attendees, disconnects all clients, and prevents
+%% new clients from joining the meeting. For more information about the
+%% Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon Chime
+%% Developer Guide.
 delete_meeting(Client, MeetingId, Input) ->
     delete_meeting(Client, MeetingId, Input, []).
 delete_meeting(Client, MeetingId, Input0, Options0) ->
@@ -1820,7 +1913,7 @@ delete_meeting(Client, MeetingId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Moves the specified phone number into the Deletionqueue.
+%% @doc Moves the specified phone number into the Deletion queue.
 %%
 %% A phone number must be disassociated from any users or Amazon Chime Voice
 %% Connectors before it can be deleted.
@@ -2216,7 +2309,7 @@ describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, QueryMa
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the full details of an `AppInstanceUser' .
+%% @doc Returns the full details of an `AppInstanceUser'.
 describe_app_instance_user(Client, AppInstanceUserArn)
   when is_map(Client) ->
     describe_app_instance_user(Client, AppInstanceUserArn, #{}, #{}).
@@ -2760,6 +2853,29 @@ get_global_settings(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets an existing media capture pipeline.
+get_media_capture_pipeline(Client, MediaPipelineId)
+  when is_map(Client) ->
+    get_media_capture_pipeline(Client, MediaPipelineId, #{}, #{}).
+
+get_media_capture_pipeline(Client, MediaPipelineId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_media_capture_pipeline(Client, MediaPipelineId, QueryMap, HeadersMap, []).
+
+get_media_capture_pipeline(Client, MediaPipelineId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/media-capture-pipelines/", aws_util:encode_uri(MediaPipelineId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets the Amazon Chime SDK meeting details for the specified meeting
 %% ID.
 %%
@@ -2911,7 +3027,7 @@ get_proxy_session(Client, ProxySessionId, VoiceConnectorId, QueryMap, HeadersMap
 %% account.
 %%
 %% For more information about retention settings, see Managing Chat Retention
-%% Policies in the Amazon Chime Administration Guide .
+%% Policies in the Amazon Chime Administration Guide.
 get_retention_settings(Client, AccountId)
   when is_map(Client) ->
     get_retention_settings(Client, AccountId, #{}, #{}).
@@ -3130,7 +3246,7 @@ get_voice_connector_emergency_calling_configuration(Client, VoiceConnectorId, Qu
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves details for the specified Amazon Chime Voice Connector
-%% group, such as timestamps,name, and associated `VoiceConnectorItems' .
+%% group, such as timestamps,name, and associated `VoiceConnectorItems'.
 get_voice_connector_group(Client, VoiceConnectorGroupId)
   when is_map(Client) ->
     get_voice_connector_group(Client, VoiceConnectorGroupId, #{}, #{}).
@@ -3334,7 +3450,7 @@ invite_users(Client, AccountId, Input0, Options0) ->
 %% account.
 %%
 %% You can filter accounts by account name prefix. To find out which Amazon
-%% Chime account a user belongs to, toucan filter by the user's email
+%% Chime account a user belongs to, you can filter by the user's email
 %% address, which returns one account result.
 list_accounts(Client)
   when is_map(Client) ->
@@ -3477,7 +3593,7 @@ list_attendee_tags(Client, AttendeeId, MeetingId, QueryMap, HeadersMap, Options0
 %% @doc Lists the attendees for the specified Amazon Chime SDK meeting.
 %%
 %% For more information about the Amazon Chime SDK, see Using the Amazon
-%% Chime SDK in the Amazon Chime Developer Guide .
+%% Chime SDK in the Amazon Chime Developer Guide.
 list_attendees(Client, MeetingId)
   when is_map(Client) ->
     list_attendees(Client, MeetingId, #{}, #{}).
@@ -3650,7 +3766,7 @@ list_channel_memberships_for_app_instance_user(Client, QueryMap, HeadersMap, Opt
 %% @doc List all the messages in a channel.
 %%
 %% Returns a paginated list of `ChannelMessages'. By default, sorted by
-%% creation timestamp in descending order .
+%% creation timestamp in descending order.
 %%
 %% Redacted messages appear in the results as empty, since they are only
 %% redacted, not deleted. Deleted messages do not appear in the results. This
@@ -3737,7 +3853,7 @@ list_channel_moderators(Client, ChannelArn, QueryMap, HeadersMap, Options0)
 %% == Functionality & restrictions ==
 %%
 %% <ul> <li> Use privacy = `PUBLIC' to retrieve all public channels in the
-%% account
+%% account.
 %%
 %% </li> <li> Only an `AppInstanceAdmin' can set privacy = `PRIVATE' to list
 %% the private channels in an account.
@@ -3815,6 +3931,34 @@ list_channels_moderated_by_app_instance_user(Client, QueryMap, HeadersMap, Optio
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns a list of media capture pipelines.
+list_media_capture_pipelines(Client)
+  when is_map(Client) ->
+    list_media_capture_pipelines(Client, #{}, #{}).
+
+list_media_capture_pipelines(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_media_capture_pipelines(Client, QueryMap, HeadersMap, []).
+
+list_media_capture_pipelines(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/media-capture-pipelines"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Lists the tags applied to an Amazon Chime SDK meeting resource.
 list_meeting_tags(Client, MeetingId)
   when is_map(Client) ->
@@ -3841,7 +3985,7 @@ list_meeting_tags(Client, MeetingId, QueryMap, HeadersMap, Options0)
 %% @doc Lists up to 100 active Amazon Chime SDK meetings.
 %%
 %% For more information about the Amazon Chime SDK, see Using the Amazon
-%% Chime SDK in the Amazon Chime Developer Guide .
+%% Chime SDK in the Amazon Chime Developer Guide.
 list_meetings(Client)
   when is_map(Client) ->
     list_meetings(Client, #{}, #{}).
@@ -4078,6 +4222,33 @@ list_sip_rules(Client, QueryMap, HeadersMap, Options0)
         {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
         {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)},
         {<<"sip-media-application">>, maps:get(<<"sip-media-application">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists supported phone number countries.
+list_supported_phone_number_countries(Client, ProductType)
+  when is_map(Client) ->
+    list_supported_phone_number_countries(Client, ProductType, #{}, #{}).
+
+list_supported_phone_number_countries(Client, ProductType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_supported_phone_number_countries(Client, ProductType, QueryMap, HeadersMap, []).
+
+list_supported_phone_number_countries(Client, ProductType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/phone-number-countries"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"product-type">>, ProductType}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -4328,12 +4499,12 @@ put_events_configuration(Client, AccountId, BotId, Input0, Options0) ->
 %%
 %% We recommend using AWS CloudTrail to monitor usage of this API for your
 %% account. For more information, see Logging Amazon Chime API Calls with AWS
-%% CloudTrail in the Amazon Chime Administration Guide .
+%% CloudTrail in the Amazon Chime Administration Guide.
 %%
 %% To turn off existing retention settings, remove the number of days from
 %% the corresponding RetentionDays field in the RetentionSettings object. For
 %% more information about retention settings, see Managing Chat Retention
-%% Policies in the Amazon Chime Administration Guide .
+%% Policies in the Amazon Chime Administration Guide.
 put_retention_settings(Client, AccountId, Input) ->
     put_retention_settings(Client, AccountId, Input, []).
 put_retention_settings(Client, AccountId, Input0, Options0) ->
@@ -4718,7 +4889,12 @@ restore_phone_number(Client, PhoneNumberId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Searches phone numbers that can be ordered.
+%% @doc Searches for phone numbers that can be ordered.
+%%
+%% For US numbers, provide at least one of the following search filters:
+%% `AreaCode', `City', `State', or `TollFreePrefix'. If you provide `City',
+%% you must also provide `State'. Numbers outside the US only support the
+%% `PhoneNumberType' filter, which you must use.
 search_available_phone_numbers(Client)
   when is_map(Client) ->
     search_available_phone_numbers(Client, #{}, #{}).
@@ -4744,6 +4920,7 @@ search_available_phone_numbers(Client, QueryMap, HeadersMap, Options0)
         {<<"country">>, maps:get(<<"country">>, QueryMap, undefined)},
         {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
         {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)},
+        {<<"phone-number-type">>, maps:get(<<"phone-number-type">>, QueryMap, undefined)},
         {<<"state">>, maps:get(<<"state">>, QueryMap, undefined)},
         {<<"toll-free-prefix">>, maps:get(<<"toll-free-prefix">>, QueryMap, undefined)}
       ],
@@ -4774,6 +4951,52 @@ send_channel_message(Client, ChannelArn, Input0, Options0) ->
                        {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
                      ],
     {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts transcription for the specified `meetingId'.
+start_meeting_transcription(Client, MeetingId, Input) ->
+    start_meeting_transcription(Client, MeetingId, Input, []).
+start_meeting_transcription(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/transcription?operation=start"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Stops transcription for the specified `meetingId'.
+stop_meeting_transcription(Client, MeetingId, Input) ->
+    stop_meeting_transcription(Client, MeetingId, Input, []).
+stop_meeting_transcription(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/transcription?operation=stop"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
 
     CustomHeaders = [],
     Input2 = Input1,
@@ -4928,7 +5151,8 @@ untag_resource(Client, Input0, Options0) ->
 
 %% @doc Updates account details for the specified Amazon Chime account.
 %%
-%% Currently, only account name updates are supported for this action.
+%% Currently, only account name and default license updates are supported for
+%% this action.
 update_account(Client, AccountId, Input) ->
     update_account(Client, AccountId, Input, []).
 update_account(Client, AccountId, Input0, Options0) ->
@@ -5169,12 +5393,13 @@ update_global_settings(Client, Input0, Options0) ->
 %% You can update one phone number detail at a time. For example, you can
 %% update either the product type or the calling name in one action.
 %%
-%% For toll-free numbers, you must use the Amazon Chime Voice Connector
-%% product type.
+%% For toll-free numbers, you cannot use the Amazon Chime Business Calling
+%% product type. For numbers outside the U.S., you must use the Amazon Chime
+%% SIP Media Application Dial-In product type.
 %%
-%% Updates to outbound calling names can take up to 72 hours to complete.
-%% Pending updates to outbound calling names must be complete before you can
-%% request another update.
+%% Updates to outbound calling names can take 72 hours to complete. Pending
+%% updates to outbound calling names must be complete before you can request
+%% another update.
 update_phone_number(Client, PhoneNumberId, Input) ->
     update_phone_number(Client, PhoneNumberId, Input, []).
 update_phone_number(Client, PhoneNumberId, Input0, Options0) ->
@@ -5307,6 +5532,31 @@ update_sip_media_application(Client, SipMediaApplicationId, Input0, Options0) ->
     Method = put,
     Path = ["/sip-media-applications/", aws_util:encode_uri(SipMediaApplicationId), ""],
     SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows you to trigger a Lambda function at any time while a call is
+%% active, and replace the current actions with new actions returned by the
+%% invocation.
+update_sip_media_application_call(Client, SipMediaApplicationId, TransactionId, Input) ->
+    update_sip_media_application_call(Client, SipMediaApplicationId, TransactionId, Input, []).
+update_sip_media_application_call(Client, SipMediaApplicationId, TransactionId, Input0, Options0) ->
+    Method = post,
+    Path = ["/sip-media-applications/", aws_util:encode_uri(SipMediaApplicationId), "/calls/", aws_util:encode_uri(TransactionId), ""],
+    SuccessStatusCode = 202,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -5478,6 +5728,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_chime_sdk_identity.erl
+++ b/src/aws_chime_sdk_identity.erl
@@ -1,0 +1,772 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The Amazon Chime SDK Identity APIs in this section allow software
+%% developers to create and manage unique instances of their messaging
+%% applications.
+%%
+%% These APIs provide the overarching framework for creating and sending
+%% messages. For more information about the identity APIs, refer to Amazon
+%% Chime SDK identity.
+-module(aws_chime_sdk_identity).
+
+-export([create_app_instance/2,
+         create_app_instance/3,
+         create_app_instance_admin/3,
+         create_app_instance_admin/4,
+         create_app_instance_user/2,
+         create_app_instance_user/3,
+         delete_app_instance/3,
+         delete_app_instance/4,
+         delete_app_instance_admin/4,
+         delete_app_instance_admin/5,
+         delete_app_instance_user/3,
+         delete_app_instance_user/4,
+         deregister_app_instance_user_endpoint/4,
+         deregister_app_instance_user_endpoint/5,
+         describe_app_instance/2,
+         describe_app_instance/4,
+         describe_app_instance/5,
+         describe_app_instance_admin/3,
+         describe_app_instance_admin/5,
+         describe_app_instance_admin/6,
+         describe_app_instance_user/2,
+         describe_app_instance_user/4,
+         describe_app_instance_user/5,
+         describe_app_instance_user_endpoint/3,
+         describe_app_instance_user_endpoint/5,
+         describe_app_instance_user_endpoint/6,
+         get_app_instance_retention_settings/2,
+         get_app_instance_retention_settings/4,
+         get_app_instance_retention_settings/5,
+         list_app_instance_admins/2,
+         list_app_instance_admins/4,
+         list_app_instance_admins/5,
+         list_app_instance_user_endpoints/2,
+         list_app_instance_user_endpoints/4,
+         list_app_instance_user_endpoints/5,
+         list_app_instance_users/2,
+         list_app_instance_users/4,
+         list_app_instance_users/5,
+         list_app_instances/1,
+         list_app_instances/3,
+         list_app_instances/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         put_app_instance_retention_settings/3,
+         put_app_instance_retention_settings/4,
+         register_app_instance_user_endpoint/3,
+         register_app_instance_user_endpoint/4,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_app_instance/3,
+         update_app_instance/4,
+         update_app_instance_user/3,
+         update_app_instance_user/4,
+         update_app_instance_user_endpoint/4,
+         update_app_instance_user_endpoint/5]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates an Amazon Chime SDK messaging `AppInstance' under an AWS
+%% account.
+%%
+%% Only SDK messaging customers use this API. `CreateAppInstance' supports
+%% idempotency behavior as described in the AWS API Standard.
+%%
+%% identity
+create_app_instance(Client, Input) ->
+    create_app_instance(Client, Input, []).
+create_app_instance(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/app-instances"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Promotes an `AppInstanceUser' to an `AppInstanceAdmin'.
+%%
+%% The promoted user can perform the following actions.
+%%
+%% <ul> <li> `ChannelModerator' actions across all channels in the
+%% `AppInstance'.
+%%
+%% </li> <li> `DeleteChannelMessage' actions.
+%%
+%% </li> </ul> Only an `AppInstanceUser' can be promoted to an
+%% `AppInstanceAdmin' role.
+create_app_instance_admin(Client, AppInstanceArn, Input) ->
+    create_app_instance_admin(Client, AppInstanceArn, Input, []).
+create_app_instance_admin(Client, AppInstanceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/admins"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a user under an Amazon Chime `AppInstance'.
+%%
+%% The request consists of a unique `appInstanceUserId' and `Name' for that
+%% user.
+create_app_instance_user(Client, Input) ->
+    create_app_instance_user(Client, Input, []).
+create_app_instance_user(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/app-instance-users"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an `AppInstance' and all associated data asynchronously.
+delete_app_instance(Client, AppInstanceArn, Input) ->
+    delete_app_instance(Client, AppInstanceArn, Input, []).
+delete_app_instance(Client, AppInstanceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Demotes an `AppInstanceAdmin' to an `AppInstanceUser'.
+%%
+%% This action does not delete the user.
+delete_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, Input) ->
+    delete_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, Input, []).
+delete_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/admins/", aws_util:encode_uri(AppInstanceAdminArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an `AppInstanceUser'.
+delete_app_instance_user(Client, AppInstanceUserArn, Input) ->
+    delete_app_instance_user(Client, AppInstanceUserArn, Input, []).
+delete_app_instance_user(Client, AppInstanceUserArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deregisters an `AppInstanceUserEndpoint'.
+deregister_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input) ->
+    deregister_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input, []).
+deregister_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), "/endpoints/", aws_util:encode_uri(EndpointId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of an `AppInstance'.
+describe_app_instance(Client, AppInstanceArn)
+  when is_map(Client) ->
+    describe_app_instance(Client, AppInstanceArn, #{}, #{}).
+
+describe_app_instance(Client, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_app_instance(Client, AppInstanceArn, QueryMap, HeadersMap, []).
+
+describe_app_instance(Client, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of an `AppInstanceAdmin'.
+describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn)
+  when is_map(Client) ->
+    describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, #{}, #{}).
+
+describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, QueryMap, HeadersMap, []).
+
+describe_app_instance_admin(Client, AppInstanceAdminArn, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/admins/", aws_util:encode_uri(AppInstanceAdminArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of an `AppInstanceUser'.
+describe_app_instance_user(Client, AppInstanceUserArn)
+  when is_map(Client) ->
+    describe_app_instance_user(Client, AppInstanceUserArn, #{}, #{}).
+
+describe_app_instance_user(Client, AppInstanceUserArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_app_instance_user(Client, AppInstanceUserArn, QueryMap, HeadersMap, []).
+
+describe_app_instance_user(Client, AppInstanceUserArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of an `AppInstanceUserEndpoint'.
+describe_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId)
+  when is_map(Client) ->
+    describe_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, #{}, #{}).
+
+describe_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, QueryMap, HeadersMap, []).
+
+describe_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), "/endpoints/", aws_util:encode_uri(EndpointId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the retention settings for an `AppInstance'.
+get_app_instance_retention_settings(Client, AppInstanceArn)
+  when is_map(Client) ->
+    get_app_instance_retention_settings(Client, AppInstanceArn, #{}, #{}).
+
+get_app_instance_retention_settings(Client, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_app_instance_retention_settings(Client, AppInstanceArn, QueryMap, HeadersMap, []).
+
+get_app_instance_retention_settings(Client, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/retention-settings"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of the administrators in the `AppInstance'.
+list_app_instance_admins(Client, AppInstanceArn)
+  when is_map(Client) ->
+    list_app_instance_admins(Client, AppInstanceArn, #{}, #{}).
+
+list_app_instance_admins(Client, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_app_instance_admins(Client, AppInstanceArn, QueryMap, HeadersMap, []).
+
+list_app_instance_admins(Client, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/admins"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all the `AppInstanceUserEndpoints' created under a single
+%% `AppInstanceUser'.
+list_app_instance_user_endpoints(Client, AppInstanceUserArn)
+  when is_map(Client) ->
+    list_app_instance_user_endpoints(Client, AppInstanceUserArn, #{}, #{}).
+
+list_app_instance_user_endpoints(Client, AppInstanceUserArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_app_instance_user_endpoints(Client, AppInstanceUserArn, QueryMap, HeadersMap, []).
+
+list_app_instance_user_endpoints(Client, AppInstanceUserArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), "/endpoints"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all `AppInstanceUsers' created under a single `AppInstance'.
+list_app_instance_users(Client, AppInstanceArn)
+  when is_map(Client) ->
+    list_app_instance_users(Client, AppInstanceArn, #{}, #{}).
+
+list_app_instance_users(Client, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_app_instance_users(Client, AppInstanceArn, QueryMap, HeadersMap, []).
+
+list_app_instance_users(Client, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instance-users"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"app-instance-arn">>, AppInstanceArn},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all Amazon Chime `AppInstance's created under a single AWS
+%% account.
+list_app_instances(Client)
+  when is_map(Client) ->
+    list_app_instances(Client, #{}, #{}).
+
+list_app_instances(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_app_instances(Client, QueryMap, HeadersMap, []).
+
+list_app_instances(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/app-instances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags applied to an Amazon Chime SDK identity resource.
+list_tags_for_resource(Client, ResourceARN)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceARN, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, ResourceARN}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Sets the amount of time in days that a given `AppInstance' retains
+%% data.
+put_app_instance_retention_settings(Client, AppInstanceArn, Input) ->
+    put_app_instance_retention_settings(Client, AppInstanceArn, Input, []).
+put_app_instance_retention_settings(Client, AppInstanceArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), "/retention-settings"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Registers an endpoint under an Amazon Chime `AppInstanceUser'.
+%%
+%% The endpoint receives messages for a user. For push notifications, the
+%% endpoint is a mobile device used to receive mobile push notifications for
+%% a user.
+register_app_instance_user_endpoint(Client, AppInstanceUserArn, Input) ->
+    register_app_instance_user_endpoint(Client, AppInstanceUserArn, Input, []).
+register_app_instance_user_endpoint(Client, AppInstanceUserArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), "/endpoints"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Applies the specified tags to the specified Amazon Chime SDK identity
+%% resource.
+tag_resource(Client, Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags?operation=tag-resource"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the specified tags from the specified Amazon Chime SDK
+%% identity resource.
+untag_resource(Client, Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags?operation=untag-resource"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates `AppInstance' metadata.
+update_app_instance(Client, AppInstanceArn, Input) ->
+    update_app_instance(Client, AppInstanceArn, Input, []).
+update_app_instance(Client, AppInstanceArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/app-instances/", aws_util:encode_uri(AppInstanceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the details of an `AppInstanceUser'.
+%%
+%% You can update names and metadata.
+update_app_instance_user(Client, AppInstanceUserArn, Input) ->
+    update_app_instance_user(Client, AppInstanceUserArn, Input, []).
+update_app_instance_user(Client, AppInstanceUserArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the details of an `AppInstanceUserEndpoint'.
+%%
+%% You can update the name and `AllowMessage' values.
+update_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input) ->
+    update_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input, []).
+update_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input0, Options0) ->
+    Method = put,
+    Path = ["/app-instance-users/", aws_util:encode_uri(AppInstanceUserArn), "/endpoints/", aws_util:encode_uri(EndpointId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"chime">>},
+    Host = build_host(<<"identity-chime">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_chime_sdk_meetings.erl
+++ b/src/aws_chime_sdk_meetings.erl
@@ -1,0 +1,422 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The Amazon Chime SDK meetings APIs in this section allow software
+%% developers to create Amazon Chime SDK meetings, set the AWS Regions for
+%% meetings, create and manage users, and send and receive meeting
+%% notifications.
+%%
+%% For more information about the meeting APIs, see Amazon Chime SDK
+%% meetings.
+-module(aws_chime_sdk_meetings).
+
+-export([batch_create_attendee/3,
+         batch_create_attendee/4,
+         create_attendee/3,
+         create_attendee/4,
+         create_meeting/2,
+         create_meeting/3,
+         create_meeting_with_attendees/2,
+         create_meeting_with_attendees/3,
+         delete_attendee/4,
+         delete_attendee/5,
+         delete_meeting/3,
+         delete_meeting/4,
+         get_attendee/3,
+         get_attendee/5,
+         get_attendee/6,
+         get_meeting/2,
+         get_meeting/4,
+         get_meeting/5,
+         list_attendees/2,
+         list_attendees/4,
+         list_attendees/5,
+         start_meeting_transcription/3,
+         start_meeting_transcription/4,
+         stop_meeting_transcription/3,
+         stop_meeting_transcription/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a group of meeting attendees.
+batch_create_attendee(Client, MeetingId, Input) ->
+    batch_create_attendee(Client, MeetingId, Input, []).
+batch_create_attendee(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/attendees?operation=batch-create"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new attendee for an active Amazon Chime SDK meeting.
+%%
+%% For more information about the Amazon Chime SDK, see Using the Amazon
+%% Chime SDK in the Amazon Chime Developer Guide.
+create_attendee(Client, MeetingId, Input) ->
+    create_attendee(Client, MeetingId, Input, []).
+create_attendee(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/attendees"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Amazon Chime SDK meeting in the specified media Region
+%% with no initial attendees.
+%%
+%% For more information about specifying media Regions, see Amazon Chime SDK
+%% Media Regions in the Amazon Chime Developer Guide. For more information
+%% about the Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon
+%% Chime Developer Guide.
+create_meeting(Client, Input) ->
+    create_meeting(Client, Input, []).
+create_meeting(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Amazon Chime SDK meeting in the specified media Region,
+%% with attendees.
+%%
+%% For more information about specifying media Regions, see Amazon Chime SDK
+%% Media Regions in the Amazon Chime Developer Guide. For more information
+%% about the Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon
+%% Chime Developer Guide.
+create_meeting_with_attendees(Client, Input) ->
+    create_meeting_with_attendees(Client, Input, []).
+create_meeting_with_attendees(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings?operation=create-attendees"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an attendee from the specified Amazon Chime SDK meeting and
+%% deletes their `JoinToken'.
+%%
+%% Attendees are automatically deleted when a Amazon Chime SDK meeting is
+%% deleted. For more information about the Amazon Chime SDK, see Using the
+%% Amazon Chime SDK in the Amazon Chime Developer Guide.
+delete_attendee(Client, AttendeeId, MeetingId, Input) ->
+    delete_attendee(Client, AttendeeId, MeetingId, Input, []).
+delete_attendee(Client, AttendeeId, MeetingId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/attendees/", aws_util:encode_uri(AttendeeId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified Amazon Chime SDK meeting.
+%%
+%% The operation deletes all attendees, disconnects all clients, and prevents
+%% new clients from joining the meeting. For more information about the
+%% Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon Chime
+%% Developer Guide.
+delete_meeting(Client, MeetingId, Input) ->
+    delete_meeting(Client, MeetingId, Input, []).
+delete_meeting(Client, MeetingId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets the Amazon Chime SDK attendee details for a specified meeting ID
+%% and attendee ID.
+%%
+%% For more information about the Amazon Chime SDK, see Using the Amazon
+%% Chime SDK in the Amazon Chime Developer Guide.
+get_attendee(Client, AttendeeId, MeetingId)
+  when is_map(Client) ->
+    get_attendee(Client, AttendeeId, MeetingId, #{}, #{}).
+
+get_attendee(Client, AttendeeId, MeetingId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_attendee(Client, AttendeeId, MeetingId, QueryMap, HeadersMap, []).
+
+get_attendee(Client, AttendeeId, MeetingId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/attendees/", aws_util:encode_uri(AttendeeId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the Amazon Chime SDK meeting details for the specified meeting
+%% ID.
+%%
+%% For more information about the Amazon Chime SDK, see Using the Amazon
+%% Chime SDK in the Amazon Chime Developer Guide.
+get_meeting(Client, MeetingId)
+  when is_map(Client) ->
+    get_meeting(Client, MeetingId, #{}, #{}).
+
+get_meeting(Client, MeetingId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_meeting(Client, MeetingId, QueryMap, HeadersMap, []).
+
+get_meeting(Client, MeetingId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the attendees for the specified Amazon Chime SDK meeting.
+%%
+%% For more information about the Amazon Chime SDK, see Using the Amazon
+%% Chime SDK in the Amazon Chime Developer Guide.
+list_attendees(Client, MeetingId)
+  when is_map(Client) ->
+    list_attendees(Client, MeetingId, #{}, #{}).
+
+list_attendees(Client, MeetingId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_attendees(Client, MeetingId, QueryMap, HeadersMap, []).
+
+list_attendees(Client, MeetingId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/attendees"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Starts transcription for the specified `meetingId'.
+start_meeting_transcription(Client, MeetingId, Input) ->
+    start_meeting_transcription(Client, MeetingId, Input, []).
+start_meeting_transcription(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/transcription?operation=start"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Stops transcription for the specified `meetingId'.
+stop_meeting_transcription(Client, MeetingId, Input) ->
+    stop_meeting_transcription(Client, MeetingId, Input, []).
+stop_meeting_transcription(Client, MeetingId, Input0, Options0) ->
+    Method = post,
+    Path = ["/meetings/", aws_util:encode_uri(MeetingId), "/transcription?operation=stop"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"chime">>},
+    Host = build_host(<<"meetings-chime">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_chime_sdk_messaging.erl
+++ b/src/aws_chime_sdk_messaging.erl
@@ -1,0 +1,1715 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The Amazon Chime SDK Messaging APIs in this section allow software
+%% developers to send and receive messages in custom messaging applications.
+%%
+%% These APIs depend on the frameworks provided by the Amazon Chime SDK
+%% Identity APIs. For more information about the messaging APIs, see Amazon
+%% Chime SDK messaging
+-module(aws_chime_sdk_messaging).
+
+-export([associate_channel_flow/3,
+         associate_channel_flow/4,
+         batch_create_channel_membership/3,
+         batch_create_channel_membership/4,
+         channel_flow_callback/3,
+         channel_flow_callback/4,
+         create_channel/2,
+         create_channel/3,
+         create_channel_ban/3,
+         create_channel_ban/4,
+         create_channel_flow/2,
+         create_channel_flow/3,
+         create_channel_membership/3,
+         create_channel_membership/4,
+         create_channel_moderator/3,
+         create_channel_moderator/4,
+         delete_channel/3,
+         delete_channel/4,
+         delete_channel_ban/4,
+         delete_channel_ban/5,
+         delete_channel_flow/3,
+         delete_channel_flow/4,
+         delete_channel_membership/4,
+         delete_channel_membership/5,
+         delete_channel_message/4,
+         delete_channel_message/5,
+         delete_channel_moderator/4,
+         delete_channel_moderator/5,
+         describe_channel/3,
+         describe_channel/5,
+         describe_channel/6,
+         describe_channel_ban/4,
+         describe_channel_ban/6,
+         describe_channel_ban/7,
+         describe_channel_flow/2,
+         describe_channel_flow/4,
+         describe_channel_flow/5,
+         describe_channel_membership/4,
+         describe_channel_membership/6,
+         describe_channel_membership/7,
+         describe_channel_membership_for_app_instance_user/4,
+         describe_channel_membership_for_app_instance_user/6,
+         describe_channel_membership_for_app_instance_user/7,
+         describe_channel_moderated_by_app_instance_user/4,
+         describe_channel_moderated_by_app_instance_user/6,
+         describe_channel_moderated_by_app_instance_user/7,
+         describe_channel_moderator/4,
+         describe_channel_moderator/6,
+         describe_channel_moderator/7,
+         disassociate_channel_flow/4,
+         disassociate_channel_flow/5,
+         get_channel_membership_preferences/4,
+         get_channel_membership_preferences/6,
+         get_channel_membership_preferences/7,
+         get_channel_message/4,
+         get_channel_message/6,
+         get_channel_message/7,
+         get_channel_message_status/4,
+         get_channel_message_status/6,
+         get_channel_message_status/7,
+         get_messaging_session_endpoint/1,
+         get_messaging_session_endpoint/3,
+         get_messaging_session_endpoint/4,
+         list_channel_bans/3,
+         list_channel_bans/5,
+         list_channel_bans/6,
+         list_channel_flows/2,
+         list_channel_flows/4,
+         list_channel_flows/5,
+         list_channel_memberships/3,
+         list_channel_memberships/5,
+         list_channel_memberships/6,
+         list_channel_memberships_for_app_instance_user/2,
+         list_channel_memberships_for_app_instance_user/4,
+         list_channel_memberships_for_app_instance_user/5,
+         list_channel_messages/3,
+         list_channel_messages/5,
+         list_channel_messages/6,
+         list_channel_moderators/3,
+         list_channel_moderators/5,
+         list_channel_moderators/6,
+         list_channels/3,
+         list_channels/5,
+         list_channels/6,
+         list_channels_associated_with_channel_flow/2,
+         list_channels_associated_with_channel_flow/4,
+         list_channels_associated_with_channel_flow/5,
+         list_channels_moderated_by_app_instance_user/2,
+         list_channels_moderated_by_app_instance_user/4,
+         list_channels_moderated_by_app_instance_user/5,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         put_channel_membership_preferences/4,
+         put_channel_membership_preferences/5,
+         redact_channel_message/4,
+         redact_channel_message/5,
+         send_channel_message/3,
+         send_channel_message/4,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_channel/3,
+         update_channel/4,
+         update_channel_flow/3,
+         update_channel_flow/4,
+         update_channel_message/4,
+         update_channel_message/5,
+         update_channel_read_marker/3,
+         update_channel_read_marker/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Associates a channel flow with a channel.
+%%
+%% Once associated, all messages to that channel go through channel flow
+%% processors. To stop processing, use the `DisassociateChannelFlow' API.
+%%
+%% Only administrators or channel moderators can associate a channel flow.
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+associate_channel_flow(Client, ChannelArn, Input) ->
+    associate_channel_flow(Client, ChannelArn, Input, []).
+associate_channel_flow(Client, ChannelArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/channel-flow"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds a specified number of users to a channel.
+batch_create_channel_membership(Client, ChannelArn, Input) ->
+    batch_create_channel_membership(Client, ChannelArn, Input, []).
+batch_create_channel_membership(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships?operation=batch-create"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Calls back Chime SDK Messaging with a processing response message.
+%%
+%% This should be invoked from the processor Lambda. This is a developer API.
+%%
+%% You can return one of the following processing responses:
+%%
+%% <ul> <li> Update message content or metadata
+%%
+%% </li> <li> Deny a message
+%%
+%% </li> <li> Make no changes to the message
+%%
+%% </li> </ul>
+channel_flow_callback(Client, ChannelArn, Input) ->
+    channel_flow_callback(Client, ChannelArn, Input, []).
+channel_flow_callback(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "?operation=channel-flow-callback"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a channel to which you can add users and send messages.
+%%
+%% Restriction: You can't change a channel's privacy.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+create_channel(Client, Input) ->
+    create_channel(Client, Input, []).
+create_channel(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Permanently bans a member from a channel.
+%%
+%% Moderators can't add banned members to a channel. To undo a ban, you first
+%% have to `DeleteChannelBan', and then `CreateChannelMembership'. Bans are
+%% cleaned up when you delete users or channels.
+%%
+%% If you ban a user who is already part of a channel, that user is
+%% automatically kicked from the channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+create_channel_ban(Client, ChannelArn, Input) ->
+    create_channel_ban(Client, ChannelArn, Input, []).
+create_channel_ban(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/bans"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a channel flow, a container for processors.
+%%
+%% Processors are AWS Lambda functions that perform actions on chat messages,
+%% such as stripping out profanity. You can associate channel flows with
+%% channels, and the processors in the channel flow then take action on all
+%% messages sent to that channel. This is a developer API.
+%%
+%% Channel flows process the following items:
+%%
+%% <ol> <li> New and updated messages
+%%
+%% </li> <li> Persistent and non-persistent messages
+%%
+%% </li> <li> The Standard message type
+%%
+%% </li> </ol> Channel flows don't process Control or System messages. For
+%% more information about the message types provided by Chime SDK Messaging,
+%% refer to Message types in the Amazon Chime developer guide.
+create_channel_flow(Client, Input) ->
+    create_channel_flow(Client, Input, []).
+create_channel_flow(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/channel-flows"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds a user to a channel.
+%%
+%% The `InvitedBy' field in `ChannelMembership' is derived from the request
+%% header. A channel member can:
+%%
+%% <ul> <li> List messages
+%%
+%% </li> <li> Send messages
+%%
+%% </li> <li> Receive messages
+%%
+%% </li> <li> Edit their own messages
+%%
+%% </li> <li> Leave the channel
+%%
+%% </li> </ul> Privacy settings impact this action as follows:
+%%
+%% <ul> <li> Public Channels: You do not need to be a member to list
+%% messages, but you must be a member to send messages.
+%%
+%% </li> <li> Private Channels: You must be a member to list or send
+%% messages.
+%%
+%% </li> </ul> The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+create_channel_membership(Client, ChannelArn, Input) ->
+    create_channel_membership(Client, ChannelArn, Input, []).
+create_channel_membership(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new `ChannelModerator'.
+%%
+%% A channel moderator can:
+%%
+%% <ul> <li> Add and remove other members of the channel.
+%%
+%% </li> <li> Add and remove other moderators of the channel.
+%%
+%% </li> <li> Add and remove user bans for the channel.
+%%
+%% </li> <li> Redact messages in the channel.
+%%
+%% </li> <li> List messages in the channel.
+%%
+%% </li> </ul> The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+create_channel_moderator(Client, ChannelArn, Input) ->
+    create_channel_moderator(Client, ChannelArn, Input, []).
+create_channel_moderator(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/moderators"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Immediately makes a channel and its memberships inaccessible and
+%% marks them for deletion.
+%%
+%% This is an irreversible process.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+delete_channel(Client, ChannelArn, Input) ->
+    delete_channel(Client, ChannelArn, Input, []).
+delete_channel(Client, ChannelArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a user from a channel's ban list.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+delete_channel_ban(Client, ChannelArn, MemberArn, Input) ->
+    delete_channel_ban(Client, ChannelArn, MemberArn, Input, []).
+delete_channel_ban(Client, ChannelArn, MemberArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/bans/", aws_util:encode_uri(MemberArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a channel flow, an irreversible process.
+%%
+%% This is a developer API.
+%%
+%% This API works only when the channel flow is not associated with any
+%% channel. To get a list of all channels that a channel flow is associated
+%% with, use the `ListChannelsAssociatedWithChannelFlow' API. Use the
+%% `DisassociateChannelFlow' API to disassociate a channel flow from all
+%% channels.
+delete_channel_flow(Client, ChannelFlowArn, Input) ->
+    delete_channel_flow(Client, ChannelFlowArn, Input, []).
+delete_channel_flow(Client, ChannelFlowArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channel-flows/", aws_util:encode_uri(ChannelFlowArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a member from a channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+delete_channel_membership(Client, ChannelArn, MemberArn, Input) ->
+    delete_channel_membership(Client, ChannelArn, MemberArn, Input, []).
+delete_channel_membership(Client, ChannelArn, MemberArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships/", aws_util:encode_uri(MemberArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a channel message.
+%%
+%% Only admins can perform this action. Deletion makes messages inaccessible
+%% immediately. A background process deletes any revisions created by
+%% `UpdateChannelMessage'.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+delete_channel_message(Client, ChannelArn, MessageId, Input) ->
+    delete_channel_message(Client, ChannelArn, MessageId, Input, []).
+delete_channel_message(Client, ChannelArn, MessageId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages/", aws_util:encode_uri(MessageId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a channel moderator.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+delete_channel_moderator(Client, ChannelArn, ChannelModeratorArn, Input) ->
+    delete_channel_moderator(Client, ChannelArn, ChannelModeratorArn, Input, []).
+delete_channel_moderator(Client, ChannelArn, ChannelModeratorArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/moderators/", aws_util:encode_uri(ChannelModeratorArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a channel in an Amazon Chime
+%% `AppInstance'.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel(Client, ChannelArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel(Client, ChannelArn, ChimeBearer, #{}, #{}).
+
+describe_channel(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a channel ban.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel_ban(Client, ChannelArn, MemberArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel_ban(Client, ChannelArn, MemberArn, ChimeBearer, #{}, #{}).
+
+describe_channel_ban(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_ban(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel_ban(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/bans/", aws_util:encode_uri(MemberArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a channel flow in an Amazon Chime
+%% `AppInstance'.
+%%
+%% This is a developer API.
+describe_channel_flow(Client, ChannelFlowArn)
+  when is_map(Client) ->
+    describe_channel_flow(Client, ChannelFlowArn, #{}, #{}).
+
+describe_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap, []).
+
+describe_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel-flows/", aws_util:encode_uri(ChannelFlowArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a user's channel membership.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel_membership(Client, ChannelArn, MemberArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel_membership(Client, ChannelArn, MemberArn, ChimeBearer, #{}, #{}).
+
+describe_channel_membership(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_membership(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel_membership(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships/", aws_util:encode_uri(MemberArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the details of a channel based on the membership of the
+%% specified `AppInstanceUser'.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel_membership_for_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel_membership_for_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, #{}, #{}).
+
+describe_channel_membership_for_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_membership_for_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel_membership_for_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "?scope=app-instance-user-membership"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"app-instance-user-arn">>, AppInstanceUserArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a channel moderated by the specified
+%% `AppInstanceUser'.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel_moderated_by_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel_moderated_by_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, #{}, #{}).
+
+describe_channel_moderated_by_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_moderated_by_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel_moderated_by_app_instance_user(Client, ChannelArn, AppInstanceUserArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "?scope=app-instance-user-moderated-channel"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"app-instance-user-arn">>, AppInstanceUserArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the full details of a single ChannelModerator.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+describe_channel_moderator(Client, ChannelArn, ChannelModeratorArn, ChimeBearer)
+  when is_map(Client) ->
+    describe_channel_moderator(Client, ChannelArn, ChannelModeratorArn, ChimeBearer, #{}, #{}).
+
+describe_channel_moderator(Client, ChannelArn, ChannelModeratorArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel_moderator(Client, ChannelArn, ChannelModeratorArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+describe_channel_moderator(Client, ChannelArn, ChannelModeratorArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/moderators/", aws_util:encode_uri(ChannelModeratorArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Disassociates a channel flow from all its channels.
+%%
+%% Once disassociated, all messages to that channel stop going through the
+%% channel flow processor.
+%%
+%% Only administrators or channel moderators can disassociate a channel flow.
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+disassociate_channel_flow(Client, ChannelArn, ChannelFlowArn, Input) ->
+    disassociate_channel_flow(Client, ChannelArn, ChannelFlowArn, Input, []).
+disassociate_channel_flow(Client, ChannelArn, ChannelFlowArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/channel-flow/", aws_util:encode_uri(ChannelFlowArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets the membership preferences of an `AppInstanceUser' for the
+%% specified channel.
+%%
+%% The `AppInstanceUser' must be a member of the channel. Only the
+%% `AppInstanceUser' who owns the membership can retrieve preferences. Users
+%% in the `AppInstanceAdmin' and channel moderator roles can't retrieve
+%% preferences for other users. Banned users can't retrieve membership
+%% preferences for the channel from which they are banned.
+get_channel_membership_preferences(Client, ChannelArn, MemberArn, ChimeBearer)
+  when is_map(Client) ->
+    get_channel_membership_preferences(Client, ChannelArn, MemberArn, ChimeBearer, #{}, #{}).
+
+get_channel_membership_preferences(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_channel_membership_preferences(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+get_channel_membership_preferences(Client, ChannelArn, MemberArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships/", aws_util:encode_uri(MemberArn), "/preferences"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the full details of a channel message.
+%%
+%% The x-amz-chime-bearer request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+get_channel_message(Client, ChannelArn, MessageId, ChimeBearer)
+  when is_map(Client) ->
+    get_channel_message(Client, ChannelArn, MessageId, ChimeBearer, #{}, #{}).
+
+get_channel_message(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_channel_message(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap, []).
+
+get_channel_message(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages/", aws_util:encode_uri(MessageId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets message status for a specified `messageId'.
+%%
+%% Use this API to determine the intermediate status of messages going
+%% through channel flow processing. The API provides an alternative to
+%% retrieving message status if the event was not received because a client
+%% wasn't connected to a websocket.
+%%
+%% Messages can have any one of these statuses.
+%%
+%% <dl> <dt>SENT</dt> <dd> Message processed successfully
+%%
+%% </dd> <dt>PENDING</dt> <dd> Ongoing processing
+%%
+%% </dd> <dt>FAILED</dt> <dd> Processing failed
+%%
+%% </dd> <dt>DENIED</dt> <dd> Messasge denied by the processor
+%%
+%% </dd> </dl> This API does not return statuses for denied messages, because
+%% we don't store them once the processor denies them.
+%%
+%% Only the message sender can invoke this API.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header
+get_channel_message_status(Client, ChannelArn, MessageId, ChimeBearer)
+  when is_map(Client) ->
+    get_channel_message_status(Client, ChannelArn, MessageId, ChimeBearer, #{}, #{}).
+
+get_channel_message_status(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_channel_message_status(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap, []).
+
+get_channel_message_status(Client, ChannelArn, MessageId, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages/", aws_util:encode_uri(MessageId), "?scope=message-status"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc The details of the endpoint for the messaging session.
+get_messaging_session_endpoint(Client)
+  when is_map(Client) ->
+    get_messaging_session_endpoint(Client, #{}, #{}).
+
+get_messaging_session_endpoint(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_messaging_session_endpoint(Client, QueryMap, HeadersMap, []).
+
+get_messaging_session_endpoint(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/endpoints/messaging-session"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all the users banned from a particular channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channel_bans(Client, ChannelArn, ChimeBearer)
+  when is_map(Client) ->
+    list_channel_bans(Client, ChannelArn, ChimeBearer, #{}, #{}).
+
+list_channel_bans(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_bans(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channel_bans(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/bans"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a paginated lists of all the channel flows created under a
+%% single Chime.
+%%
+%% This is a developer API.
+list_channel_flows(Client, AppInstanceArn)
+  when is_map(Client) ->
+    list_channel_flows(Client, AppInstanceArn, #{}, #{}).
+
+list_channel_flows(Client, AppInstanceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_flows(Client, AppInstanceArn, QueryMap, HeadersMap, []).
+
+list_channel_flows(Client, AppInstanceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel-flows"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"app-instance-arn">>, AppInstanceArn},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all channel memberships in a channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+%%
+%% If you want to list the channels to which a specific app instance user
+%% belongs, see the ListChannelMembershipsForAppInstanceUser API.
+list_channel_memberships(Client, ChannelArn, ChimeBearer)
+  when is_map(Client) ->
+    list_channel_memberships(Client, ChannelArn, ChimeBearer, #{}, #{}).
+
+list_channel_memberships(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_memberships(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channel_memberships(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)},
+        {<<"type">>, maps:get(<<"type">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all channels that a particular `AppInstanceUser' is a part of.
+%%
+%% Only an `AppInstanceAdmin' can call the API with a user ARN that is not
+%% their own.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channel_memberships_for_app_instance_user(Client, ChimeBearer)
+  when is_map(Client) ->
+    list_channel_memberships_for_app_instance_user(Client, ChimeBearer, #{}, #{}).
+
+list_channel_memberships_for_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_memberships_for_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channel_memberships_for_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels?scope=app-instance-user-memberships"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"app-instance-user-arn">>, maps:get(<<"app-instance-user-arn">>, QueryMap, undefined)},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all the messages in a channel.
+%%
+%% Returns a paginated list of `ChannelMessages'. By default, sorted by
+%% creation timestamp in descending order.
+%%
+%% Redacted messages appear in the results as empty, since they are only
+%% redacted, not deleted. Deleted messages do not appear in the results. This
+%% action always returns the latest version of an edited message.
+%%
+%% Also, the x-amz-chime-bearer request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channel_messages(Client, ChannelArn, ChimeBearer)
+  when is_map(Client) ->
+    list_channel_messages(Client, ChannelArn, ChimeBearer, #{}, #{}).
+
+list_channel_messages(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_messages(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channel_messages(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)},
+        {<<"not-after">>, maps:get(<<"not-after">>, QueryMap, undefined)},
+        {<<"not-before">>, maps:get(<<"not-before">>, QueryMap, undefined)},
+        {<<"sort-order">>, maps:get(<<"sort-order">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all the moderators for a channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channel_moderators(Client, ChannelArn, ChimeBearer)
+  when is_map(Client) ->
+    list_channel_moderators(Client, ChannelArn, ChimeBearer, #{}, #{}).
+
+list_channel_moderators(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channel_moderators(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channel_moderators(Client, ChannelArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/moderators"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all Channels created under a single Chime App as a paginated
+%% list.
+%%
+%% You can specify filters to narrow results.
+%%
+%% == Functionality & restrictions ==
+%%
+%% <ul> <li> Use privacy = `PUBLIC' to retrieve all public channels in the
+%% account.
+%%
+%% </li> <li> Only an `AppInstanceAdmin' can set privacy = `PRIVATE' to list
+%% the private channels in an account.
+%%
+%% </li> </ul> The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channels(Client, AppInstanceArn, ChimeBearer)
+  when is_map(Client) ->
+    list_channels(Client, AppInstanceArn, ChimeBearer, #{}, #{}).
+
+list_channels(Client, AppInstanceArn, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channels(Client, AppInstanceArn, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channels(Client, AppInstanceArn, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"app-instance-arn">>, AppInstanceArn},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)},
+        {<<"privacy">>, maps:get(<<"privacy">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all channels associated with a specified channel flow.
+%%
+%% You can associate a channel flow with multiple channels, but you can only
+%% associate a channel with one channel flow. This is a developer API.
+list_channels_associated_with_channel_flow(Client, ChannelFlowArn)
+  when is_map(Client) ->
+    list_channels_associated_with_channel_flow(Client, ChannelFlowArn, #{}, #{}).
+
+list_channels_associated_with_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channels_associated_with_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap, []).
+
+list_channels_associated_with_channel_flow(Client, ChannelFlowArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels?scope=channel-flow-associations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"channel-flow-arn">>, ChannelFlowArn},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc A list of the channels moderated by an `AppInstanceUser'.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+list_channels_moderated_by_app_instance_user(Client, ChimeBearer)
+  when is_map(Client) ->
+    list_channels_moderated_by_app_instance_user(Client, ChimeBearer, #{}, #{}).
+
+list_channels_moderated_by_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channels_moderated_by_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap, []).
+
+list_channels_moderated_by_app_instance_user(Client, ChimeBearer, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels?scope=app-instance-user-moderated-channels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-chime-bearer">>, ChimeBearer}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"app-instance-user-arn">>, maps:get(<<"app-instance-user-arn">>, QueryMap, undefined)},
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags applied to an Amazon Chime SDK messaging resource.
+list_tags_for_resource(Client, ResourceARN)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceARN, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, ResourceARN}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Sets the membership preferences of an `AppInstanceUser' for the
+%% specified channel.
+%%
+%% The `AppInstanceUser' must be a member of the channel. Only the
+%% `AppInstanceUser' who owns the membership can set preferences. Users in
+%% the `AppInstanceAdmin' and channel moderator roles can't set preferences
+%% for other users. Banned users can't set membership preferences for the
+%% channel from which they are banned.
+put_channel_membership_preferences(Client, ChannelArn, MemberArn, Input) ->
+    put_channel_membership_preferences(Client, ChannelArn, MemberArn, Input, []).
+put_channel_membership_preferences(Client, ChannelArn, MemberArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/memberships/", aws_util:encode_uri(MemberArn), "/preferences"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Redacts message content, but not metadata.
+%%
+%% The message exists in the back end, but the action returns null content,
+%% and the state shows as redacted.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+redact_channel_message(Client, ChannelArn, MessageId, Input) ->
+    redact_channel_message(Client, ChannelArn, MessageId, Input, []).
+redact_channel_message(Client, ChannelArn, MessageId, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages/", aws_util:encode_uri(MessageId), "?operation=redact"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Sends a message to a particular channel that the member is a part of.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+%%
+%% Also, `STANDARD' messages can contain 4KB of data and the 1KB of metadata.
+%% `CONTROL' messages can contain 30 bytes of data and no metadata.
+send_channel_message(Client, ChannelArn, Input) ->
+    send_channel_message(Client, ChannelArn, Input, []).
+send_channel_message(Client, ChannelArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Applies the specified tags to the specified Amazon Chime SDK
+%% messaging resource.
+tag_resource(Client, Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags?operation=tag-resource"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the specified tags from the specified Amazon Chime SDK
+%% messaging resource.
+untag_resource(Client, Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags?operation=untag-resource"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a channel's attributes.
+%%
+%% Restriction: You can't change a channel's privacy.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+update_channel(Client, ChannelArn, Input) ->
+    update_channel(Client, ChannelArn, Input, []).
+update_channel(Client, ChannelArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates channel flow attributes.
+%%
+%% This is a developer API.
+update_channel_flow(Client, ChannelFlowArn, Input) ->
+    update_channel_flow(Client, ChannelFlowArn, Input, []).
+update_channel_flow(Client, ChannelFlowArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/channel-flows/", aws_util:encode_uri(ChannelFlowArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the content of a message.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+update_channel_message(Client, ChannelArn, MessageId, Input) ->
+    update_channel_message(Client, ChannelArn, MessageId, Input, []).
+update_channel_message(Client, ChannelArn, MessageId, Input0, Options0) ->
+    Method = put,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/messages/", aws_util:encode_uri(MessageId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc The details of the time when a user last read messages in a channel.
+%%
+%% The `x-amz-chime-bearer' request header is mandatory. Use the
+%% `AppInstanceUserArn' of the user that makes the API call as the value in
+%% the header.
+update_channel_read_marker(Client, ChannelArn, Input) ->
+    update_channel_read_marker(Client, ChannelArn, Input, []).
+update_channel_read_marker(Client, ChannelArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/channels/", aws_util:encode_uri(ChannelArn), "/readMarker"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-chime-bearer">>, <<"ChimeBearer">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"chime">>},
+    Host = build_host(<<"messaging-chime">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_cloud9.erl
+++ b/src/aws_cloud9.erl
@@ -1,16 +1,16 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Cloud9
+%% @doc Cloud9
 %%
-%% AWS Cloud9 is a collection of tools that you can use to code, build, run,
+%% Cloud9 is a collection of tools that you can use to code, build, run,
 %% test, debug, and release software in the cloud.
 %%
-%% For more information about AWS Cloud9, see the AWS Cloud9 User Guide.
+%% For more information about Cloud9, see the Cloud9 User Guide.
 %%
-%% AWS Cloud9 supports these operations:
+%% Cloud9 supports these operations:
 %%
-%% <ul> <li> `CreateEnvironmentEC2': Creates an AWS Cloud9 development
+%% <ul> <li> `CreateEnvironmentEC2': Creates an Cloud9 development
 %% environment, launches an Amazon EC2 instance, and then connects from the
 %% instance to the environment.
 %%
@@ -81,9 +81,9 @@
 %% API
 %%====================================================================
 
-%% @doc Creates an AWS Cloud9 development environment, launches an Amazon
-%% Elastic Compute Cloud (Amazon EC2) instance, and then connects from the
-%% instance to the environment.
+%% @doc Creates an Cloud9 development environment, launches an Amazon Elastic
+%% Compute Cloud (Amazon EC2) instance, and then connects from the instance
+%% to the environment.
 create_environment_ec2(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_environment_ec2(Client, Input, []).
@@ -91,7 +91,7 @@ create_environment_ec2(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateEnvironmentEC2">>, Input, Options).
 
-%% @doc Adds an environment member to an AWS Cloud9 development environment.
+%% @doc Adds an environment member to an Cloud9 development environment.
 create_environment_membership(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_environment_membership(Client, Input, []).
@@ -99,7 +99,7 @@ create_environment_membership(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateEnvironmentMembership">>, Input, Options).
 
-%% @doc Deletes an AWS Cloud9 development environment.
+%% @doc Deletes an Cloud9 development environment.
 %%
 %% If an Amazon EC2 instance is connected to the environment, also terminates
 %% the instance.
@@ -110,8 +110,7 @@ delete_environment(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteEnvironment">>, Input, Options).
 
-%% @doc Deletes an environment member from an AWS Cloud9 development
-%% environment.
+%% @doc Deletes an environment member from an Cloud9 development environment.
 delete_environment_membership(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_environment_membership(Client, Input, []).
@@ -119,8 +118,8 @@ delete_environment_membership(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteEnvironmentMembership">>, Input, Options).
 
-%% @doc Gets information about environment members for an AWS Cloud9
-%% development environment.
+%% @doc Gets information about environment members for an Cloud9 development
+%% environment.
 describe_environment_memberships(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_environment_memberships(Client, Input, []).
@@ -128,7 +127,7 @@ describe_environment_memberships(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEnvironmentMemberships">>, Input, Options).
 
-%% @doc Gets status information for an AWS Cloud9 development environment.
+%% @doc Gets status information for an Cloud9 development environment.
 describe_environment_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_environment_status(Client, Input, []).
@@ -136,7 +135,7 @@ describe_environment_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEnvironmentStatus">>, Input, Options).
 
-%% @doc Gets information about AWS Cloud9 development environments.
+%% @doc Gets information about Cloud9 development environments.
 describe_environments(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_environments(Client, Input, []).
@@ -144,7 +143,7 @@ describe_environments(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEnvironments">>, Input, Options).
 
-%% @doc Gets a list of AWS Cloud9 development environment identifiers.
+%% @doc Gets a list of Cloud9 development environment identifiers.
 list_environments(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_environments(Client, Input, []).
@@ -152,7 +151,7 @@ list_environments(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListEnvironments">>, Input, Options).
 
-%% @doc Gets a list of the tags associated with an AWS Cloud9 development
+%% @doc Gets a list of the tags associated with an Cloud9 development
 %% environment.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -161,10 +160,10 @@ list_tags_for_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListTagsForResource">>, Input, Options).
 
-%% @doc Adds tags to an AWS Cloud9 development environment.
+%% @doc Adds tags to an Cloud9 development environment.
 %%
-%% Tags that you add to an AWS Cloud9 environment by using this method will
-%% NOT be automatically propagated to underlying resources.
+%% Tags that you add to an Cloud9 environment by using this method will NOT
+%% be automatically propagated to underlying resources.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -172,7 +171,7 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Removes tags from an AWS Cloud9 development environment.
+%% @doc Removes tags from an Cloud9 development environment.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
@@ -180,8 +179,7 @@ untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
 
-%% @doc Changes the settings of an existing AWS Cloud9 development
-%% environment.
+%% @doc Changes the settings of an existing Cloud9 development environment.
 update_environment(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_environment(Client, Input, []).
@@ -189,8 +187,8 @@ update_environment(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateEnvironment">>, Input, Options).
 
-%% @doc Changes the settings of an existing environment member for an AWS
-%% Cloud9 development environment.
+%% @doc Changes the settings of an existing environment member for an Cloud9
+%% development environment.
 update_environment_membership(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_environment_membership(Client, Input, []).

--- a/src/aws_cloudcontrol.erl
+++ b/src/aws_cloudcontrol.erl
@@ -1,0 +1,216 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Use Amazon Web Services Cloud Control API to create, read, update,
+%% delete, and list (CRUD-L) your cloud resources that belong to a wide range
+%% of services--both Amazon Web Services and third-party.
+%%
+%% With the Cloud Control API standardized set of application programming
+%% interfaces (APIs), you can perform CRUD-L operations on any supported
+%% resources in your Amazon Web Services account. Using Cloud Control API,
+%% you won't have to generate code or scripts specific to each individual
+%% service responsible for those resources.
+%%
+%% For more information about Amazon Web Services Cloud Control API, see the
+%% Amazon Web Services Cloud Control API User Guide.
+-module(aws_cloudcontrol).
+
+-export([cancel_resource_request/2,
+         cancel_resource_request/3,
+         create_resource/2,
+         create_resource/3,
+         delete_resource/2,
+         delete_resource/3,
+         get_resource/2,
+         get_resource/3,
+         get_resource_request_status/2,
+         get_resource_request_status/3,
+         list_resource_requests/2,
+         list_resource_requests/3,
+         list_resources/2,
+         list_resources/3,
+         update_resource/2,
+         update_resource/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Cancels the specified resource operation request.
+%%
+%% For more information, see Canceling resource operation requests in the
+%% Amazon Web Services Cloud Control API User Guide.
+%%
+%% Only resource operations requests with a status of `PENDING' or
+%% `IN_PROGRESS' can be cancelled.
+cancel_resource_request(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_resource_request(Client, Input, []).
+cancel_resource_request(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelResourceRequest">>, Input, Options).
+
+%% @doc Creates the specified resource.
+%%
+%% For more information, see Creating a resource in the Amazon Web Services
+%% Cloud Control API User Guide.
+%%
+%% After you have initiated a resource creation request, you can monitor the
+%% progress of your request by calling GetResourceRequestStatus using the
+%% `RequestToken' of the `ProgressEvent' type returned by `CreateResource'.
+create_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_resource(Client, Input, []).
+create_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateResource">>, Input, Options).
+
+%% @doc Deletes the specified resource.
+%%
+%% For details, see Deleting a resource in the Amazon Web Services Cloud
+%% Control API User Guide.
+%%
+%% After you have initiated a resource deletion request, you can monitor the
+%% progress of your request by calling GetResourceRequestStatus using the
+%% `RequestToken' of the `ProgressEvent' returned by `DeleteResource'.
+delete_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_resource(Client, Input, []).
+delete_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteResource">>, Input, Options).
+
+%% @doc Returns information about the current state of the specified
+%% resource.
+%%
+%% For details, see Reading a resource's current state.
+%%
+%% You can use this action to return information about an existing resource
+%% in your account and Amazon Web Services Region, whether or not those
+%% resources were provisioned using Cloud Control API.
+get_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_resource(Client, Input, []).
+get_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetResource">>, Input, Options).
+
+%% @doc Returns the current status of a resource operation request.
+%%
+%% For more information, see Tracking the progress of resource operation
+%% requests in the Amazon Web Services Cloud Control API User Guide.
+get_resource_request_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_resource_request_status(Client, Input, []).
+get_resource_request_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetResourceRequestStatus">>, Input, Options).
+
+%% @doc Returns existing resource operation requests.
+%%
+%% This includes requests of all status types. For more information, see
+%% Listing active resource operation requests in the Amazon Web Services
+%% Cloud Control API User Guide.
+%%
+%% Resource operation requests expire after seven days.
+list_resource_requests(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_resource_requests(Client, Input, []).
+list_resource_requests(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListResourceRequests">>, Input, Options).
+
+%% @doc Returns information about the specified resources.
+%%
+%% For more information, see Discovering resources in the Amazon Web Services
+%% Cloud Control API User Guide.
+%%
+%% You can use this action to return information about existing resources in
+%% your account and Amazon Web Services Region, whether or not those
+%% resources were provisioned using Cloud Control API.
+list_resources(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_resources(Client, Input, []).
+list_resources(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListResources">>, Input, Options).
+
+%% @doc Updates the specified property values in the resource.
+%%
+%% You specify your resource property updates as a list of patch operations
+%% contained in a JSON patch document that adheres to the RFC 6902 -
+%% JavaScript Object Notation (JSON) Patch standard.
+%%
+%% For details on how Cloud Control API performs resource update operations,
+%% see Updating a resource in the Amazon Web Services Cloud Control API User
+%% Guide.
+%%
+%% After you have initiated a resource update request, you can monitor the
+%% progress of your request by calling GetResourceRequestStatus using the
+%% `RequestToken' of the `ProgressEvent' returned by `UpdateResource'.
+%%
+%% For more information about the properties of a specific resource, refer to
+%% the related topic for the resource in the Resource and property types
+%% reference in the Amazon Web Services CloudFormation Users Guide.
+update_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_resource(Client, Input, []).
+update_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateResource">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"cloudcontrolapi">>},
+    Host = build_host(<<"cloudcontrolapi">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"CloudApiService.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -1986,6 +1986,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_cloudformation.erl
+++ b/src/aws_cloudformation.erl
@@ -3,30 +3,35 @@
 
 %% @doc AWS CloudFormation
 %%
-%% AWS CloudFormation allows you to create and manage AWS infrastructure
-%% deployments predictably and repeatedly.
+%% CloudFormation allows you to create and manage Amazon Web Services
+%% infrastructure deployments predictably and repeatedly.
 %%
-%% You can use AWS CloudFormation to leverage AWS products, such as Amazon
-%% Elastic Compute Cloud, Amazon Elastic Block Store, Amazon Simple
+%% You can use CloudFormation to leverage Amazon Web Services products, such
+%% as Amazon Elastic Compute Cloud, Amazon Elastic Block Store, Amazon Simple
 %% Notification Service, Elastic Load Balancing, and Auto Scaling to build
 %% highly-reliable, highly scalable, cost-effective applications without
-%% creating or configuring the underlying AWS infrastructure.
+%% creating or configuring the underlying Amazon Web Services infrastructure.
 %%
-%% With AWS CloudFormation, you declare all of your resources and
-%% dependencies in a template file. The template defines a collection of
-%% resources as a single unit called a stack. AWS CloudFormation creates and
-%% deletes all member resources of the stack together and manages all
-%% dependencies between the resources for you.
+%% With CloudFormation, you declare all of your resources and dependencies in
+%% a template file. The template defines a collection of resources as a
+%% single unit called a stack. CloudFormation creates and deletes all member
+%% resources of the stack together and manages all dependencies between the
+%% resources for you.
 %%
-%% For more information about AWS CloudFormation, see the AWS CloudFormation
-%% Product Page.
+%% For more information about CloudFormation, see the CloudFormation Product
+%% Page.
 %%
-%% Amazon CloudFormation makes use of other AWS products. If you need
-%% additional technical information about a specific AWS product, you can
-%% find the product's technical documentation at docs.aws.amazon.com.
+%% CloudFormation makes use of other Amazon Web Services products. If you
+%% need additional technical information about a specific Amazon Web Services
+%% product, you can find the product's technical documentation at
+%% `docs.aws.amazon.com' .
 -module(aws_cloudformation).
 
--export([cancel_update_stack/2,
+-export([activate_type/2,
+         activate_type/3,
+         batch_describe_type_configurations/2,
+         batch_describe_type_configurations/3,
+         cancel_update_stack/2,
          cancel_update_stack/3,
          continue_update_rollback/2,
          continue_update_rollback/3,
@@ -38,6 +43,8 @@
          create_stack_instances/3,
          create_stack_set/2,
          create_stack_set/3,
+         deactivate_type/2,
+         deactivate_type/3,
          delete_change_set/2,
          delete_change_set/3,
          delete_stack/2,
@@ -52,6 +59,8 @@
          describe_account_limits/3,
          describe_change_set/2,
          describe_change_set/3,
+         describe_publisher/2,
+         describe_publisher/3,
          describe_stack_drift_detection_status/2,
          describe_stack_drift_detection_status/3,
          describe_stack_events/2,
@@ -90,6 +99,8 @@
          get_template/3,
          get_template_summary/2,
          get_template_summary/3,
+         import_stacks_to_stack_set/2,
+         import_stacks_to_stack_set/3,
          list_change_sets/2,
          list_change_sets/3,
          list_exports/2,
@@ -114,18 +125,28 @@
          list_type_versions/3,
          list_types/2,
          list_types/3,
+         publish_type/2,
+         publish_type/3,
          record_handler_progress/2,
          record_handler_progress/3,
+         register_publisher/2,
+         register_publisher/3,
          register_type/2,
          register_type/3,
+         rollback_stack/2,
+         rollback_stack/3,
          set_stack_policy/2,
          set_stack_policy/3,
+         set_type_configuration/2,
+         set_type_configuration/3,
          set_type_default_version/2,
          set_type_default_version/3,
          signal_resource/2,
          signal_resource/3,
          stop_stack_set_operation/2,
          stop_stack_set_operation/3,
+         test_type/2,
+         test_type/3,
          update_stack/2,
          update_stack/3,
          update_stack_instances/2,
@@ -142,6 +163,35 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Activates a public third-party extension, making it available for use
+%% in stack templates.
+%%
+%% For more information, see Using public extensions in the CloudFormation
+%% User Guide.
+%%
+%% Once you have activated a public third-party extension in your account and
+%% region, use SetTypeConfiguration to specify configuration properties for
+%% the extension. For more information, see Configuring extensions at the
+%% account level in the CloudFormation User Guide.
+activate_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    activate_type(Client, Input, []).
+activate_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ActivateType">>, Input, Options).
+
+%% @doc Returns configuration data for the specified CloudFormation
+%% extensions, from the CloudFormation registry for the account and region.
+%%
+%% For more information, see Configuring extensions at the account level in
+%% the CloudFormation User Guide.
+batch_describe_type_configurations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_describe_type_configurations(Client, Input, []).
+batch_describe_type_configurations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchDescribeTypeConfigurations">>, Input, Options).
 
 %% @doc Cancels an update on the specified stack.
 %%
@@ -164,13 +214,13 @@ cancel_update_stack(Client, Input, Options)
 %% stack to a working state (the `UPDATE_ROLLBACK_COMPLETE' state), and then
 %% try to update the stack again.
 %%
-%% A stack goes into the `UPDATE_ROLLBACK_FAILED' state when AWS
-%% CloudFormation cannot roll back all changes after a failed stack update.
-%% For example, you might have a stack that is rolling back to an old
-%% database instance that was deleted outside of AWS CloudFormation. Because
-%% AWS CloudFormation doesn't know the database was deleted, it assumes that
-%% the database instance still exists and attempts to roll back to it,
-%% causing the update rollback to fail.
+%% A stack goes into the `UPDATE_ROLLBACK_FAILED' state when CloudFormation
+%% cannot roll back all changes after a failed stack update. For example, you
+%% might have a stack that is rolling back to an old database instance that
+%% was deleted outside of CloudFormation. Because CloudFormation doesn't know
+%% the database was deleted, it assumes that the database instance still
+%% exists and attempts to roll back to it, causing the update rollback to
+%% fail.
 continue_update_rollback(Client, Input)
   when is_map(Client), is_map(Input) ->
     continue_update_rollback(Client, Input, []).
@@ -183,25 +233,24 @@ continue_update_rollback(Client, Input, Options)
 %%
 %% You can create a change set for a stack that doesn't exist or an existing
 %% stack. If you create a change set for a stack that doesn't exist, the
-%% change set shows all of the resources that AWS CloudFormation will create.
-%% If you create a change set for an existing stack, AWS CloudFormation
-%% compares the stack's information with the information that you submit in
-%% the change set and lists the differences. Use change sets to understand
-%% which resources AWS CloudFormation will create or change, and how it will
-%% change resources in an existing stack, before you create or update a
-%% stack.
+%% change set shows all of the resources that CloudFormation will create. If
+%% you create a change set for an existing stack, CloudFormation compares the
+%% stack's information with the information that you submit in the change set
+%% and lists the differences. Use change sets to understand which resources
+%% CloudFormation will create or change, and how it will change resources in
+%% an existing stack, before you create or update a stack.
 %%
 %% To create a change set for a stack that doesn't exist, for the
 %% `ChangeSetType' parameter, specify `CREATE'. To create a change set for an
 %% existing stack, specify `UPDATE' for the `ChangeSetType' parameter. To
 %% create a change set for an import operation, specify `IMPORT' for the
 %% `ChangeSetType' parameter. After the `CreateChangeSet' call successfully
-%% completes, AWS CloudFormation starts creating the change set. To check the
+%% completes, CloudFormation starts creating the change set. To check the
 %% status of the change set or to review it, use the `DescribeChangeSet'
 %% action.
 %%
 %% When you are satisfied with the changes the change set will make, execute
-%% the change set by using the `ExecuteChangeSet' action. AWS CloudFormation
+%% the change set by using the `ExecuteChangeSet' action. CloudFormation
 %% doesn't make changes until you execute the change set.
 %%
 %% To create a change set for the entire stack hierachy, set
@@ -246,12 +295,27 @@ create_stack_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateStackSet">>, Input, Options).
 
+%% @doc Deactivates a public extension that was previously activated in this
+%% account and region.
+%%
+%% Once deactivated, an extension cannot be used in any CloudFormation
+%% operation. This includes stack update operations where the stack template
+%% includes the extension, even if no updates are being made to the
+%% extension. In addition, deactivated extensions are not automatically
+%% updated if a new version of the extension is released.
+deactivate_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    deactivate_type(Client, Input, []).
+deactivate_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeactivateType">>, Input, Options).
+
 %% @doc Deletes the specified change set.
 %%
 %% Deleting change sets ensures that no one executes the wrong change set.
 %%
-%% If the call successfully completes, AWS CloudFormation successfully
-%% deleted the change set.
+%% If the call successfully completes, CloudFormation successfully deleted
+%% the change set.
 %%
 %% If `IncludeNestedStacks' specifies `True' during the creation of the
 %% nested change set, then `DeleteChangeSet' will delete all change sets that
@@ -322,11 +386,11 @@ deregister_type(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeregisterType">>, Input, Options).
 
-%% @doc Retrieves your account's AWS CloudFormation limits, such as the
-%% maximum number of stacks that you can create in your account.
+%% @doc Retrieves your account's CloudFormation limits, such as the maximum
+%% number of stacks that you can create in your account.
 %%
-%% For more information about account limits, see AWS CloudFormation Limits
-%% in the AWS CloudFormation User Guide.
+%% For more information about account limits, see CloudFormation Limits in
+%% the CloudFormation User Guide.
 describe_account_limits(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_account_limits(Client, Input, []).
@@ -334,10 +398,10 @@ describe_account_limits(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAccountLimits">>, Input, Options).
 
-%% @doc Returns the inputs for the change set and a list of changes that AWS
+%% @doc Returns the inputs for the change set and a list of changes that
 %% CloudFormation will make if you execute the change set.
 %%
-%% For more information, see Updating Stacks Using Change Sets in the AWS
+%% For more information, see Updating Stacks Using Change Sets in the
 %% CloudFormation User Guide.
 describe_change_set(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -345,6 +409,27 @@ describe_change_set(Client, Input)
 describe_change_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeChangeSet">>, Input, Options).
+
+%% @doc Returns information about a CloudFormation extension publisher.
+%%
+%% If you do not supply a `PublisherId', and you have registered as an
+%% extension publisher, `DescribePublisher' returns information about your
+%% own publisher account.
+%%
+%% For more information on registering as a publisher, see:
+%%
+%% <ul> <li> RegisterPublisher
+%%
+%% </li> <li> Publishing extensions to make them available for public use in
+%% the CloudFormation CLI User Guide
+%%
+%% </li> </ul>
+describe_publisher(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_publisher(Client, Input, []).
+describe_publisher(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribePublisher">>, Input, Options).
 
 %% @doc Returns information about a stack drift detection operation.
 %%
@@ -372,7 +457,7 @@ describe_stack_drift_detection_status(Client, Input, Options)
 %% chronological order.
 %%
 %% For more information about a stack's event history, go to Stacks in the
-%% AWS CloudFormation User Guide.
+%% CloudFormation User Guide.
 %%
 %% You can list events for stacks that have failed to create or have been
 %% deleted by specifying the unique stack identifier (stack ID).
@@ -384,7 +469,7 @@ describe_stack_events(Client, Input, Options)
     request(Client, <<"DescribeStackEvents">>, Input, Options).
 
 %% @doc Returns the stack instance that's associated with the specified stack
-%% set, AWS account, and Region.
+%% set, Amazon Web Services account, and Region.
 %%
 %% For a list of stack instances that are associated with a specific stack
 %% set, use `ListStackInstances'.
@@ -411,10 +496,10 @@ describe_stack_resource(Client, Input, Options)
 %% for drift in the specified stack.
 %%
 %% This includes actual and expected configuration values for resources where
-%% AWS CloudFormation detects configuration drift.
+%% CloudFormation detects configuration drift.
 %%
 %% For a given stack, there will be one `StackResourceDrift' for each stack
-%% resource that has been checked for drift. Resources that have not yet been
+%% resource that has been checked for drift. Resources that haven't yet been
 %% checked for drift are not included. Resources that do not currently
 %% support drift detection are not checked, and so not included. For a list
 %% of resources that support drift detection, see Resources that Support
@@ -430,7 +515,8 @@ describe_stack_resource_drifts(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeStackResourceDrifts">>, Input, Options).
 
-%% @doc Returns AWS resource descriptions for running and deleted stacks.
+%% @doc Returns Amazon Web Services resource descriptions for running and
+%% deleted stacks.
 %%
 %% If `StackName' is specified, all the associated resources that are part of
 %% the stack are returned. If `PhysicalResourceId' is specified, the
@@ -446,7 +532,7 @@ describe_stack_resource_drifts(Client, Input, Options)
 %% You must specify either `StackName' or `PhysicalResourceId', but not both.
 %% In addition, you can specify `LogicalResourceId' to filter the returned
 %% result. For more information about resources, the `LogicalResourceId' and
-%% `PhysicalResourceId', go to the AWS CloudFormation User Guide.
+%% `PhysicalResourceId', go to the CloudFormation User Guide.
 %%
 %% A `ValidationError' is returned if you specify both `StackName' and
 %% `PhysicalResourceId' in the same request.
@@ -476,8 +562,7 @@ describe_stack_set_operation(Client, Input, Options)
 %% @doc Returns the description for the specified stack; if no stack name was
 %% specified, then it returns the description for all the stacks created.
 %%
-%% If the stack does not exist, an `AmazonCloudFormationException' is
-%% returned.
+%% If the stack does not exist, an `ValidationError' is returned.
 describe_stacks(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_stacks(Client, Input, []).
@@ -518,7 +603,7 @@ describe_type_registration(Client, Input, Options)
 %% drifted, from it's expected configuration, as defined in the stack
 %% template and any values specified as template parameters.
 %%
-%% For each resource in the stack that supports drift detection, AWS
+%% For each resource in the stack that supports drift detection,
 %% CloudFormation compares the actual configuration of the resource with its
 %% expected template configuration. Only resource properties explicitly
 %% defined in the stack template are checked for drift. A stack is considered
@@ -540,8 +625,8 @@ describe_type_registration(Client, Input, Options)
 %% use `DescribeStackResourceDrifts' to return drift information about the
 %% stack and its resources.
 %%
-%% When detecting drift on a stack, AWS CloudFormation does not detect drift
-%% on any nested stacks belonging to that stack. Perform `DetectStackDrift'
+%% When detecting drift on a stack, CloudFormation does not detect drift on
+%% any nested stacks belonging to that stack. Perform `DetectStackDrift'
 %% directly on the nested stack itself.
 detect_stack_drift(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -555,10 +640,10 @@ detect_stack_drift(Client, Input, Options)
 %% the stack template and any values specified as template parameters.
 %%
 %% This information includes actual and expected property values for
-%% resources in which AWS CloudFormation detects drift. Only resource
-%% properties explicitly defined in the stack template are checked for drift.
-%% For more information about stack and resource drift, see Detecting
-%% Unregulated Configuration Changes to Stacks and Resources.
+%% resources in which CloudFormation detects drift. Only resource properties
+%% explicitly defined in the stack template are checked for drift. For more
+%% information about stack and resource drift, see Detecting Unregulated
+%% Configuration Changes to Stacks and Resources.
 %%
 %% Use `DetectStackResourceDrift' to detect drift on individual resources, or
 %% `DetectStackDrift' to detect drift on all resources in a given stack that
@@ -621,8 +706,9 @@ detect_stack_set_drift(Client, Input, Options)
 
 %% @doc Returns the estimated monthly cost of a template.
 %%
-%% The return value is an AWS Simple Monthly Calculator URL with a query
-%% string that describes the resources required to run the template.
+%% The return value is an Amazon Web Services Simple Monthly Calculator URL
+%% with a query string that describes the resources required to run the
+%% template.
 estimate_template_cost(Client, Input)
   when is_map(Client), is_map(Input) ->
     estimate_template_cost(Client, Input, []).
@@ -633,17 +719,16 @@ estimate_template_cost(Client, Input, Options)
 %% @doc Updates a stack using the input information that was provided when
 %% the specified change set was created.
 %%
-%% After the call successfully completes, AWS CloudFormation starts updating
-%% the stack. Use the `DescribeStacks' action to view the status of the
-%% update.
+%% After the call successfully completes, CloudFormation starts updating the
+%% stack. Use the `DescribeStacks' action to view the status of the update.
 %%
-%% When you execute a change set, AWS CloudFormation deletes all other change
+%% When you execute a change set, CloudFormation deletes all other change
 %% sets associated with the stack because they aren't valid for the updated
 %% stack.
 %%
-%% If a stack policy is associated with the stack, AWS CloudFormation
-%% enforces the policy during the update. You can't specify a temporary stack
-%% policy that overrides the current policy.
+%% If a stack policy is associated with the stack, CloudFormation enforces
+%% the policy during the update. You can't specify a temporary stack policy
+%% that overrides the current policy.
 %%
 %% To create a change set for the entire stack hierachy,
 %% `IncludeNestedStacks' must have been set to `True'.
@@ -699,9 +784,24 @@ get_template_summary(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetTemplateSummary">>, Input, Options).
 
+%% @doc Import existing stacks into a new stack sets.
+%%
+%% Use the stack import operation to import up to 10 stacks into a new stack
+%% set in the same account as the source stack or in a different
+%% administrator account and Region, by specifying the stack ID of the stack
+%% you intend to import.
+%%
+%% `ImportStacksToStackSet' is only supported by self-managed permissions.
+import_stacks_to_stack_set(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    import_stacks_to_stack_set(Client, Input, []).
+import_stacks_to_stack_set(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ImportStacksToStackSet">>, Input, Options).
+
 %% @doc Returns the ID and status of each active change set for a stack.
 %%
-%% For example, AWS CloudFormation lists change sets that are in the
+%% For example, CloudFormation lists change sets that are in the
 %% `CREATE_IN_PROGRESS' or `CREATE_PENDING' state.
 list_change_sets(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -716,7 +816,7 @@ list_change_sets(Client, Input, Options)
 %% Use this action to see the exported output values that you can import into
 %% other stacks. To import values, use the `Fn::ImportValue' function.
 %%
-%% For more information, see AWS CloudFormation Export Stack Output Values.
+%% For more information, see CloudFormation Export Stack Output Values.
 list_exports(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_exports(Client, Input, []).
@@ -742,8 +842,9 @@ list_imports(Client, Input, Options)
 %% @doc Returns summary information about stack instances that are associated
 %% with the specified stack set.
 %%
-%% You can filter for stack instances that are associated with a specific AWS
-%% account name or Region, or that have a specific status.
+%% You can filter for stack instances that are associated with a specific
+%% Amazon Web Services account name or Region, or that have a specific
+%% status.
 list_stack_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_stack_instances(Client, Input, []).
@@ -784,8 +885,9 @@ list_stack_set_operations(Client, Input, Options)
 %% the user.
 %%
 %% <ul> <li> [Self-managed permissions] If you set the `CallAs' parameter to
-%% `SELF' while signed in to your AWS account, `ListStackSets' returns all
-%% self-managed stack sets in your AWS account.
+%% `SELF' while signed in to your Amazon Web Services account,
+%% `ListStackSets' returns all self-managed stack sets in your Amazon Web
+%% Services account.
 %%
 %% </li> <li> [Service-managed permissions] If you set the `CallAs' parameter
 %% to `SELF' while signed in to the organization's management account,
@@ -843,6 +945,22 @@ list_types(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListTypes">>, Input, Options).
 
+%% @doc Publishes the specified extension to the CloudFormation registry as a
+%% public extension in this region.
+%%
+%% Public extensions are available for use by all CloudFormation users. For
+%% more information on publishing extensions, see Publishing extensions to
+%% make them available for public use in the CloudFormation CLI User Guide.
+%%
+%% To publish an extension, you must be registered as a publisher with
+%% CloudFormation. For more information, see RegisterPublisher.
+publish_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    publish_type(Client, Input, []).
+publish_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PublishType">>, Input, Options).
+
 %% @doc Reports progress of a resource handler to CloudFormation.
 %%
 %% Reserved for use by the CloudFormation CLI. Do not use this API in your
@@ -854,10 +972,26 @@ record_handler_progress(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RecordHandlerProgress">>, Input, Options).
 
+%% @doc Registers your account as a publisher of public extensions in the
+%% CloudFormation registry.
+%%
+%% Public extensions are available for use by all CloudFormation users. This
+%% publisher ID applies to your account in all Amazon Web Services Regions.
+%%
+%% For information on requirements for registering as a public extension
+%% publisher, see Registering your account to publish CloudFormation
+%% extensions in the CloudFormation CLI User Guide.
+register_publisher(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    register_publisher(Client, Input, []).
+register_publisher(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RegisterPublisher">>, Input, Options).
+
 %% @doc Registers an extension with the CloudFormation service.
 %%
 %% Registering an extension makes it available for use in CloudFormation
-%% templates in your AWS account, and includes:
+%% templates in your Amazon Web Services account, and includes:
 %%
 %% <ul> <li> Validating the extension schema
 %%
@@ -877,12 +1011,47 @@ record_handler_progress(Client, Input, Options)
 %% Once you have initiated a registration request using ` `RegisterType' ',
 %% you can use ` `DescribeTypeRegistration' ' to monitor the progress of the
 %% registration request.
+%%
+%% Once you have registered a private extension in your account and region,
+%% use SetTypeConfiguration to specify configuration properties for the
+%% extension. For more information, see Configuring extensions at the account
+%% level in the CloudFormation User Guide.
 register_type(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_type(Client, Input, []).
 register_type(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RegisterType">>, Input, Options).
+
+%% @doc When specifying `RollbackStack', you preserve the state of previously
+%% provisioned resources when an operation fails.
+%%
+%% You can check the status of the stack through the `DescribeStacks' API.
+%%
+%% Rolls back the specified stack to the last known stable state from
+%% `CREATE_FAILED' or `UPDATE_FAILED' stack statuses.
+%%
+%% This operation will delete a stack if it doesn't contain a last known
+%% stable state. A last known stable state includes any status in a
+%% `*_COMPLETE'. This includes the following stack statuses.
+%%
+%% <ul> <li> `CREATE_COMPLETE'
+%%
+%% </li> <li> `UPDATE_COMPLETE'
+%%
+%% </li> <li> `UPDATE_ROLLBACK_COMPLETE'
+%%
+%% </li> <li> `IMPORT_COMPLETE'
+%%
+%% </li> <li> `IMPORT_ROLLBACK_COMPLETE'
+%%
+%% </li> </ul>
+rollback_stack(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    rollback_stack(Client, Input, []).
+rollback_stack(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RollbackStack">>, Input, Options).
 
 %% @doc Sets a stack policy for a specified stack.
 set_stack_policy(Client, Input)
@@ -891,6 +1060,25 @@ set_stack_policy(Client, Input)
 set_stack_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SetStackPolicy">>, Input, Options).
+
+%% @doc Specifies the configuration data for a registered CloudFormation
+%% extension, in the given account and region.
+%%
+%% To view the current configuration data for an extension, refer to the
+%% `ConfigurationSchema' element of DescribeType. For more information, see
+%% Configuring extensions at the account level in the CloudFormation User
+%% Guide.
+%%
+%% It is strongly recommended that you use dynamic references to restrict
+%% sensitive configuration definitions, such as third-party credentials. For
+%% more details on dynamic references, see Using dynamic references to
+%% specify template values in the CloudFormation User Guide.
+set_type_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    set_type_configuration(Client, Input, []).
+set_type_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SetTypeConfiguration">>, Input, Options).
 
 %% @doc Specify the default version of an extension.
 %%
@@ -907,8 +1095,8 @@ set_type_default_version(Client, Input, Options)
 %% status.
 %%
 %% You can use the SignalResource API in conjunction with a creation policy
-%% or update policy. AWS CloudFormation doesn't proceed with a stack creation
-%% or update until resources receive the required number of signals or the
+%% or update policy. CloudFormation doesn't proceed with a stack creation or
+%% update until resources receive the required number of signals or the
 %% timeout period is exceeded. The SignalResource API is useful in cases
 %% where you want to send signals from anywhere other than an Amazon EC2
 %% instance.
@@ -927,6 +1115,38 @@ stop_stack_set_operation(Client, Input)
 stop_stack_set_operation(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StopStackSetOperation">>, Input, Options).
+
+%% @doc Tests a registered extension to make sure it meets all necessary
+%% requirements for being published in the CloudFormation registry.
+%%
+%% <ul> <li> For resource types, this includes passing all contracts tests
+%% defined for the type.
+%%
+%% </li> <li> For modules, this includes determining if the module's model
+%% meets all necessary requirements.
+%%
+%% </li> </ul> For more information, see Testing your public extension prior
+%% to publishing in the CloudFormation CLI User Guide.
+%%
+%% If you do not specify a version, CloudFormation uses the default version
+%% of the extension in your account and region for testing.
+%%
+%% To perform testing, CloudFormation assumes the execution role specified
+%% when the type was registered. For more information, see RegisterType.
+%%
+%% Once you've initiated testing on an extension using `TestType', you can
+%% use DescribeType to monitor the current test status and test status
+%% description for the extension.
+%%
+%% An extension must have a test status of `PASSED' before it can be
+%% published. For more information, see Publishing extensions to make them
+%% available for public use in the CloudFormation CLI User Guide.
+test_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    test_type(Client, Input, []).
+test_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TestType">>, Input, Options).
 
 %% @doc Updates a stack as specified in the template.
 %%
@@ -991,7 +1211,7 @@ update_stack_set(Client, Input, Options)
 %%
 %% If a user attempts to delete a stack with termination protection enabled,
 %% the operation fails and the stack remains unchanged. For more information,
-%% see Protecting a Stack From Being Deleted in the AWS CloudFormation User
+%% see Protecting a Stack From Being Deleted in the CloudFormation User
 %% Guide.
 %%
 %% For nested stacks, termination protection is set on the root stack and
@@ -1005,9 +1225,9 @@ update_termination_protection(Client, Input, Options)
 
 %% @doc Validates a specified template.
 %%
-%% AWS CloudFormation first checks if the template is valid JSON. If it
-%% isn't, AWS CloudFormation checks if the template is valid YAML. If both
-%% these checks fail, AWS CloudFormation returns a template validation error.
+%% CloudFormation first checks if the template is valid JSON. If it isn't,
+%% CloudFormation checks if the template is valid YAML. If both these checks
+%% fail, CloudFormation returns a template validation error.
 validate_template(Client, Input)
   when is_map(Client), is_map(Input) ->
     validate_template(Client, Input, []).

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -10,7 +10,9 @@
 %% about CloudFront features, see the Amazon CloudFront Developer Guide.
 -module(aws_cloudfront).
 
--export([create_cache_policy/2,
+-export([associate_alias/3,
+         associate_alias/4,
+         create_cache_policy/2,
          create_cache_policy/3,
          create_cloud_front_origin_access_identity/2,
          create_cloud_front_origin_access_identity/3,
@@ -22,6 +24,8 @@
          create_field_level_encryption_config/3,
          create_field_level_encryption_profile/2,
          create_field_level_encryption_profile/3,
+         create_function/2,
+         create_function/3,
          create_invalidation/3,
          create_invalidation/4,
          create_key_group/2,
@@ -34,6 +38,8 @@
          create_public_key/3,
          create_realtime_log_config/2,
          create_realtime_log_config/3,
+         create_response_headers_policy/2,
+         create_response_headers_policy/3,
          create_streaming_distribution/2,
          create_streaming_distribution/3,
          create_streaming_distribution_with_tags/2,
@@ -48,6 +54,8 @@
          delete_field_level_encryption_config/4,
          delete_field_level_encryption_profile/3,
          delete_field_level_encryption_profile/4,
+         delete_function/3,
+         delete_function/4,
          delete_key_group/3,
          delete_key_group/4,
          delete_monitoring_subscription/3,
@@ -58,8 +66,13 @@
          delete_public_key/4,
          delete_realtime_log_config/2,
          delete_realtime_log_config/3,
+         delete_response_headers_policy/3,
+         delete_response_headers_policy/4,
          delete_streaming_distribution/3,
          delete_streaming_distribution/4,
+         describe_function/2,
+         describe_function/4,
+         describe_function/5,
          get_cache_policy/2,
          get_cache_policy/4,
          get_cache_policy/5,
@@ -90,6 +103,9 @@
          get_field_level_encryption_profile_config/2,
          get_field_level_encryption_profile_config/4,
          get_field_level_encryption_profile_config/5,
+         get_function/2,
+         get_function/4,
+         get_function/5,
          get_invalidation/3,
          get_invalidation/5,
          get_invalidation/6,
@@ -116,6 +132,12 @@
          get_public_key_config/5,
          get_realtime_log_config/2,
          get_realtime_log_config/3,
+         get_response_headers_policy/2,
+         get_response_headers_policy/4,
+         get_response_headers_policy/5,
+         get_response_headers_policy_config/2,
+         get_response_headers_policy_config/4,
+         get_response_headers_policy_config/5,
          get_streaming_distribution/2,
          get_streaming_distribution/4,
          get_streaming_distribution/5,
@@ -128,6 +150,9 @@
          list_cloud_front_origin_access_identities/1,
          list_cloud_front_origin_access_identities/3,
          list_cloud_front_origin_access_identities/4,
+         list_conflicting_aliases/3,
+         list_conflicting_aliases/5,
+         list_conflicting_aliases/6,
          list_distributions/1,
          list_distributions/3,
          list_distributions/4,
@@ -142,6 +167,9 @@
          list_distributions_by_origin_request_policy_id/5,
          list_distributions_by_realtime_log_config/2,
          list_distributions_by_realtime_log_config/3,
+         list_distributions_by_response_headers_policy_id/2,
+         list_distributions_by_response_headers_policy_id/4,
+         list_distributions_by_response_headers_policy_id/5,
          list_distributions_by_web_acl_id/2,
          list_distributions_by_web_acl_id/4,
          list_distributions_by_web_acl_id/5,
@@ -151,6 +179,9 @@
          list_field_level_encryption_profiles/1,
          list_field_level_encryption_profiles/3,
          list_field_level_encryption_profiles/4,
+         list_functions/1,
+         list_functions/3,
+         list_functions/4,
          list_invalidations/2,
          list_invalidations/4,
          list_invalidations/5,
@@ -166,14 +197,21 @@
          list_realtime_log_configs/1,
          list_realtime_log_configs/3,
          list_realtime_log_configs/4,
+         list_response_headers_policies/1,
+         list_response_headers_policies/3,
+         list_response_headers_policies/4,
          list_streaming_distributions/1,
          list_streaming_distributions/3,
          list_streaming_distributions/4,
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
+         publish_function/3,
+         publish_function/4,
          tag_resource/2,
          tag_resource/3,
+         test_function/3,
+         test_function/4,
          untag_resource/2,
          untag_resource/3,
          update_cache_policy/3,
@@ -186,6 +224,8 @@
          update_field_level_encryption_config/4,
          update_field_level_encryption_profile/3,
          update_field_level_encryption_profile/4,
+         update_function/3,
+         update_function/4,
          update_key_group/3,
          update_key_group/4,
          update_origin_request_policy/3,
@@ -194,6 +234,8 @@
          update_public_key/4,
          update_realtime_log_config/2,
          update_realtime_log_config/3,
+         update_response_headers_policy/3,
+         update_response_headers_policy/4,
          update_streaming_distribution/3,
          update_streaming_distribution/4]).
 
@@ -202,6 +244,44 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Associates an alias (also known as a CNAME or an alternate domain
+%% name) with a CloudFront distribution.
+%%
+%% With this operation you can move an alias that’s already in use on a
+%% CloudFront distribution to a different distribution in one step. This
+%% prevents the downtime that could occur if you first remove the alias from
+%% one distribution and then separately add the alias to another
+%% distribution.
+%%
+%% To use this operation to associate an alias with a distribution, you
+%% provide the alias and the ID of the target distribution for the alias. For
+%% more information, including how to set up the target distribution,
+%% prerequisites that you must complete, and other restrictions, see Moving
+%% an alternate domain name to a different distribution in the Amazon
+%% CloudFront Developer Guide.
+associate_alias(Client, TargetDistributionId, Input) ->
+    associate_alias(Client, TargetDistributionId, Input, []).
+associate_alias(Client, TargetDistributionId, Input0, Options0) ->
+    Method = put,
+    Path = ["/2020-05-31/distribution/", aws_util:encode_uri(TargetDistributionId), "/associate-alias"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"Alias">>, <<"Alias">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a cache policy.
 %%
@@ -450,6 +530,59 @@ create_field_level_encryption_profile(Client, Input) ->
 create_field_level_encryption_profile(Client, Input0, Options0) ->
     Method = post,
     Path = ["/2020-05-31/field-level-encryption-profile"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>},
+            {<<"Location">>, <<"Location">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
+%% @doc Creates a CloudFront function.
+%%
+%% To create a function, you provide the function code and some configuration
+%% information about the function. The response contains an Amazon Resource
+%% Name (ARN) that uniquely identifies the function.
+%%
+%% When you create a function, it’s in the `DEVELOPMENT' stage. In this
+%% stage, you can test the function with `TestFunction', and update it with
+%% `UpdateFunction'.
+%%
+%% When you’re ready to use your function with a CloudFront distribution, use
+%% `PublishFunction' to copy the function from the `DEVELOPMENT' stage to
+%% `LIVE'. When it’s live, you can attach the function to a distribution’s
+%% cache behavior, using the function’s ARN.
+create_function(Client, Input) ->
+    create_function(Client, Input, []).
+create_function(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-05-31/function"],
     SuccessStatusCode = 201,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -738,6 +871,56 @@ create_realtime_log_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates a response headers policy.
+%%
+%% A response headers policy contains information about a set of HTTP
+%% response headers and their values. To create a response headers policy,
+%% you provide some metadata about the policy, and a set of configurations
+%% that specify the response headers.
+%%
+%% After you create a response headers policy, you can use its ID to attach
+%% it to one or more cache behaviors in a CloudFront distribution. When it’s
+%% attached to a cache behavior, CloudFront adds the headers in the policy to
+%% HTTP responses that it sends for requests that match the cache behavior.
+create_response_headers_policy(Client, Input) ->
+    create_response_headers_policy(Client, Input, []).
+create_response_headers_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-05-31/response-headers-policy"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>},
+            {<<"Location">>, <<"Location">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
 %% @doc This API is deprecated.
 %%
 %% Amazon CloudFront is deprecating real-time messaging protocol (RTMP)
@@ -959,6 +1142,39 @@ delete_field_level_encryption_profile(Client, Id, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes a CloudFront function.
+%%
+%% You cannot delete a function if it’s associated with a cache behavior.
+%% First, update your distributions to remove the function association from
+%% all cache behaviors, then delete the function.
+%%
+%% To delete a function, you must provide the function’s name and version
+%% (`ETag' value). To get these values, you can use `ListFunctions' and
+%% `DescribeFunction'.
+delete_function(Client, Name, Input) ->
+    delete_function(Client, Name, Input, []).
+delete_function(Client, Name, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes a key group.
 %%
 %% You cannot delete a key group that is referenced in a cache behavior.
@@ -1107,6 +1323,39 @@ delete_realtime_log_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes a response headers policy.
+%%
+%% You cannot delete a response headers policy if it’s attached to a cache
+%% behavior. First update your distributions to remove the response headers
+%% policy from all cache behaviors, then delete the response headers policy.
+%%
+%% To delete a response headers policy, you must provide the policy’s
+%% identifier and version. To get these values, you can use
+%% `ListResponseHeadersPolicies' or `GetResponseHeadersPolicy'.
+delete_response_headers_policy(Client, Id, Input) ->
+    delete_response_headers_policy(Client, Id, Input, []).
+delete_response_headers_policy(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-05-31/response-headers-policy/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Delete a streaming distribution.
 %%
 %% To delete an RTMP distribution using the CloudFront API, perform the
@@ -1171,6 +1420,56 @@ delete_streaming_distribution(Client, Id, Input0, Options0) ->
     Input = Input2,
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets configuration information and metadata about a CloudFront
+%% function, but not the function’s code.
+%%
+%% To get a function’s code, use `GetFunction'.
+%%
+%% To get configuration information and metadata about a function, you must
+%% provide the function’s name and stage. To get these values, you can use
+%% `ListFunctions'.
+describe_function(Client, Name)
+  when is_map(Client) ->
+    describe_function(Client, Name, #{}, #{}).
+
+describe_function(Client, Name, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_function(Client, Name, QueryMap, HeadersMap, []).
+
+describe_function(Client, Name, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), "/describe"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Stage">>, maps:get(<<"Stage">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    case request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
 
 %% @doc Gets a cache policy, including the following metadata:
 %%
@@ -1578,6 +1877,56 @@ get_field_level_encryption_profile_config(Client, Id, QueryMap, HeadersMap, Opti
         Result
     end.
 
+%% @doc Gets the code of a CloudFront function.
+%%
+%% To get configuration information and metadata about a function, use
+%% `DescribeFunction'.
+%%
+%% To get a function’s code, you must provide the function’s name and stage.
+%% To get these values, you can use `ListFunctions'.
+get_function(Client, Name)
+  when is_map(Client) ->
+    get_function(Client, Name, #{}, #{}).
+
+get_function(Client, Name, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_function(Client, Name, QueryMap, HeadersMap, []).
+
+get_function(Client, Name, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Stage">>, maps:get(<<"Stage">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    case request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"Content-Type">>, <<"ContentType">>},
+            {<<"ETag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
 %% @doc Get the information about an invalidation.
 get_invalidation(Client, DistributionId, Id)
   when is_map(Client) ->
@@ -1918,6 +2267,99 @@ get_realtime_log_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Gets a response headers policy, including metadata (the policy’s
+%% identifier and the date and time when the policy was last modified).
+%%
+%% To get a response headers policy, you must provide the policy’s
+%% identifier. If the response headers policy is attached to a distribution’s
+%% cache behavior, you can get the policy’s identifier using
+%% `ListDistributions' or `GetDistribution'. If the response headers policy
+%% is not attached to a cache behavior, you can get the identifier using
+%% `ListResponseHeadersPolicies'.
+get_response_headers_policy(Client, Id)
+  when is_map(Client) ->
+    get_response_headers_policy(Client, Id, #{}, #{}).
+
+get_response_headers_policy(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_response_headers_policy(Client, Id, QueryMap, HeadersMap, []).
+
+get_response_headers_policy(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/response-headers-policy/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    case request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
+%% @doc Gets a response headers policy configuration.
+%%
+%% To get a response headers policy configuration, you must provide the
+%% policy’s identifier. If the response headers policy is attached to a
+%% distribution’s cache behavior, you can get the policy’s identifier using
+%% `ListDistributions' or `GetDistribution'. If the response headers policy
+%% is not attached to a cache behavior, you can get the identifier using
+%% `ListResponseHeadersPolicies'.
+get_response_headers_policy_config(Client, Id)
+  when is_map(Client) ->
+    get_response_headers_policy_config(Client, Id, #{}, #{}).
+
+get_response_headers_policy_config(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_response_headers_policy_config(Client, Id, QueryMap, HeadersMap, []).
+
+get_response_headers_policy_config(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/response-headers-policy/", aws_util:encode_uri(Id), "/config"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    case request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
 %% @doc Gets information about a specified RTMP distribution, including the
 %% distribution configuration.
 get_streaming_distribution(Client, Id)
@@ -2000,7 +2442,8 @@ get_streaming_distribution_config(Client, Id, QueryMap, HeadersMap, Options0)
 %% @doc Gets a list of cache policies.
 %%
 %% You can optionally apply a filter to return only the managed policies
-%% created by AWS, or only the custom policies created in your AWS account.
+%% created by Amazon Web Services, or only the custom policies created in
+%% your Amazon Web Services account.
 %%
 %% You can optionally specify the maximum number of items to receive in the
 %% response. If the total number of items in the list exceeds the maximum
@@ -2057,6 +2500,65 @@ list_cloud_front_origin_access_identities(Client, QueryMap, HeadersMap, Options0
 
     Query0_ =
       [
+        {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
+        {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets a list of aliases (also called CNAMEs or alternate domain names)
+%% that conflict or overlap with the provided alias, and the associated
+%% CloudFront distributions and Amazon Web Services accounts for each
+%% conflicting alias.
+%%
+%% In the returned list, the distribution and account IDs are partially
+%% hidden, which allows you to identify the distributions and accounts that
+%% you own, but helps to protect the information of ones that you don’t own.
+%%
+%% Use this operation to find aliases that are in use in CloudFront that
+%% conflict or overlap with the provided alias. For example, if you provide
+%% `www.example.com' as input, the returned list can include
+%% `www.example.com' and the overlapping wildcard alternate domain name
+%% (`*.example.com'), if they exist. If you provide `*.example.com' as input,
+%% the returned list can include `*.example.com' and any alternate domain
+%% names covered by that wildcard (for example, `www.example.com',
+%% `test.example.com', `dev.example.com', and so on), if they exist.
+%%
+%% To list conflicting aliases, you provide the alias to search and the ID of
+%% a distribution in your account that has an attached SSL/TLS certificate
+%% that includes the provided alias. For more information, including how to
+%% set up the distribution and certificate, see Moving an alternate domain
+%% name to a different distribution in the Amazon CloudFront Developer Guide.
+%%
+%% You can optionally specify the maximum number of items to receive in the
+%% response. If the total number of items in the list exceeds the maximum
+%% that you specify, or the default maximum, the response is paginated. To
+%% get the next page of items, send a subsequent request that specifies the
+%% `NextMarker' value from the current response as the `Marker' value in the
+%% subsequent request.
+list_conflicting_aliases(Client, Alias, DistributionId)
+  when is_map(Client) ->
+    list_conflicting_aliases(Client, Alias, DistributionId, #{}, #{}).
+
+list_conflicting_aliases(Client, Alias, DistributionId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_conflicting_aliases(Client, Alias, DistributionId, QueryMap, HeadersMap, []).
+
+list_conflicting_aliases(Client, Alias, DistributionId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/conflicting-alias"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Alias">>, Alias},
+        {<<"DistributionId">>, DistributionId},
         {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
         {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)}
       ],
@@ -2236,8 +2738,44 @@ list_distributions_by_realtime_log_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc List the distributions that are associated with a specified AWS WAF
-%% web ACL.
+%% @doc Gets a list of distribution IDs for distributions that have a cache
+%% behavior that’s associated with the specified response headers policy.
+%%
+%% You can optionally specify the maximum number of items to receive in the
+%% response. If the total number of items in the list exceeds the maximum
+%% that you specify, or the default maximum, the response is paginated. To
+%% get the next page of items, send a subsequent request that specifies the
+%% `NextMarker' value from the current response as the `Marker' value in the
+%% subsequent request.
+list_distributions_by_response_headers_policy_id(Client, ResponseHeadersPolicyId)
+  when is_map(Client) ->
+    list_distributions_by_response_headers_policy_id(Client, ResponseHeadersPolicyId, #{}, #{}).
+
+list_distributions_by_response_headers_policy_id(Client, ResponseHeadersPolicyId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_distributions_by_response_headers_policy_id(Client, ResponseHeadersPolicyId, QueryMap, HeadersMap, []).
+
+list_distributions_by_response_headers_policy_id(Client, ResponseHeadersPolicyId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/distributionsByResponseHeadersPolicyId/", aws_util:encode_uri(ResponseHeadersPolicyId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
+        {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List the distributions that are associated with a specified WAF web
+%% ACL.
 list_distributions_by_web_acl_id(Client, WebACLId)
   when is_map(Client) ->
     list_distributions_by_web_acl_id(Client, WebACLId, #{}, #{}).
@@ -2323,6 +2861,46 @@ list_field_level_encryption_profiles(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets a list of all CloudFront functions in your Amazon Web Services
+%% account.
+%%
+%% You can optionally apply a filter to return only the functions that are in
+%% the specified stage, either `DEVELOPMENT' or `LIVE'.
+%%
+%% You can optionally specify the maximum number of items to receive in the
+%% response. If the total number of items in the list exceeds the maximum
+%% that you specify, or the default maximum, the response is paginated. To
+%% get the next page of items, send a subsequent request that specifies the
+%% `NextMarker' value from the current response as the `Marker' value in the
+%% subsequent request.
+list_functions(Client)
+  when is_map(Client) ->
+    list_functions(Client, #{}, #{}).
+
+list_functions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_functions(Client, QueryMap, HeadersMap, []).
+
+list_functions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/function"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
+        {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)},
+        {<<"Stage">>, maps:get(<<"Stage">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Lists invalidation batches.
 list_invalidations(Client, DistributionId)
   when is_map(Client) ->
@@ -2389,7 +2967,8 @@ list_key_groups(Client, QueryMap, HeadersMap, Options0)
 %% @doc Gets a list of origin request policies.
 %%
 %% You can optionally apply a filter to return only the managed policies
-%% created by AWS, or only the custom policies created in your AWS account.
+%% created by Amazon Web Services, or only the custom policies created in
+%% your Amazon Web Services account.
 %%
 %% You can optionally specify the maximum number of items to receive in the
 %% response. If the total number of items in the list exceeds the maximum
@@ -2489,6 +3068,46 @@ list_realtime_log_configs(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets a list of response headers policies.
+%%
+%% You can optionally apply a filter to get only the managed policies created
+%% by Amazon Web Services, or only the custom policies created in your Amazon
+%% Web Services account.
+%%
+%% You can optionally specify the maximum number of items to receive in the
+%% response. If the total number of items in the list exceeds the maximum
+%% that you specify, or the default maximum, the response is paginated. To
+%% get the next page of items, send a subsequent request that specifies the
+%% `NextMarker' value from the current response as the `Marker' value in the
+%% subsequent request.
+list_response_headers_policies(Client)
+  when is_map(Client) ->
+    list_response_headers_policies(Client, #{}, #{}).
+
+list_response_headers_policies(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_response_headers_policies(Client, QueryMap, HeadersMap, []).
+
+list_response_headers_policies(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-05-31/response-headers-policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
+        {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)},
+        {<<"Type">>, maps:get(<<"Type">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc List streaming distributions.
 list_streaming_distributions(Client)
   when is_map(Client) ->
@@ -2544,6 +3163,43 @@ list_tags_for_resource(Client, Resource, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Publishes a CloudFront function by copying the function code from the
+%% `DEVELOPMENT' stage to `LIVE'.
+%%
+%% This automatically updates all cache behaviors that are using this
+%% function to use the newly published copy in the `LIVE' stage.
+%%
+%% When a function is published to the `LIVE' stage, you can attach the
+%% function to a distribution’s cache behavior, using the function’s Amazon
+%% Resource Name (ARN).
+%%
+%% To publish a function, you must provide the function’s name and version
+%% (`ETag' value). To get these values, you can use `ListFunctions' and
+%% `DescribeFunction'.
+publish_function(Client, Name, Input) ->
+    publish_function(Client, Name, Input, []).
+publish_function(Client, Name, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), "/publish"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Add tags to a CloudFront resource.
 tag_resource(Client, Input) ->
     tag_resource(Client, Input, []).
@@ -2566,6 +3222,43 @@ tag_resource(Client, Input0, Options0) ->
                      {<<"Resource">>, <<"Resource">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Tests a CloudFront function.
+%%
+%% To test a function, you provide an event object that represents an HTTP
+%% request or response that your CloudFront distribution could receive in
+%% production. CloudFront runs the function, passing it the event object that
+%% you provided, and returns the function’s result (the modified event
+%% object) in the response. The response also contains function logs and
+%% error messages, if any exist. For more information about testing
+%% functions, see Testing functions in the Amazon CloudFront Developer Guide.
+%%
+%% To test a function, you provide the function’s name and version (`ETag'
+%% value) along with the event object. To get the function’s name and
+%% version, you can use `ListFunctions' and `DescribeFunction'.
+test_function(Client, Name, Input) ->
+    test_function(Client, Name, Input, []).
+test_function(Client, Name, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), "/test"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Remove tags from a CloudFront resource.
@@ -2878,6 +3571,54 @@ update_field_level_encryption_profile(Client, Id, Input0, Options0) ->
         Result
     end.
 
+%% @doc Updates a CloudFront function.
+%%
+%% You can update a function’s code or the comment that describes the
+%% function. You cannot update a function’s name.
+%%
+%% To update a function, you provide the function’s name and version (`ETag'
+%% value) along with the updated function code. To get the name and version,
+%% you can use `ListFunctions' and `DescribeFunction'.
+update_function(Client, Name, Input) ->
+    update_function(Client, Name, Input, []).
+update_function(Client, Name, Input0, Options0) ->
+    Method = put,
+    Path = ["/2020-05-31/function/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETtag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
 %% @doc Updates a key group.
 %%
 %% When you update a key group, all the fields are updated with the values
@@ -3075,6 +3816,63 @@ update_realtime_log_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates a response headers policy.
+%%
+%% When you update a response headers policy, the entire policy is replaced.
+%% You cannot update some policy fields independent of others. To update a
+%% response headers policy configuration:
+%%
+%% <ol> <li> Use `GetResponseHeadersPolicyConfig' to get the current policy’s
+%% configuration.
+%%
+%% </li> <li> Modify the fields in the response headers policy configuration
+%% that you want to update.
+%%
+%% </li> <li> Call `UpdateResponseHeadersPolicy', providing the entire
+%% response headers policy configuration, including the fields that you
+%% modified and those that you didn’t.
+%%
+%% </li> </ol>
+update_response_headers_policy(Client, Id, Input) ->
+    update_response_headers_policy(Client, Id, Input, []).
+update_response_headers_policy(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/2020-05-31/response-headers-policy/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"If-Match">>, <<"IfMatch">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [
+            {<<"ETag">>, <<"ETag">>}
+          ],
+        FoldFun = fun({Name_, Key_}, Acc_) ->
+                      case lists:keyfind(Name_, 1, ResponseHeaders) of
+                        false -> Acc_;
+                        {_, Value_} -> Acc_#{Key_ => Value_}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.
+
 %% @doc Update a streaming distribution.
 update_streaming_distribution(Client, Id, Input) ->
     update_streaming_distribution(Client, Id, Input, []).
@@ -3152,6 +3950,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_cloudsearchdomain.erl
+++ b/src/aws_cloudsearchdomain.erl
@@ -217,6 +217,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_cloudtrail.erl
+++ b/src/aws_cloudtrail.erl
@@ -1,30 +1,30 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS CloudTrail
+%% @doc CloudTrail
 %%
 %% This is the CloudTrail API Reference.
 %%
 %% It provides descriptions of actions, data types, common parameters, and
 %% common errors for CloudTrail.
 %%
-%% CloudTrail is a web service that records AWS API calls for your AWS
-%% account and delivers log files to an Amazon S3 bucket. The recorded
-%% information includes the identity of the user, the start time of the AWS
-%% API call, the source IP address, the request parameters, and the response
-%% elements returned by the service.
+%% CloudTrail is a web service that records Amazon Web Services API calls for
+%% your Amazon Web Services account and delivers log files to an Amazon S3
+%% bucket. The recorded information includes the identity of the user, the
+%% start time of the Amazon Web Services API call, the source IP address, the
+%% request parameters, and the response elements returned by the service.
 %%
-%% As an alternative to the API, you can use one of the AWS SDKs, which
-%% consist of libraries and sample code for various programming languages and
-%% platforms (Java, Ruby, .NET, iOS, Android, etc.). The SDKs provide a
-%% convenient way to create programmatic access to AWSCloudTrail. For
-%% example, the SDKs take care of cryptographically signing requests,
-%% managing errors, and retrying requests automatically. For information
-%% about the AWS SDKs, including how to download and install them, see the
-%% Tools for Amazon Web Services page.
+%% As an alternative to the API, you can use one of the Amazon Web Services
+%% SDKs, which consist of libraries and sample code for various programming
+%% languages and platforms (Java, Ruby, .NET, iOS, Android, etc.). The SDKs
+%% provide programmatic access to CloudTrail. For example, the SDKs handle
+%% cryptographically signing requests, managing errors, and retrying requests
+%% automatically. For more information about the Amazon Web Services SDKs,
+%% including how to download and install them, see Tools to Build on Amazon
+%% Web Services.
 %%
-%% See the AWS CloudTrail User Guide for information about the data that is
-%% included with each AWS API call listed in the log files.
+%% See the CloudTrail User Guide for information about the data that is
+%% included with each Amazon Web Services API call listed in the log files.
 -module(aws_cloudtrail).
 
 -export([add_tags/2,
@@ -76,9 +76,9 @@
 %% existing tag key. Tag key names must be unique for a trail; you cannot
 %% have two keys with the same name but different values. If you specify a
 %% key without a value, the tag will be created with the specified key and a
-%% value of null. You can tag a trail that applies to all AWS Regions only
-%% from the Region in which the trail was created (also known as its home
-%% region).
+%% value of null. You can tag a trail that applies to all Amazon Web Services
+%% Regions only from the Region in which the trail was created (also known as
+%% its home region).
 add_tags(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_tags(Client, Input, []).
@@ -127,11 +127,11 @@ describe_trails(Client, Input, Options)
 %%
 %% </li> <li> If your event selector includes management events.
 %%
-%% </li> <li> If your event selector includes data events, the Amazon S3
-%% objects or AWS Lambda functions that you are logging for data events.
+%% </li> <li> If your event selector includes data events, the resources on
+%% which you are logging data events.
 %%
 %% </li> </ul> For more information, see Logging Data and Management Events
-%% for Trails in the AWS CloudTrail User Guide.
+%% for Trails in the CloudTrail User Guide.
 get_event_selectors(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_event_selectors(Client, Input, []).
@@ -149,7 +149,7 @@ get_event_selectors(Client, Input, Options)
 %% `InsightNotEnabledException'
 %%
 %% For more information, see Logging CloudTrail Insights Events for Trails in
-%% the AWS CloudTrail User Guide.
+%% the CloudTrail User Guide.
 get_insight_selectors(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_insight_selectors(Client, Input, []).
@@ -185,10 +185,10 @@ get_trail_status(Client, Input, Options)
 %% The public key is needed to validate digest files that were signed with
 %% its corresponding private key.
 %%
-%% CloudTrail uses different private/public key pairs per region. Each digest
-%% file is signed with a private key unique to its region. Therefore, when
-%% you validate a digest file from a particular region, you must look in the
-%% same region for its corresponding public key.
+%% CloudTrail uses different private and public key pairs per region. Each
+%% digest file is signed with a private key unique to its region. When you
+%% validate a digest file from a specific region, you must look in the same
+%% region for its corresponding public key.
 list_public_keys(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_public_keys(Client, Input, []).
@@ -218,7 +218,7 @@ list_trails(Client, Input, Options)
 %% You can look up events that occurred in a region within the last 90 days.
 %% Lookup supports the following attributes for management events:
 %%
-%% <ul> <li> AWS access key
+%% <ul> <li> Amazon Web Services access key
 %%
 %% </li> <li> Event ID
 %%
@@ -292,7 +292,7 @@ lookup_events(Client, Input, Options)
 %%
 %% You can configure up to five event selectors for each trail. For more
 %% information, see Logging data and management events for trails and Quotas
-%% in AWS CloudTrail in the AWS CloudTrail User Guide.
+%% in CloudTrail in the CloudTrail User Guide.
 %%
 %% You can add advanced event selectors, and conditions for your advanced
 %% event selectors, up to a maximum of 500 values for all conditions and
@@ -300,7 +300,7 @@ lookup_events(Client, Input, Options)
 %% `EventSelectors', but not both. If you apply `AdvancedEventSelectors' to a
 %% trail, any existing `EventSelectors' are overwritten. For more information
 %% about advanced event selectors, see Logging data events for trails in the
-%% AWS CloudTrail User Guide.
+%% CloudTrail User Guide.
 put_event_selectors(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_event_selectors(Client, Input, []).
@@ -312,8 +312,8 @@ put_event_selectors(Client, Input, Options)
 %% selectors that you want to enable on an existing trail.
 %%
 %% You also use `PutInsightSelectors' to turn off Insights event logging, by
-%% passing an empty list of insight types. In this release, only
-%% `ApiCallRateInsight' is supported as an Insights selector.
+%% passing an empty list of insight types. The valid Insights event type in
+%% this release is `ApiCallRateInsight'.
 put_insight_selectors(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_insight_selectors(Client, Input, []).
@@ -329,8 +329,8 @@ remove_tags(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveTags">>, Input, Options).
 
-%% @doc Starts the recording of AWS API calls and log file delivery for a
-%% trail.
+%% @doc Starts the recording of Amazon Web Services API calls and log file
+%% delivery for a trail.
 %%
 %% For a trail that is enabled in all regions, this operation must be called
 %% from the region in which the trail was created. This operation cannot be
@@ -343,8 +343,8 @@ start_logging(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartLogging">>, Input, Options).
 
-%% @doc Suspends the recording of AWS API calls and log file delivery for the
-%% specified trail.
+%% @doc Suspends the recording of Amazon Web Services API calls and log file
+%% delivery for the specified trail.
 %%
 %% Under most circumstances, there is no need to use this action. You can
 %% update a trail without stopping it first. This action is the only way to
@@ -360,7 +360,8 @@ stop_logging(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StopLogging">>, Input, Options).
 
-%% @doc Updates the settings that specify delivery of log files.
+%% @doc Updates trail settings that control what events you are logging, and
+%% how to handle log files.
 %%
 %% Changes to a trail do not require stopping the CloudTrail service. Use
 %% this action to designate an existing bucket for log delivery. If the

--- a/src/aws_cloudwatch.erl
+++ b/src/aws_cloudwatch.erl
@@ -1,8 +1,9 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Amazon CloudWatch monitors your Amazon Web Services (AWS) resources
-%% and the applications you run on AWS in real time.
+%% @doc Amazon CloudWatch monitors your Amazon Web Services (Amazon Web
+%% Services) resources and the applications you run on Amazon Web Services in
+%% real time.
 %%
 %% You can use CloudWatch to collect and track metrics, which are the
 %% variables you want to measure for your resources and applications.
@@ -14,10 +15,10 @@
 %% additional instances to handle increased load. You can also use this data
 %% to stop under-used instances to save money.
 %%
-%% In addition to monitoring the built-in metrics that come with AWS, you can
-%% monitor your own custom metrics. With CloudWatch, you gain system-wide
-%% visibility into resource utilization, application performance, and
-%% operational health.
+%% In addition to monitoring the built-in metrics that come with Amazon Web
+%% Services, you can monitor your own custom metrics. With CloudWatch, you
+%% gain system-wide visibility into resource utilization, application
+%% performance, and operational health.
 -module(aws_cloudwatch).
 
 -export([delete_alarms/2,
@@ -28,6 +29,8 @@
          delete_dashboards/3,
          delete_insight_rules/2,
          delete_insight_rules/3,
+         delete_metric_stream/2,
+         delete_metric_stream/3,
          describe_alarm_history/2,
          describe_alarm_history/3,
          describe_alarms/2,
@@ -54,10 +57,14 @@
          get_metric_data/3,
          get_metric_statistics/2,
          get_metric_statistics/3,
+         get_metric_stream/2,
+         get_metric_stream/3,
          get_metric_widget_image/2,
          get_metric_widget_image/3,
          list_dashboards/2,
          list_dashboards/3,
+         list_metric_streams/2,
+         list_metric_streams/3,
          list_metrics/2,
          list_metrics/3,
          list_tags_for_resource/2,
@@ -74,8 +81,14 @@
          put_metric_alarm/3,
          put_metric_data/2,
          put_metric_data/3,
+         put_metric_stream/2,
+         put_metric_stream/3,
          set_alarm_state/2,
          set_alarm_state/3,
+         start_metric_streams/2,
+         start_metric_streams/3,
+         stop_metric_streams/2,
+         stop_metric_streams/3,
          tag_resource/2,
          tag_resource/3,
          untag_resource/2,
@@ -146,6 +159,14 @@ delete_insight_rules(Client, Input)
 delete_insight_rules(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteInsightRules">>, Input, Options).
+
+%% @doc Permanently deletes the metric stream that you specify.
+delete_metric_stream(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_metric_stream(Client, Input, []).
+delete_metric_stream(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteMetricStream">>, Input, Options).
 
 %% @doc Retrieves the history for the specified alarm.
 %%
@@ -412,15 +433,23 @@ get_metric_data(Client, Input, Options)
 %% CloudWatch started retaining 5-minute and 1-hour metric data as of July 9,
 %% 2016.
 %%
-%% For information about metrics and dimensions supported by AWS services,
-%% see the Amazon CloudWatch Metrics and Dimensions Reference in the Amazon
-%% CloudWatch User Guide.
+%% For information about metrics and dimensions supported by Amazon Web
+%% Services services, see the Amazon CloudWatch Metrics and Dimensions
+%% Reference in the Amazon CloudWatch User Guide.
 get_metric_statistics(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_metric_statistics(Client, Input, []).
 get_metric_statistics(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetMetricStatistics">>, Input, Options).
+
+%% @doc Returns information about the metric stream that you specify.
+get_metric_stream(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_metric_stream(Client, Input, []).
+get_metric_stream(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetMetricStream">>, Input, Options).
 
 %% @doc You can use the `GetMetricWidgetImage' API to retrieve a snapshot
 %% graph of one or more Amazon CloudWatch metrics as a bitmap image.
@@ -464,6 +493,14 @@ list_dashboards(Client, Input)
 list_dashboards(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListDashboards">>, Input, Options).
+
+%% @doc Returns a list of metric streams in this account.
+list_metric_streams(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_metric_streams(Client, Input, []).
+list_metric_streams(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListMetricStreams">>, Input, Options).
 
 %% @doc List the specified metrics.
 %%
@@ -629,12 +666,34 @@ put_insight_rule(Client, Input, Options)
 %% </li> <li> The `iam:CreateServiceLinkedRole' to create an alarm with
 %% Systems Manager OpsItem actions.
 %%
-%% </li> </ul> The first time you create an alarm in the AWS Management
-%% Console, the CLI, or by using the PutMetricAlarm API, CloudWatch creates
-%% the necessary service-linked rolea for you. The service-linked roles are
-%% called `AWSServiceRoleForCloudWatchEvents' and
+%% </li> </ul> The first time you create an alarm in the Management Console,
+%% the CLI, or by using the PutMetricAlarm API, CloudWatch creates the
+%% necessary service-linked role for you. The service-linked roles are called
+%% `AWSServiceRoleForCloudWatchEvents' and
 %% `AWSServiceRoleForCloudWatchAlarms_ActionSSM'. For more information, see
-%% AWS service-linked role.
+%% Amazon Web Services service-linked role.
+%%
+%% Cross-account alarms
+%%
+%% You can set an alarm on metrics in the current account, or in another
+%% account. To create a cross-account alarm that watches a metric in a
+%% different account, you must have completed the following pre-requisites:
+%%
+%% <ul> <li> The account where the metrics are located (the sharing account)
+%% must already have a sharing role named CloudWatch-CrossAccountSharingRole.
+%% If it does not already have this role, you must create it using the
+%% instructions in Set up a sharing account in Cross-account cross-Region
+%% CloudWatch console. The policy for that role must grant access to the ID
+%% of the account where you are creating the alarm.
+%%
+%% </li> <li> The account where you are creating the alarm (the monitoring
+%% account) must already have a service-linked role named
+%% AWSServiceRoleForCloudWatchCrossAccount to allow CloudWatch to assume the
+%% sharing role in the sharing account. If it does not, you must create it
+%% following the directions in Set up a monitoring account in Cross-account
+%% cross-Region CloudWatch console.
+%%
+%% </li> </ul>
 put_metric_alarm(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_metric_alarm(Client, Input, []).
@@ -699,6 +758,39 @@ put_metric_data(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutMetricData">>, Input, Options).
 
+%% @doc Creates or updates a metric stream.
+%%
+%% Metric streams can automatically stream CloudWatch metrics to Amazon Web
+%% Services destinations including Amazon S3 and to many third-party
+%% solutions.
+%%
+%% For more information, see Using Metric Streams.
+%%
+%% To create a metric stream, you must be logged on to an account that has
+%% the `iam:PassRole' permission and either the `CloudWatchFullAccess' policy
+%% or the `cloudwatch:PutMetricStream' permission.
+%%
+%% When you create or update a metric stream, you choose one of the
+%% following:
+%%
+%% <ul> <li> Stream metrics from all metric namespaces in the account.
+%%
+%% </li> <li> Stream metrics from all metric namespaces in the account,
+%% except for the namespaces that you list in `ExcludeFilters'.
+%%
+%% </li> <li> Stream metrics from only the metric namespaces that you list in
+%% `IncludeFilters'.
+%%
+%% </li> </ul> When you use `PutMetricStream' to create a new metric stream,
+%% the stream is created in the `running' state. If you use it to update an
+%% existing stream, the state of the stream is not changed.
+put_metric_stream(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_metric_stream(Client, Input, []).
+put_metric_stream(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutMetricStream">>, Input, Options).
+
 %% @doc Temporarily sets the state of an alarm for testing purposes.
 %%
 %% When the updated state differs from the previous value, the action
@@ -727,6 +819,24 @@ set_alarm_state(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SetAlarmState">>, Input, Options).
 
+%% @doc Starts the streaming of metrics for one or more of your metric
+%% streams.
+start_metric_streams(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_metric_streams(Client, Input, []).
+start_metric_streams(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartMetricStreams">>, Input, Options).
+
+%% @doc Stops the streaming of metrics for one or more of your metric
+%% streams.
+stop_metric_streams(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    stop_metric_streams(Client, Input, []).
+stop_metric_streams(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StopMetricStreams">>, Input, Options).
+
 %% @doc Assigns one or more tags (key-value pairs) to the specified
 %% CloudWatch resource.
 %%
@@ -737,8 +847,8 @@ set_alarm_state(Client, Input, Options)
 %% them to scope user permissions by granting a user permission to access or
 %% change only resources with certain tag values.
 %%
-%% Tags don't have any semantic meaning to AWS and are interpreted strictly
-%% as strings of characters.
+%% Tags don't have any semantic meaning to Amazon Web Services and are
+%% interpreted strictly as strings of characters.
 %%
 %% You can use the `TagResource' action with an alarm that already has tags.
 %% If you specify a new tag key for the alarm, this tag is appended to the

--- a/src/aws_cloudwatch_events.erl
+++ b/src/aws_cloudwatch_events.erl
@@ -1,20 +1,20 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Amazon EventBridge helps you to respond to state changes in your AWS
-%% resources.
+%% @doc Amazon EventBridge helps you to respond to state changes in your
+%% Amazon Web Services resources.
 %%
-%% When your resources change state, they automatically send events into an
+%% When your resources change state, they automatically send events to an
 %% event stream. You can create rules that match selected events in the
 %% stream and route them to targets to take action. You can also use rules to
 %% take action on a predetermined schedule. For example, you can configure
 %% rules to:
 %%
-%% <ul> <li> Automatically invoke an AWS Lambda function to update DNS
-%% entries when an event notifies you that Amazon EC2 instance enters the
-%% running state.
+%% <ul> <li> Automatically invoke an Lambda function to update DNS entries
+%% when an event notifies you that Amazon EC2 instance enters the running
+%% state.
 %%
-%% </li> <li> Direct specific API records from AWS CloudTrail to an Amazon
+%% </li> <li> Direct specific API records from CloudTrail to an Amazon
 %% Kinesis data stream for detailed analysis of potential security or
 %% availability risks.
 %%
@@ -201,31 +201,32 @@ create_event_bus(Client, Input, Options)
 
 %% @doc Called by an SaaS partner to create a partner event source.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 %%
-%% Each partner event source can be used by one AWS account to create a
-%% matching partner event bus in that AWS account. A SaaS partner must create
-%% one partner event source for each AWS account that wants to receive those
-%% event types.
+%% Each partner event source can be used by one Amazon Web Services account
+%% to create a matching partner event bus in that Amazon Web Services
+%% account. A SaaS partner must create one partner event source for each
+%% Amazon Web Services account that wants to receive those event types.
 %%
 %% A partner event source creates events based on resources within the SaaS
 %% partner's service or application.
 %%
-%% An AWS account that creates a partner event bus that matches the partner
-%% event source can use that event bus to receive events from the partner,
-%% and then process them using AWS Events rules and targets.
+%% An Amazon Web Services account that creates a partner event bus that
+%% matches the partner event source can use that event bus to receive events
+%% from the partner, and then process them using Amazon Web Services Events
+%% rules and targets.
 %%
 %% Partner event source names follow this format:
 %%
 %% ` partner_name/event_namespace/event_name '
 %%
 %% partner_name is determined during partner registration and identifies the
-%% partner to AWS customers. event_namespace is determined by the partner and
-%% is a way for the partner to categorize their events. event_name is
-%% determined by the partner, and should uniquely identify an
+%% partner to Amazon Web Services customers. event_namespace is determined by
+%% the partner and is a way for the partner to categorize their events.
+%% event_name is determined by the partner, and should uniquely identify an
 %% event-generating resource within the partner system. The combination of
-%% event_namespace and event_name should help AWS customers decide whether to
-%% create an event bus to receive these events.
+%% event_namespace and event_name should help Amazon Web Services customers
+%% decide whether to create an event bus to receive these events.
 create_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_partner_event_source(Client, Input, []).
@@ -242,7 +243,7 @@ create_partner_event_source(Client, Input, Options)
 %% state. If it remains in PENDING state for more than two weeks, it is
 %% deleted.
 %%
-%% To activate a deactivated partner event source, use `ActivateEventSource'.
+%% To activate a deactivated partner event source, use ActivateEventSource.
 deactivate_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     deactivate_event_source(Client, Input, []).
@@ -299,10 +300,10 @@ delete_event_bus(Client, Input, Options)
 %% @doc This operation is used by SaaS partners to delete a partner event
 %% source.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 %%
 %% When you delete an event source, the status of the corresponding partner
-%% event bus in the AWS customer account becomes DELETED.
+%% event bus in the Amazon Web Services customer account becomes DELETED.
 delete_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_partner_event_source(Client, Input, []).
@@ -313,16 +314,20 @@ delete_partner_event_source(Client, Input, Options)
 %% @doc Deletes the specified rule.
 %%
 %% Before you can delete the rule, you must remove all targets, using
-%% `RemoveTargets'.
+%% RemoveTargets.
 %%
 %% When you delete a rule, incoming events might continue to match to the
 %% deleted rule. Allow a short period of time for changes to take effect.
 %%
-%% Managed rules are rules created and managed by another AWS service on your
-%% behalf. These rules are created by those other AWS services to support
-%% functionality in those services. You can delete these rules using the
-%% `Force' option, but you should do so only if you are sure the other
-%% service is not still using that rule.
+%% If you call delete rule multiple times for the same rule, all calls will
+%% succeed. When you call delete rule for a non-existent custom eventbus,
+%% `ResourceNotFoundException' is returned.
+%%
+%% Managed rules are rules created and managed by another Amazon Web Services
+%% service on your behalf. These rules are created by those other Amazon Web
+%% Services services to support functionality in those services. You can
+%% delete these rules using the `Force' option, but you should do so only if
+%% you are sure the other service is not still using that rule.
 delete_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_rule(Client, Input, []).
@@ -356,15 +361,15 @@ describe_connection(Client, Input, Options)
 
 %% @doc Displays details about an event bus in your account.
 %%
-%% This can include the external AWS accounts that are permitted to write
-%% events to your default event bus, and the associated policy. For custom
-%% event buses and partner event buses, it displays the name, ARN, policy,
-%% state, and creation time.
+%% This can include the external Amazon Web Services accounts that are
+%% permitted to write events to your default event bus, and the associated
+%% policy. For custom event buses and partner event buses, it displays the
+%% name, ARN, policy, state, and creation time.
 %%
 %% To enable your account to receive events from other accounts on its
-%% default event bus, use `PutPermission'.
+%% default event bus, use PutPermission.
 %%
-%% For more information about partner event buses, see `CreateEventBus'.
+%% For more information about partner event buses, see CreateEventBus.
 describe_event_bus(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_event_bus(Client, Input, []).
@@ -384,9 +389,9 @@ describe_event_source(Client, Input, Options)
 %% @doc An SaaS partner can use this operation to list details about a
 %% partner event source that they have created.
 %%
-%% AWS customers do not use this operation. Instead, AWS customers can use
-%% `DescribeEventSource' to see details about a partner event source that is
-%% shared with them.
+%% Amazon Web Services customers do not use this operation. Instead, Amazon
+%% Web Services customers can use DescribeEventSource to see details about a
+%% partner event source that is shared with them.
 describe_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_partner_event_source(Client, Input, []).
@@ -415,7 +420,7 @@ describe_replay(Client, Input, Options)
 %% @doc Describes the specified rule.
 %%
 %% DescribeRule does not list the targets of a rule. To see the targets
-%% associated with a rule, use `ListTargetsByRule'.
+%% associated with a rule, use ListTargetsByRule.
 describe_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_rule(Client, Input, []).
@@ -489,9 +494,9 @@ list_event_buses(Client, Input, Options)
     request(Client, <<"ListEventBuses">>, Input, Options).
 
 %% @doc You can use this to see all the partner event sources that have been
-%% shared with your AWS account.
+%% shared with your Amazon Web Services account.
 %%
-%% For more information about partner event sources, see `CreateEventBus'.
+%% For more information about partner event sources, see CreateEventBus.
 list_event_sources(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_event_sources(Client, Input, []).
@@ -499,10 +504,11 @@ list_event_sources(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListEventSources">>, Input, Options).
 
-%% @doc An SaaS partner can use this operation to display the AWS account ID
-%% that a particular partner event source name is associated with.
+%% @doc An SaaS partner can use this operation to display the Amazon Web
+%% Services account ID that a particular partner event source name is
+%% associated with.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 list_partner_event_source_accounts(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_partner_event_source_accounts(Client, Input, []).
@@ -513,7 +519,7 @@ list_partner_event_source_accounts(Client, Input, Options)
 %% @doc An SaaS partner can use this operation to list all the partner event
 %% source names that they have created.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 list_partner_event_sources(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_partner_event_sources(Client, Input, []).
@@ -549,7 +555,7 @@ list_rule_names_by_target(Client, Input, Options)
 %% the rule names.
 %%
 %% ListRules does not list the targets of a rule. To see the targets
-%% associated with a rule, use `ListTargetsByRule'.
+%% associated with a rule, use ListTargetsByRule.
 list_rules(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_rules(Client, Input, []).
@@ -587,7 +593,7 @@ put_events(Client, Input, Options)
 %% @doc This is used by SaaS partners to write events to a customer's partner
 %% event bus.
 %%
-%% AWS customers do not use this operation.
+%% Amazon Web Services customers do not use this operation.
 put_partner_events(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_partner_events(Client, Input, []).
@@ -595,8 +601,9 @@ put_partner_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutPartnerEvents">>, Input, Options).
 
-%% @doc Running `PutPermission' permits the specified AWS account or AWS
-%% organization to put events to the specified event bus.
+%% @doc Running `PutPermission' permits the specified Amazon Web Services
+%% account or Amazon Web Services organization to put events to the specified
+%% event bus.
 %%
 %% Amazon EventBridge (CloudWatch Events) rules in your account are triggered
 %% by these events arriving to an event bus in your account.
@@ -604,20 +611,20 @@ put_partner_events(Client, Input, Options)
 %% For another account to send events to your account, that external account
 %% must have an EventBridge rule with your account's event bus as a target.
 %%
-%% To enable multiple AWS accounts to put events to your event bus, run
-%% `PutPermission' once for each of these accounts. Or, if all the accounts
-%% are members of the same AWS organization, you can run `PutPermission' once
-%% specifying `Principal' as "*" and specifying the AWS organization ID in
-%% `Condition', to grant permissions to all accounts in that organization.
+%% To enable multiple Amazon Web Services accounts to put events to your
+%% event bus, run `PutPermission' once for each of these accounts. Or, if all
+%% the accounts are members of the same Amazon Web Services organization, you
+%% can run `PutPermission' once specifying `Principal' as "*" and specifying
+%% the Amazon Web Services organization ID in `Condition', to grant
+%% permissions to all accounts in that organization.
 %%
 %% If you grant permissions using an organization, then accounts in that
 %% organization must specify a `RoleArn' with proper permissions when they
 %% use `PutTarget' to add your account's event bus as a target. For more
-%% information, see Sending and Receiving Events Between AWS Accounts in the
-%% Amazon EventBridge User Guide.
+%% information, see Sending and Receiving Events Between Amazon Web Services
+%% Accounts in the Amazon EventBridge User Guide.
 %%
-%% The permission policy on the default event bus cannot exceed 10 KB in
-%% size.
+%% The permission policy on the event bus cannot exceed 10 KB in size.
 put_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_permission(Client, Input, []).
@@ -628,14 +635,15 @@ put_permission(Client, Input, Options)
 %% @doc Creates or updates the specified rule.
 %%
 %% Rules are enabled by default, or based on value of the state. You can
-%% disable a rule using `DisableRule'.
+%% disable a rule using DisableRule.
 %%
 %% A single rule watches for events from a single event bus. Events generated
-%% by AWS services go to your account's default event bus. Events generated
-%% by SaaS partner services or applications go to the matching partner event
-%% bus. If you have custom applications or services, you can specify whether
-%% their events go to your default event bus or a custom event bus that you
-%% have created. For more information, see `CreateEventBus'.
+%% by Amazon Web Services services go to your account's default event bus.
+%% Events generated by SaaS partner services or applications go to the
+%% matching partner event bus. If you have custom applications or services,
+%% you can specify whether their events go to your default event bus or a
+%% custom event bus that you have created. For more information, see
+%% CreateEventBus.
 %%
 %% If you are updating an existing rule, the rule is replaced with what you
 %% specify in this `PutRule' command. If you omit arguments in `PutRule', the
@@ -661,12 +669,13 @@ put_permission(Client, Input, Options)
 %%
 %% If you are updating an existing rule, any tags you specify in the
 %% `PutRule' operation are ignored. To update the tags of an existing rule,
-%% use `TagResource' and `UntagResource'.
+%% use TagResource and UntagResource.
 %%
-%% Most services in AWS treat : or / as the same character in Amazon Resource
-%% Names (ARNs). However, EventBridge uses an exact match in event patterns
-%% and rules. Be sure to use the correct ARN characters when creating event
-%% patterns so that they match the ARN syntax in the event you want to match.
+%% Most services in Amazon Web Services treat : or / as the same character in
+%% Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+%% event patterns and rules. Be sure to use the correct ARN characters when
+%% creating event patterns so that they match the ARN syntax in the event you
+%% want to match.
 %%
 %% In EventBridge, it is possible to create rules that lead to infinite
 %% loops, where a rule is fired repeatedly. For example, a rule might detect
@@ -697,44 +706,60 @@ put_rule(Client, Input, Options)
 %%
 %% You can configure the following as targets for Events:
 %%
-%% <ul> <li> EC2 instances
+%% <ul> <li> API destination
 %%
-%% </li> <li> SSM Run Command
+%% </li> <li> Amazon API Gateway REST API endpoints
 %%
-%% </li> <li> SSM Automation
+%% </li> <li> API Gateway
 %%
-%% </li> <li> AWS Lambda functions
+%% </li> <li> Batch job queue
 %%
-%% </li> <li> Data streams in Amazon Kinesis Data Streams
+%% </li> <li> CloudWatch Logs group
 %%
-%% </li> <li> Data delivery streams in Amazon Kinesis Data Firehose
+%% </li> <li> CodeBuild project
+%%
+%% </li> <li> CodePipeline
+%%
+%% </li> <li> Amazon EC2 `CreateSnapshot' API call
+%%
+%% </li> <li> Amazon EC2 `RebootInstances' API call
+%%
+%% </li> <li> Amazon EC2 `StopInstances' API call
+%%
+%% </li> <li> Amazon EC2 `TerminateInstances' API call
 %%
 %% </li> <li> Amazon ECS tasks
 %%
-%% </li> <li> AWS Step Functions state machines
+%% </li> <li> Event bus in a different Amazon Web Services account or Region.
 %%
-%% </li> <li> AWS Batch jobs
+%% You can use an event bus in the US East (N. Virginia) us-east-1, US West
+%% (Oregon) us-west-2, or Europe (Ireland) eu-west-1 Regions as a target for
+%% a rule.
 %%
-%% </li> <li> AWS CodeBuild projects
+%% </li> <li> Firehose delivery stream (Kinesis Data Firehose)
 %%
-%% </li> <li> Pipelines in AWS CodePipeline
+%% </li> <li> Inspector assessment template (Amazon Inspector)
 %%
-%% </li> <li> Amazon Inspector assessment templates
+%% </li> <li> Kinesis stream (Kinesis Data Stream)
 %%
-%% </li> <li> Amazon SNS topics
+%% </li> <li> Lambda function
 %%
-%% </li> <li> Amazon SQS queues, including FIFO queues
+%% </li> <li> Redshift clusters (Data API statement execution)
 %%
-%% </li> <li> The default event bus of another AWS account
+%% </li> <li> Amazon SNS topic
 %%
-%% </li> <li> Amazon API Gateway REST APIs
+%% </li> <li> Amazon SQS queues (includes FIFO queues
 %%
-%% </li> <li> Redshift Clusters to invoke Data API ExecuteStatement on
+%% </li> <li> SSM Automation
 %%
-%% </li> <li> Custom/SaaS HTTPS APIs via EventBridge API Destinations
+%% </li> <li> SSM OpsItem
+%%
+%% </li> <li> SSM Run Command
+%%
+%% </li> <li> Step Functions state machines
 %%
 %% </li> </ul> Creating rules with built-in targets is supported only in the
-%% AWS Management Console. The built-in targets are `EC2 CreateSnapshot API
+%% Management Console. The built-in targets are `EC2 CreateSnapshot API
 %% call', `EC2 RebootInstances API call', `EC2 StopInstances API call', and
 %% `EC2 TerminateInstances API call'.
 %%
@@ -745,36 +770,36 @@ put_rule(Client, Input, Options)
 %% `RunCommandParameters' field.
 %%
 %% To be able to make API calls against the resources that you own, Amazon
-%% EventBridge (CloudWatch Events) needs the appropriate permissions. For AWS
-%% Lambda and Amazon SNS resources, EventBridge relies on resource-based
-%% policies. For EC2 instances, Kinesis data streams, AWS Step Functions
-%% state machines and API Gateway REST APIs, EventBridge relies on IAM roles
-%% that you specify in the `RoleARN' argument in `PutTargets'. For more
-%% information, see Authentication and Access Control in the Amazon
-%% EventBridge User Guide.
+%% EventBridge needs the appropriate permissions. For Lambda and Amazon SNS
+%% resources, EventBridge relies on resource-based policies. For EC2
+%% instances, Kinesis Data Streams, Step Functions state machines and API
+%% Gateway REST APIs, EventBridge relies on IAM roles that you specify in the
+%% `RoleARN' argument in `PutTargets'. For more information, see
+%% Authentication and Access Control in the Amazon EventBridge User Guide.
 %%
-%% If another AWS account is in the same region and has granted you
-%% permission (using `PutPermission'), you can send events to that account.
-%% Set that account's event bus as a target of the rules in your account. To
-%% send the matched events to the other account, specify that account's event
-%% bus as the `Arn' value when you run `PutTargets'. If your account sends
-%% events to another account, your account is charged for each sent event.
-%% Each event sent to another account is charged as a custom event. The
-%% account receiving the event is not charged. For more information, see
-%% Amazon EventBridge (CloudWatch Events) Pricing.
+%% If another Amazon Web Services account is in the same region and has
+%% granted you permission (using `PutPermission'), you can send events to
+%% that account. Set that account's event bus as a target of the rules in
+%% your account. To send the matched events to the other account, specify
+%% that account's event bus as the `Arn' value when you run `PutTargets'. If
+%% your account sends events to another account, your account is charged for
+%% each sent event. Each event sent to another account is charged as a custom
+%% event. The account receiving the event is not charged. For more
+%% information, see Amazon EventBridge Pricing.
 %%
 %% `Input', `InputPath', and `InputTransformer' are not available with
-%% `PutTarget' if the target is an event bus of a different AWS account.
+%% `PutTarget' if the target is an event bus of a different Amazon Web
+%% Services account.
 %%
 %% If you are setting the event bus of another account as the target, and
 %% that account granted permission to your account through an organization
 %% instead of directly by the account ID, then you must specify a `RoleArn'
 %% with proper permissions in the `Target' structure. For more information,
-%% see Sending and Receiving Events Between AWS Accounts in the Amazon
-%% EventBridge User Guide.
+%% see Sending and Receiving Events Between Amazon Web Services Accounts in
+%% the Amazon EventBridge User Guide.
 %%
 %% For more information about enabling cross-account events, see
-%% `PutPermission'.
+%% PutPermission.
 %%
 %% Input, InputPath, and InputTransformer are mutually exclusive and optional
 %% parameters of a target. When a rule is triggered due to a matched event:
@@ -814,13 +839,12 @@ put_targets(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutTargets">>, Input, Options).
 
-%% @doc Revokes the permission of another AWS account to be able to put
-%% events to the specified event bus.
+%% @doc Revokes the permission of another Amazon Web Services account to be
+%% able to put events to the specified event bus.
 %%
 %% Specify the account to revoke by the `StatementId' value that you
 %% associated with the account when you granted it permission with
-%% `PutPermission'. You can find the `StatementId' by using
-%% `DescribeEventBus'.
+%% `PutPermission'. You can find the `StatementId' by using DescribeEventBus.
 remove_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     remove_permission(Client, Input, []).
@@ -873,8 +897,8 @@ start_replay(Client, Input, Options)
 %% change only resources with certain tag values. In EventBridge, rules and
 %% event buses can be tagged.
 %%
-%% Tags don't have any semantic meaning to AWS and are interpreted strictly
-%% as strings of characters.
+%% Tags don't have any semantic meaning to Amazon Web Services and are
+%% interpreted strictly as strings of characters.
 %%
 %% You can use the `TagResource' action with a resource that already has
 %% tags. If you specify a new tag key, this tag is appended to the list of
@@ -892,10 +916,11 @@ tag_resource(Client, Input, Options)
 
 %% @doc Tests whether the specified event pattern matches the provided event.
 %%
-%% Most services in AWS treat : or / as the same character in Amazon Resource
-%% Names (ARNs). However, EventBridge uses an exact match in event patterns
-%% and rules. Be sure to use the correct ARN characters when creating event
-%% patterns so that they match the ARN syntax in the event you want to match.
+%% Most services in Amazon Web Services treat : or / as the same character in
+%% Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+%% event patterns and rules. Be sure to use the correct ARN characters when
+%% creating event patterns so that they match the ARN syntax in the event you
+%% want to match.
 test_event_pattern(Client, Input)
   when is_map(Client), is_map(Input) ->
     test_event_pattern(Client, Input, []).
@@ -905,7 +930,7 @@ test_event_pattern(Client, Input, Options)
 
 %% @doc Removes one or more tags from the specified EventBridge resource.
 %%
-%% In Amazon EventBridge (CloudWatch Events, rules and event buses can be
+%% In Amazon EventBridge (CloudWatch Events), rules and event buses can be
 %% tagged.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->

--- a/src/aws_cloudwatch_logs.erl
+++ b/src/aws_cloudwatch_logs.erl
@@ -2,11 +2,11 @@
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
 %% @doc You can use Amazon CloudWatch Logs to monitor, store, and access your
-%% log files from EC2 instances, AWS CloudTrail, or other sources.
+%% log files from EC2 instances, CloudTrail, and other sources.
 %%
 %% You can then retrieve the associated log data from CloudWatch Logs using
-%% the CloudWatch console, CloudWatch Logs commands in the AWS CLI,
-%% CloudWatch Logs API, or CloudWatch Logs SDK.
+%% the CloudWatch console, CloudWatch Logs commands in the Amazon Web
+%% Services CLI, CloudWatch Logs API, or CloudWatch Logs SDK.
 %%
 %% You can use CloudWatch Logs to:
 %%
@@ -22,7 +22,7 @@
 %% an Apache access log). When the term you are searching for is found,
 %% CloudWatch Logs reports the data to a CloudWatch metric that you specify.
 %%
-%% </li> <li> Monitor AWS CloudTrail logged events: You can create alarms in
+%% </li> <li> Monitor CloudTrail logged events: You can create alarms in
 %% CloudWatch and receive notifications of particular API activity as
 %% captured by CloudTrail. You can use the notification to perform
 %% troubleshooting.
@@ -128,15 +128,15 @@
 %% API
 %%====================================================================
 
-%% @doc Associates the specified AWS Key Management Service (AWS KMS)
-%% customer master key (CMK) with the specified log group.
+%% @doc Associates the specified Key Management Service customer master key
+%% (CMK) with the specified log group.
 %%
-%% Associating an AWS KMS CMK with a log group overrides any existing
+%% Associating an KMS CMK with a log group overrides any existing
 %% associations between the log group and a CMK. After a CMK is associated
 %% with a log group, all newly ingested data for the log group is encrypted
 %% using the CMK. This association is stored as long as the data encrypted
-%% with the CMK is still within Amazon CloudWatch Logs. This enables Amazon
-%% CloudWatch Logs to decrypt this data whenever it is requested.
+%% with the CMK is still within CloudWatch Logs. This enables CloudWatch Logs
+%% to decrypt this data whenever it is requested.
 %%
 %% CloudWatch Logs supports only symmetric CMKs. Do not use an associate an
 %% asymmetric CMK with your log group. For more information, see Using
@@ -198,8 +198,8 @@ create_export_task(Client, Input, Options)
 %%
 %% You must use the following guidelines when naming a log group:
 %%
-%% <ul> <li> Log group names must be unique within a region for an AWS
-%% account.
+%% <ul> <li> Log group names must be unique within a region for an Amazon Web
+%% Services account.
 %%
 %% </li> <li> Log group names can be between 1 and 512 characters long.
 %%
@@ -211,11 +211,11 @@ create_export_task(Client, Input, Options)
 %% log group never expire. To set a retention policy so that events expire
 %% and are deleted after a specified time, use PutRetentionPolicy.
 %%
-%% If you associate a AWS Key Management Service (AWS KMS) customer master
-%% key (CMK) with the log group, ingested data is encrypted using the CMK.
-%% This association is stored as long as the data encrypted with the CMK is
-%% still within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs
-%% to decrypt this data whenever it is requested.
+%% If you associate a Key Management Service customer master key (CMK) with
+%% the log group, ingested data is encrypted using the CMK. This association
+%% is stored as long as the data encrypted with the CMK is still within
+%% CloudWatch Logs. This enables CloudWatch Logs to decrypt this data
+%% whenever it is requested.
 %%
 %% If you attempt to associate a CMK with the log group but the CMK does not
 %% exist or the CMK is disabled, you receive an `InvalidParameterException'
@@ -366,6 +366,13 @@ describe_export_tasks(Client, Input, Options)
 %%
 %% You can list all your log groups or filter the results by prefix. The
 %% results are ASCII-sorted by log group name.
+%%
+%% CloudWatch Logs doesn’t support IAM policies that control access to the
+%% `DescribeLogGroups' action by using the `aws:ResourceTag/key-name '
+%% condition key. Other CloudWatch Logs actions do support the use of the
+%% `aws:ResourceTag/key-name ' condition key to control access. For more
+%% information about using tags to control access, see Controlling access to
+%% Amazon Web Services resources using tags.
 describe_log_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_log_groups(Client, Input, []).
@@ -443,13 +450,13 @@ describe_subscription_filters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeSubscriptionFilters">>, Input, Options).
 
-%% @doc Disassociates the associated AWS Key Management Service (AWS KMS)
-%% customer master key (CMK) from the specified log group.
+%% @doc Disassociates the associated Key Management Service customer master
+%% key (CMK) from the specified log group.
 %%
-%% After the AWS KMS CMK is disassociated from the log group, AWS CloudWatch
-%% Logs stops encrypting newly ingested data for the log group. All
-%% previously ingested data remains encrypted, and AWS CloudWatch Logs
-%% requires permissions for the CMK whenever the encrypted data is requested.
+%% After the KMS CMK is disassociated from the log group, CloudWatch Logs
+%% stops encrypting newly ingested data for the log group. All previously
+%% ingested data remains encrypted, and CloudWatch Logs requires permissions
+%% for the CMK whenever the encrypted data is requested.
 %%
 %% Note that it can take up to 5 minutes for this operation to take effect.
 disassociate_kms_key(Client, Input)
@@ -588,6 +595,11 @@ put_destination(Client, Input, Options)
 %%
 %% An access policy is an IAM policy document that is used to authorize
 %% claims to register a subscription filter against a given destination.
+%%
+%% If multiple Amazon Web Services accounts are sending logs to this
+%% destination, each sender account must be listed separately in the policy.
+%% The policy does not support specifying `*' as the Principal or the use of
+%% the `aws:PrincipalOrgId' global key.
 put_destination_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_destination_policy(Client, Input, []).
@@ -619,9 +631,10 @@ put_destination_policy(Client, Input, Options)
 %%
 %% </li> <li> The log events in the batch must be in chronological order by
 %% their timestamp. The timestamp is the time the event occurred, expressed
-%% as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In AWS
-%% Tools for PowerShell and the AWS SDK for .NET, the timestamp is specified
-%% in .NET format: yyyy-mm-ddThh:mm:ss. For example, 2017-09-15T13:45:30.)
+%% as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In Amazon
+%% Web Services Tools for PowerShell and the Amazon Web Services SDK for
+%% .NET, the timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss. For
+%% example, 2017-09-15T13:45:30.)
 %%
 %% </li> <li> A batch of log events in a single request cannot span more than
 %% 24 hours. Otherwise, the operation fails.
@@ -632,8 +645,8 @@ put_destination_policy(Client, Input, Options)
 %% Additional requests are throttled. This quota can't be changed.
 %%
 %% </li> </ul> If a call to `PutLogEvents' returns
-%% "UnrecognizedClientException" the most likely cause is an invalid AWS
-%% access key ID or secret key.
+%% "UnrecognizedClientException" the most likely cause is an invalid Amazon
+%% Web Services access key ID or secret key.
 put_log_events(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_log_events(Client, Input, []).
@@ -649,6 +662,23 @@ put_log_events(Client, Input, Options)
 %%
 %% The maximum number of metric filters that can be associated with a log
 %% group is 100.
+%%
+%% When you create a metric filter, you can also optionally assign a unit and
+%% dimensions to the metric that is created.
+%%
+%% Metrics extracted from log events are charged as custom metrics. To
+%% prevent unexpected high charges, do not specify high-cardinality fields
+%% such as `IPAddress' or `requestID' as dimensions. Each different value
+%% found for a dimension is treated as a separate metric and accrues charges
+%% as a separate custom metric.
+%%
+%% To help prevent accidental high charges, Amazon disables a metric filter
+%% if it generates 1000 different name/value pairs for the dimensions that
+%% you have specified within a certain amount of time.
+%%
+%% You can also set up a billing alarm to alert you if your charges are
+%% higher than expected. For more information, see Creating a Billing Alarm
+%% to Monitor Your Estimated Amazon Web Services Charges.
 put_metric_filter(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_metric_filter(Client, Input, []).
@@ -678,10 +708,12 @@ put_query_definition(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutQueryDefinition">>, Input, Options).
 
-%% @doc Creates or updates a resource policy allowing other AWS services to
-%% put log events to this account, such as Amazon Route 53.
+%% @doc Creates or updates a resource policy allowing other Amazon Web
+%% Services services to put log events to this account, such as Amazon Route
+%% 53.
 %%
-%% An account can have up to 10 resource policies per AWS Region.
+%% An account can have up to 10 resource policies per Amazon Web Services
+%% Region.
 put_resource_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_resource_policy(Client, Input, []).
@@ -719,13 +751,12 @@ put_retention_policy(Client, Input, Options)
 %% </li> <li> An Amazon Kinesis Firehose delivery stream that belongs to the
 %% same account as the subscription filter, for same-account delivery.
 %%
-%% </li> <li> An AWS Lambda function that belongs to the same account as the
+%% </li> <li> An Lambda function that belongs to the same account as the
 %% subscription filter, for same-account delivery.
 %%
-%% </li> </ul> There can only be one subscription filter associated with a
-%% log group. If you are updating an existing filter, you must specify the
-%% correct name in `filterName'. Otherwise, the call fails because you cannot
-%% associate a second filter with a log group.
+%% </li> </ul> Each log group can have up to two subscription filters
+%% associated with it. If you are updating an existing filter, you must
+%% specify the correct name in `filterName'.
 %%
 %% To perform a `PutSubscriptionFilter' operation, you must also have the
 %% `iam:PassRole' permission.
@@ -771,6 +802,12 @@ stop_query(Client, Input, Options)
 %%
 %% For more information about tags, see Tag Log Groups in Amazon CloudWatch
 %% Logs in the Amazon CloudWatch Logs User Guide.
+%%
+%% CloudWatch Logs doesn’t support IAM policies that prevent users from
+%% assigning specified tags to log groups using the `aws:Resource/key-name '
+%% or `aws:TagKeys' condition keys. For more information about using tags to
+%% control access, see Controlling access to Amazon Web Services resources
+%% using tags.
 tag_log_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_log_group(Client, Input, []).
@@ -794,6 +831,10 @@ test_metric_filter(Client, Input, Options)
 %%
 %% To list the tags for a log group, use ListTagsLogGroup. To add tags, use
 %% TagLogGroup.
+%%
+%% CloudWatch Logs doesn’t support IAM policies that prevent users from
+%% assigning specified tags to log groups using the `aws:Resource/key-name '
+%% or `aws:TagKeys' condition keys.
 untag_log_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_log_group(Client, Input, []).

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -3,7 +3,7 @@
 
 %% @doc AWS CodeArtifact is a fully managed artifact repository compatible
 %% with language-native package managers and build tools such as npm, Apache
-%% Maven, NuGet, and pip.
+%% Maven, and pip.
 %%
 %% You can use CodeArtifact to share packages with development teams and pull
 %% packages. Packages can be pulled from both public and CodeArtifact
@@ -20,8 +20,8 @@
 %% versions, each of which maps to a set of assets, or files. Repositories
 %% are polyglot, so a single repository can contain packages of any supported
 %% type. Each repository exposes endpoints for fetching and publishing
-%% packages using tools like the `npm' CLI, the `NuGet' CLI, the Maven CLI (
-%% `mvn' ), and `pip' .
+%% packages using tools like the `npm' CLI, the Maven CLI ( `mvn' ), and
+%% `pip' .
 %%
 %% </li> <li> Domain: Repositories are aggregated into a higher-level entity
 %% known as a domain. All package assets and metadata are stored in the
@@ -44,7 +44,7 @@
 %%
 %% </li> <li> Package: A package is a bundle of software and the metadata
 %% required to resolve dependencies and install the software. CodeArtifact
-%% supports npm, PyPI, Maven, and NuGet package formats.
+%% supports npm, PyPI, and Maven package formats.
 %%
 %% In CodeArtifact, a package consists of:
 %%
@@ -107,8 +107,8 @@
 %% </li> <li> `DescribeDomain': Returns a `DomainDescription' object that
 %% contains information about the requested domain.
 %%
-%% </li> <li> `DescribePackageVersion': Returns a ` PackageVersionDescription
-%% ' object that contains details about a package version.
+%% </li> <li> `DescribePackageVersion': Returns a PackageVersionDescription
+%% object that contains details about a package version.
 %%
 %% </li> <li> `DescribeRepository': Returns a `RepositoryDescription' object
 %% that contains detailed information about the requested repository.
@@ -144,8 +144,6 @@
 %%
 %% </li> <li> `maven'
 %%
-%% </li> <li> `nuget'
-%%
 %% </li> </ul> </li> <li> `GetRepositoryPermissionsPolicy': Returns the
 %% resource policy that is set on a repository.
 %%
@@ -169,18 +167,11 @@
 %% </li> <li> `ListRepositoriesInDomain': Returns a list of the repositories
 %% in a domain.
 %%
-%% </li> <li> `ListTagsForResource': Returns a list of the tags associated
-%% with a resource.
-%%
 %% </li> <li> `PutDomainPermissionsPolicy': Attaches a resource policy to a
 %% domain.
 %%
 %% </li> <li> `PutRepositoryPermissionsPolicy': Sets the resource policy on a
 %% repository that specifies permissions to access it.
-%%
-%% </li> <li> `TagResource': Adds or updates tags for a resource.
-%%
-%% </li> <li> `UntagResource': Removes a tag from a resource.
 %%
 %% </li> <li> `UpdatePackageVersionsStatus': Updates the status of one or
 %% more versions of a package.
@@ -459,8 +450,8 @@ delete_domain_permissions_policy(Client, Input0, Options0) ->
 %% want to remove a package version from your repository and be able to
 %% restore it later, set its status to `Archived'. Archived packages cannot
 %% be downloaded from a repository and don't show up with list package APIs
-%% (for example, ` ListackageVersions '), but you can restore them using `
-%% UpdatePackageVersionsStatus '.
+%% (for example, ListackageVersions), but you can restore them using
+%% UpdatePackageVersionsStatus.
 delete_package_versions(Client, Input) ->
     delete_package_versions(Client, Input, []).
 delete_package_versions(Client, Input0, Options0) ->
@@ -550,7 +541,7 @@ delete_repository_permissions_policy(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a `DomainDescription' object that contains information about
+%% @doc Returns a DomainDescription object that contains information about
 %% the requested domain.
 describe_domain(Client, Domain)
   when is_map(Client) ->
@@ -579,8 +570,8 @@ describe_domain(Client, Domain, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a `PackageVersionDescription' object that contains
-%% information about the requested package version.
+%% @doc Returns a PackageVersionDescription object that contains information
+%% about the requested package version.
 describe_package_version(Client, Domain, Format, Package, PackageVersion, Repository)
   when is_map(Client) ->
     describe_package_version(Client, Domain, Format, Package, PackageVersion, Repository, #{}, #{}).
@@ -677,10 +668,10 @@ disassociate_external_connection(Client, Input0, Options0) ->
 %% its assets are deleted.
 %%
 %% To view all disposed package versions in a repository, use
-%% `ListPackageVersions' and set the `status' parameter to `Disposed'.
+%% ListPackageVersions and set the status parameter to `Disposed'.
 %%
 %% To view information about a disposed package version, use
-%% `DescribePackageVersion' ..
+%% DescribePackageVersion.
 dispose_package_versions(Client, Input) ->
     dispose_package_versions(Client, Input, []).
 dispose_package_versions(Client, Input0, Options0) ->
@@ -895,8 +886,6 @@ get_package_version_readme(Client, Domain, Format, Package, PackageVersion, Repo
 %%
 %% </li> <li> `maven'
 %%
-%% </li> <li> `nuget'
-%%
 %% </li> </ul>
 get_repository_endpoint(Client, Domain, Format, Repository)
   when is_map(Client) ->
@@ -956,8 +945,8 @@ get_repository_permissions_policy(Client, Domain, Repository, QueryMap, HeadersM
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of ` DomainSummary ' objects for all domains owned by
-%% the AWS account that makes this call.
+%% @doc Returns a list of DomainSummary objects for all domains owned by the
+%% AWS account that makes this call.
 %%
 %% Each returned `DomainSummary' object contains information about a domain.
 list_domains(Client, Input) ->
@@ -982,7 +971,7 @@ list_domains(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of `AssetSummary' objects for assets in a package
+%% @doc Returns a list of AssetSummary objects for assets in a package
 %% version.
 list_package_version_assets(Client, Input) ->
     list_package_version_assets(Client, Input, []).
@@ -1017,7 +1006,7 @@ list_package_version_assets(Client, Input0, Options0) ->
 
 %% @doc Returns the direct dependencies for a package version.
 %%
-%% The dependencies are returned as `PackageDependency' objects. CodeArtifact
+%% The dependencies are returned as PackageDependency objects. CodeArtifact
 %% extracts the dependencies for a package version from the metadata file for
 %% the package format (for example, the `package.json' file for npm packages
 %% and the `pom.xml' file for Maven). Any package version dependencies that
@@ -1052,8 +1041,8 @@ list_package_version_dependencies(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of `PackageVersionSummary' objects for package
-%% versions in a repository that match the request parameters.
+%% @doc Returns a list of PackageVersionSummary objects for package versions
+%% in a repository that match the request parameters.
 list_package_versions(Client, Input) ->
     list_package_versions(Client, Input, []).
 list_package_versions(Client, Input0, Options0) ->
@@ -1086,8 +1075,8 @@ list_package_versions(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of `PackageSummary' objects for packages in a
-%% repository that match the request parameters.
+%% @doc Returns a list of PackageSummary objects for packages in a repository
+%% that match the request parameters.
 list_packages(Client, Input) ->
     list_packages(Client, Input, []).
 list_packages(Client, Input0, Options0) ->
@@ -1118,7 +1107,7 @@ list_packages(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of `RepositorySummary' objects.
+%% @doc Returns a list of RepositorySummary objects.
 %%
 %% Each `RepositorySummary' contains information about a repository in the
 %% specified AWS account and that matches the input parameters.
@@ -1147,7 +1136,7 @@ list_repositories(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of `RepositorySummary' objects.
+%% @doc Returns a list of RepositorySummary objects.
 %%
 %% Each `RepositorySummary' contains information about a repository in the
 %% specified domain and that matches the input parameters.
@@ -1403,6 +1392,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_codebuild.erl
+++ b/src/aws_codebuild.erl
@@ -1,19 +1,19 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS CodeBuild
+%% @doc CodeBuild
 %%
-%% AWS CodeBuild is a fully managed build service in the cloud.
+%% CodeBuild is a fully managed build service in the cloud.
 %%
-%% AWS CodeBuild compiles your source code, runs unit tests, and produces
-%% artifacts that are ready to deploy. AWS CodeBuild eliminates the need to
+%% CodeBuild compiles your source code, runs unit tests, and produces
+%% artifacts that are ready to deploy. CodeBuild eliminates the need to
 %% provision, manage, and scale your own build servers. It provides
 %% prepackaged build environments for the most popular programming languages
 %% and build tools, such as Apache Maven, Gradle, and more. You can also
-%% fully customize build environments in AWS CodeBuild to use your own build
-%% tools. AWS CodeBuild scales automatically to meet peak build requests. You
-%% pay only for the build time you consume. For more information about AWS
-%% CodeBuild, see the AWS CodeBuild User Guide.
+%% fully customize build environments in CodeBuild to use your own build
+%% tools. CodeBuild scales automatically to meet peak build requests. You pay
+%% only for the build time you consume. For more information about CodeBuild,
+%% see the CodeBuild User Guide.
 -module(aws_codebuild).
 
 -export([batch_delete_builds/2,
@@ -100,6 +100,8 @@
          stop_build_batch/3,
          update_project/2,
          update_project/3,
+         update_project_visibility/2,
+         update_project_visibility/3,
          update_report_group/2,
          update_report_group/3,
          update_webhook/2,
@@ -177,19 +179,19 @@ create_report_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateReportGroup">>, Input, Options).
 
-%% @doc For an existing AWS CodeBuild build project that has its source code
-%% stored in a GitHub or Bitbucket repository, enables AWS CodeBuild to start
+%% @doc For an existing CodeBuild build project that has its source code
+%% stored in a GitHub or Bitbucket repository, enables CodeBuild to start
 %% rebuilding the source code every time a code change is pushed to the
 %% repository.
 %%
-%% If you enable webhooks for an AWS CodeBuild project, and the project is
-%% used as a build step in AWS CodePipeline, then two identical builds are
-%% created for each commit. One build is triggered through webhooks, and one
-%% through AWS CodePipeline. Because billing is on a per-build basis, you are
-%% billed for both builds. Therefore, if you are using AWS CodePipeline, we
-%% recommend that you disable webhooks in AWS CodeBuild. In the AWS CodeBuild
-%% console, clear the Webhook box. For more information, see step 5 in Change
-%% a Build Project's Settings.
+%% If you enable webhooks for an CodeBuild project, and the project is used
+%% as a build step in CodePipeline, then two identical builds are created for
+%% each commit. One build is triggered through webhooks, and one through
+%% CodePipeline. Because billing is on a per-build basis, you are billed for
+%% both builds. Therefore, if you are using CodePipeline, we recommend that
+%% you disable webhooks in CodeBuild. In the CodeBuild console, clear the
+%% Webhook box. For more information, see step 5 in Change a Build Project's
+%% Settings.
 create_webhook(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_webhook(Client, Input, []).
@@ -250,8 +252,8 @@ delete_source_credentials(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteSourceCredentials">>, Input, Options).
 
-%% @doc For an existing AWS CodeBuild build project that has its source code
-%% stored in a GitHub or Bitbucket repository, stops AWS CodeBuild from
+%% @doc For an existing CodeBuild build project that has its source code
+%% stored in a GitHub or Bitbucket repository, stops CodeBuild from
 %% rebuilding the source code every time a code change is pushed to the
 %% repository.
 delete_webhook(Client, Input)
@@ -294,8 +296,8 @@ get_resource_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetResourcePolicy">>, Input, Options).
 
-%% @doc Imports the source repository credentials for an AWS CodeBuild
-%% project that has its source code stored in a GitHub, GitHub Enterprise, or
+%% @doc Imports the source repository credentials for an CodeBuild project
+%% that has its source code stored in a GitHub, GitHub Enterprise, or
 %% Bitbucket repository.
 import_source_credentials(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -348,8 +350,7 @@ list_builds_for_project(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListBuildsForProject">>, Input, Options).
 
-%% @doc Gets information about Docker images that are managed by AWS
-%% CodeBuild.
+%% @doc Gets information about Docker images that are managed by CodeBuild.
 list_curated_environment_images(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_curated_environment_images(Client, Input, []).
@@ -366,7 +367,8 @@ list_projects(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListProjects">>, Input, Options).
 
-%% @doc Gets a list ARNs for the report groups in the current AWS account.
+%% @doc Gets a list ARNs for the report groups in the current Amazon Web
+%% Services account.
 list_report_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_report_groups(Client, Input, []).
@@ -374,7 +376,8 @@ list_report_groups(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListReportGroups">>, Input, Options).
 
-%% @doc Returns a list of ARNs for the reports in the current AWS account.
+%% @doc Returns a list of ARNs for the reports in the current Amazon Web
+%% Services account.
 list_reports(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_reports(Client, Input, []).
@@ -391,8 +394,8 @@ list_reports_for_report_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListReportsForReportGroup">>, Input, Options).
 
-%% @doc Gets a list of projects that are shared with other AWS accounts or
-%% users.
+%% @doc Gets a list of projects that are shared with other Amazon Web
+%% Services accounts or users.
 list_shared_projects(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_shared_projects(Client, Input, []).
@@ -400,8 +403,8 @@ list_shared_projects(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListSharedProjects">>, Input, Options).
 
-%% @doc Gets a list of report groups that are shared with other AWS accounts
-%% or users.
+%% @doc Gets a list of report groups that are shared with other Amazon Web
+%% Services accounts or users.
 list_shared_report_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_shared_report_groups(Client, Input, []).
@@ -484,6 +487,45 @@ update_project(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateProject">>, Input, Options).
 
+%% @doc Changes the public visibility for a project.
+%%
+%% The project's build results, logs, and artifacts are available to the
+%% general public. For more information, see Public build projects in the
+%% CodeBuild User Guide.
+%%
+%% The following should be kept in mind when making your projects public:
+%%
+%% All of a project's build results, logs, and artifacts, including builds
+%% that were run when the project was private, are available to the general
+%% public.
+%%
+%% All build logs and artifacts are available to the public. Environment
+%% variables, source code, and other sensitive information may have been
+%% output to the build logs and artifacts. You must be careful about what
+%% information is output to the build logs. Some best practice are:
+%%
+%% Do not store sensitive values, especially Amazon Web Services access key
+%% IDs and secret access keys, in environment variables. We recommend that
+%% you use an Amazon EC2 Systems Manager Parameter Store or Secrets Manager
+%% to store sensitive values.
+%%
+%% Follow Best practices for using webhooks in the CodeBuild User Guide to
+%% limit which entities can trigger a build, and do not store the buildspec
+%% in the project itself, to ensure that your webhooks are as secure as
+%% possible.
+%%
+%% A malicious user can use public builds to distribute malicious artifacts.
+%% We recommend that you review all pull requests to verify that the pull
+%% request is a legitimate change. We also recommend that you validate any
+%% artifacts with their checksums to make sure that the correct artifacts are
+%% being downloaded.
+update_project_visibility(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_project_visibility(Client, Input, []).
+update_project_visibility(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateProjectVisibility">>, Input, Options).
+
 %% @doc Updates a report group.
 update_report_group(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -492,7 +534,7 @@ update_report_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateReportGroup">>, Input, Options).
 
-%% @doc Updates the webhook associated with an AWS CodeBuild build project.
+%% @doc Updates the webhook associated with an CodeBuild build project.
 %%
 %% If you use Bitbucket for your repository, `rotateSecret' is ignored.
 update_webhook(Client, Input)

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -6,7 +6,7 @@
 %%
 %% CodeGuru Reviewer is a service that uses program analysis and machine
 %% learning to detect potential defects that are difficult for developers to
-%% find and recommends fixes in your Java code.
+%% find and recommends fixes in your Java and Python code.
 %%
 %% By proactively detecting and providing recommendations for addressing code
 %% defects and implementing best practices, CodeGuru Reviewer improves the
@@ -17,8 +17,8 @@
 %% To improve the security of your CodeGuru Reviewer API calls, you can
 %% establish a private connection between your VPC and CodeGuru Reviewer by
 %% creating an interface VPC endpoint. For more information, see CodeGuru
-%% Reviewer and interface VPC endpoints (AWS PrivateLink) in the Amazon
-%% CodeGuru Reviewer User Guide.
+%% Reviewer and interface VPC endpoints (Amazon Web Services PrivateLink) in
+%% the Amazon CodeGuru Reviewer User Guide.
 -module(aws_codeguru_reviewer).
 
 -export([associate_repository/2,
@@ -64,8 +64,9 @@
 %% API
 %%====================================================================
 
-%% @doc Use to associate an AWS CodeCommit repository or a repostory managed
-%% by AWS CodeStar Connections with Amazon CodeGuru Reviewer.
+%% @doc Use to associate an Amazon Web Services CodeCommit repository or a
+%% repostory managed by Amazon Web Services CodeStar Connections with Amazon
+%% CodeGuru Reviewer.
 %%
 %% When you associate a repository, CodeGuru Reviewer reviews source code
 %% changes in the repository's pull requests and provides automatic
@@ -73,19 +74,19 @@
 %% console. For more information, see Recommendations in Amazon CodeGuru
 %% Reviewer in the Amazon CodeGuru Reviewer User Guide.
 %%
-%% If you associate a CodeCommit repository, it must be in the same AWS
-%% Region and AWS account where its CodeGuru Reviewer code reviews are
-%% configured.
+%% If you associate a CodeCommit or S3 repository, it must be in the same
+%% Amazon Web Services Region and Amazon Web Services account where its
+%% CodeGuru Reviewer code reviews are configured.
 %%
-%% Bitbucket and GitHub Enterprise Server repositories are managed by AWS
-%% CodeStar Connections to connect to CodeGuru Reviewer. For more
-%% information, see Connect to a repository source provider in the Amazon
-%% CodeGuru Reviewer User Guide.
+%% Bitbucket and GitHub Enterprise Server repositories are managed by Amazon
+%% Web Services CodeStar Connections to connect to CodeGuru Reviewer. For
+%% more information, see Associate a repository in the Amazon CodeGuru
+%% Reviewer User Guide.
 %%
-%% You cannot use the CodeGuru Reviewer SDK or the AWS CLI to associate a
-%% GitHub repository with Amazon CodeGuru Reviewer. To associate a GitHub
-%% repository, use the console. For more information, see Getting started
-%% with CodeGuru Reviewer in the CodeGuru Reviewer User Guide.
+%% You cannot use the CodeGuru Reviewer SDK or the Amazon Web Services CLI to
+%% associate a GitHub repository with Amazon CodeGuru Reviewer. To associate
+%% a GitHub repository, use the console. For more information, see Getting
+%% started with CodeGuru Reviewer in the CodeGuru Reviewer User Guide.
 associate_repository(Client, Input) ->
     associate_repository(Client, Input, []).
 associate_repository(Client, Input0, Options0) ->
@@ -113,7 +114,7 @@ associate_repository(Client, Input0, Options0) ->
 %%
 %% This type of code review analyzes all code under a specified branch in an
 %% associated repository. `PullRequest' code reviews are automatically
-%% triggered by a pull request so cannot be created using this method.
+%% triggered by a pull request.
 create_code_review(Client, Input) ->
     create_code_review(Client, Input, []).
 create_code_review(Client, Input0, Options0) ->
@@ -497,6 +498,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -4,23 +4,25 @@
 %% @doc This section provides documentation for the Amazon CodeGuru Profiler
 %% API operations.
 %%
-%% <p>Amazon CodeGuru Profiler collects runtime performance data from your
-%% live applications, and provides recommendations that can help you
-%% fine-tune your application performance. Using machine learning algorithms,
-%% CodeGuru Profiler can help you find your most expensive lines of code and
-%% suggest ways you can improve efficiency and remove CPU bottlenecks. </p>
-%% <p>Amazon CodeGuru Profiler provides different visualizations of profiling
+%% Amazon CodeGuru Profiler collects runtime performance data from your live
+%% applications, and provides recommendations that can help you fine-tune
+%% your application performance. Using machine learning algorithms, CodeGuru
+%% Profiler can help you find your most expensive lines of code and suggest
+%% ways you can improve efficiency and remove CPU bottlenecks.
+%%
+%% Amazon CodeGuru Profiler provides different visualizations of profiling
 %% data to help you identify what code is running on the CPU, see how much
-%% time is consumed, and suggest ways to reduce CPU utilization. </p> <note>
-%% <p>Amazon CodeGuru Profiler currently supports applications written in all
-%% Java virtual machine (JVM) languages. While CodeGuru Profiler supports
-%% both visualizations and recommendations for applications written in Java,
-%% it can also generate visualizations and a subset of recommendations for
-%% applications written in other JVM languages.</p> </note> <p> For more
-%% information, see <a
-%% href="https://docs.aws.amazon.com/codeguru/latest/profiler-ug/what-is-codeguru-profiler.html">What
-%% is Amazon CodeGuru Profiler</a> in the <i>Amazon CodeGuru Profiler User
-%% Guide</i>. </p>
+%% time is consumed, and suggest ways to reduce CPU utilization.
+%%
+%% Amazon CodeGuru Profiler currently supports applications written in all
+%% Java virtual machine (JVM) languages and Python. While CodeGuru Profiler
+%% supports both visualizations and recommendations for applications written
+%% in Java, it can also generate visualizations and a subset of
+%% recommendations for applications written in other JVM languages and
+%% Python.
+%%
+%% For more information, see What is Amazon CodeGuru Profiler in the Amazon
+%% CodeGuru Profiler User Guide.
 -module(aws_codeguruprofiler).
 
 -export([add_notification_channels/3,
@@ -140,7 +142,7 @@ batch_get_frame_metric_data(Client, ProfilingGroupName, Input0, Options0) ->
 %% @doc Used by profiler agents to report their current state and to receive
 %% remote configuration updates.
 %%
-%% For example, `ConfigureAgent' can be used to tell and agent whether to
+%% For example, `ConfigureAgent' can be used to tell an agent whether to
 %% profile or not and for how long to return profiling data.
 configure_agent(Client, ProfilingGroupName, Input) ->
     configure_agent(Client, ProfilingGroupName, Input, []).
@@ -811,6 +813,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -438,6 +438,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_cognito_identity_provider.erl
+++ b/src/aws_cognito_identity_provider.erl
@@ -171,6 +171,8 @@
          resend_confirmation_code/3,
          respond_to_auth_challenge/2,
          respond_to_auth_challenge/3,
+         revoke_token/2,
+         revoke_token/3,
          set_risk_configuration/2,
          set_risk_configuration/3,
          set_ui_customization/2,
@@ -255,6 +257,22 @@ admin_confirm_sign_up(Client, Input, Options)
 %%
 %% If `MessageAction' is not set, the default is to send a welcome message
 %% via email or phone (SMS).
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 %%
 %% This message is based on a template that you configured in your call to
 %% create or update a user pool. This template includes your custom sign-up
@@ -397,6 +415,22 @@ admin_get_user(Client, Input, Options)
 
 %% @doc Initiates the authentication flow, as an administrator.
 %%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
+%%
 %% Calling this action requires developer credentials.
 admin_initiate_auth(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -489,6 +523,22 @@ admin_remove_user_from_group(Client, Input, Options)
 %% user, calling this API will also result in sending a message to the end
 %% user with the code to change their password.
 %%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
+%%
 %% Calling this action requires developer credentials.
 admin_reset_user_password(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -498,6 +548,22 @@ admin_reset_user_password(Client, Input, Options)
     request(Client, <<"AdminResetUserPassword">>, Input, Options).
 
 %% @doc Responds to an authentication challenge, as an administrator.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 %%
 %% Calling this action requires developer credentials.
 admin_respond_to_auth_challenge(Client, Input)
@@ -587,6 +653,22 @@ admin_update_device_status(Client, Input, Options)
 %% In addition to updating user attributes, this API can also be used to mark
 %% phone and email as verified.
 %%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
+%%
 %% Calling this action requires developer credentials.
 admin_update_user_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -613,6 +695,14 @@ admin_user_global_sign_out(Client, Input, Options)
 %% account.
 %%
 %% The request takes an access token or a session string, but not both.
+%%
+%% Calling AssociateSoftwareToken immediately disassociates the existing
+%% software token from the user account. If the user doesn't subsequently
+%% verify the software token, their account is essentially set up to
+%% authenticate without MFA. If MFA config is set to Optional at the user
+%% pool level, the user can then login without MFA. However, if MFA is set to
+%% Required for the user pool, the user will be asked to setup a new software
+%% token MFA during sign in.
 associate_software_token(Client, Input)
   when is_map(Client), is_map(Input) ->
     associate_software_token(Client, Input, []).
@@ -693,6 +783,22 @@ create_user_import_job(Client, Input, Options)
 
 %% @doc Creates a new Amazon Cognito user pool and sets the password policy
 %% for the pool.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 create_user_pool(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_user_pool(Client, Input, []).
@@ -701,6 +807,9 @@ create_user_pool(Client, Input, Options)
     request(Client, <<"CreateUserPool">>, Input, Options).
 
 %% @doc Creates the user pool client.
+%%
+%% When you create a new user pool client, token revocation is automatically
+%% enabled. For more information about revoking tokens, see RevokeToken.
 create_user_pool_client(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_user_pool_client(Client, Input, []).
@@ -717,8 +826,6 @@ create_user_pool_domain(Client, Input, Options)
     request(Client, <<"CreateUserPoolDomain">>, Input, Options).
 
 %% @doc Deletes a group.
-%%
-%% Currently only groups with no members can be deleted.
 %%
 %% Calling this action requires developer credentials.
 delete_group(Client, Input)
@@ -860,6 +967,22 @@ forget_device(Client, Input, Options)
 %% phone number nor a verified email exists, an `InvalidParameterException'
 %% is thrown. To use the confirmation code for resetting the password, call
 %% ConfirmForgotPassword.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 forgot_password(Client, Input)
   when is_map(Client), is_map(Input) ->
     forgot_password(Client, Input, []).
@@ -934,6 +1057,22 @@ get_user(Client, Input, Options)
 
 %% @doc Gets the user attribute verification code for the specified attribute
 %% name.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 get_user_attribute_verification_code(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_user_attribute_verification_code(Client, Input, []).
@@ -962,6 +1101,22 @@ global_sign_out(Client, Input, Options)
     request(Client, <<"GlobalSignOut">>, Input, Options).
 
 %% @doc Initiates the authentication flow.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 initiate_auth(Client, Input)
   when is_map(Client), is_map(Input) ->
     initiate_auth(Client, Input, []).
@@ -1033,7 +1188,7 @@ list_user_pool_clients(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListUserPoolClients">>, Input, Options).
 
-%% @doc Lists the user pools associated with an AWS account.
+%% @doc Lists the user pools associated with an account.
 list_user_pools(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_user_pools(Client, Input, []).
@@ -1061,6 +1216,22 @@ list_users_in_group(Client, Input, Options)
 
 %% @doc Resends the confirmation (for confirmation of registration) to a
 %% specific user in the user pool.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 resend_confirmation_code(Client, Input)
   when is_map(Client), is_map(Input) ->
     resend_confirmation_code(Client, Input, []).
@@ -1069,12 +1240,40 @@ resend_confirmation_code(Client, Input, Options)
     request(Client, <<"ResendConfirmationCode">>, Input, Options).
 
 %% @doc Responds to the authentication challenge.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 respond_to_auth_challenge(Client, Input)
   when is_map(Client), is_map(Input) ->
     respond_to_auth_challenge(Client, Input, []).
 respond_to_auth_challenge(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RespondToAuthChallenge">>, Input, Options).
+
+%% @doc Revokes all of the access tokens generated by the specified refresh
+%% token.
+%%
+%% After the token is revoked, you can not use the revoked token to access
+%% Cognito authenticated APIs.
+revoke_token(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    revoke_token(Client, Input, []).
+revoke_token(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RevokeToken">>, Input, Options).
 
 %% @doc Configures actions on detected risks.
 %%
@@ -1130,6 +1329,22 @@ set_user_mfa_preference(Client, Input, Options)
     request(Client, <<"SetUserMFAPreference">>, Input, Options).
 
 %% @doc Set the user pool multi-factor authentication (MFA) configuration.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 set_user_pool_mfa_config(Client, Input)
   when is_map(Client), is_map(Input) ->
     set_user_pool_mfa_config(Client, Input, []).
@@ -1151,6 +1366,22 @@ set_user_settings(Client, Input, Options)
 
 %% @doc Registers the user in the specified user pool and creates a user
 %% name, password, and user attributes.
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 sign_up(Client, Input)
   when is_map(Client), is_map(Input) ->
     sign_up(Client, Input, []).
@@ -1233,9 +1464,6 @@ update_device_status(Client, Input, Options)
 %% @doc Updates the specified group with the specified attributes.
 %%
 %% Calling this action requires developer credentials.
-%%
-%% If you don't provide a value for an attribute, it will be set to the
-%% default value.
 update_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_group(Client, Input, []).
@@ -1265,6 +1493,22 @@ update_resource_server(Client, Input, Options)
     request(Client, <<"UpdateResourceServer">>, Input, Options).
 
 %% @doc Allows a user to update a specific attribute (one at a time).
+%%
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 update_user_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_user_attributes(Client, Input, []).
@@ -1275,10 +1519,24 @@ update_user_attributes(Client, Input, Options)
 %% @doc Updates the specified user pool with the specified attributes.
 %%
 %% You can get a list of the current user pool settings using
-%% DescribeUserPool.
+%% DescribeUserPool. If you don't provide a value for an attribute, it will
+%% be set to the default value.
 %%
-%% If you don't provide a value for an attribute, it will be set to the
-%% default value.
+%% This action might generate an SMS text message. Starting June 1, 2021,
+%% U.S. telecom carriers require that you register an origination phone
+%% number before you can send SMS messages to U.S. phone numbers. If you use
+%% SMS text messages in Amazon Cognito, you must register a phone number with
+%% Amazon Pinpoint. Cognito will use the the registered number automatically.
+%% Otherwise, Cognito users that must receive SMS messages might be unable to
+%% sign up, activate their accounts, or sign in.
+%%
+%% If you have never used SMS text messages with Amazon Cognito or any other
+%% Amazon Web Service, Amazon SNS might place your account in SMS sandbox. In
+%% sandbox mode , you’ll have limitations, such as sending messages to only
+%% verified phone numbers. After testing in the sandbox environment, you can
+%% move out of the SMS sandbox and into production. For more information, see
+%% SMS message settings for Cognito User Pools in the Amazon Cognito
+%% Developer Guide.
 update_user_pool(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_user_pool(Client, Input, []).
@@ -1294,6 +1552,9 @@ update_user_pool(Client, Input, Options)
 %%
 %% If you don't provide a value for an attribute, it will be set to the
 %% default value.
+%%
+%% You can also use this operation to enable token revocation for user pool
+%% clients. For more information about revoking tokens, see RevokeToken.
 update_user_pool_client(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_user_pool_client(Client, Input, []).
@@ -1310,9 +1571,9 @@ update_user_pool_client(Client, Input, Options)
 %%
 %% A custom domain is used to host the Amazon Cognito hosted UI, which
 %% provides sign-up and sign-in pages for your application. When you set up a
-%% custom domain, you provide a certificate that you manage with AWS
-%% Certificate Manager (ACM). When necessary, you can use this operation to
-%% change the certificate that you applied to your custom domain.
+%% custom domain, you provide a certificate that you manage with Certificate
+%% Manager (ACM). When necessary, you can use this operation to change the
+%% certificate that you applied to your custom domain.
 %%
 %% Usually, this is unnecessary following routine certificate renewal with
 %% ACM. When you renew your existing certificate in ACM, the ARN for your
@@ -1324,7 +1585,7 @@ update_user_pool_client(Client, Input, Options)
 %% custom domain, you must provide this ARN to Amazon Cognito.
 %%
 %% When you add your new certificate in ACM, you must choose US East (N.
-%% Virginia) as the AWS Region.
+%% Virginia) as the Region.
 %%
 %% After you submit your request, Amazon Cognito requires up to 1 hour to
 %% distribute your new certificate to your custom domain.

--- a/src/aws_cognito_sync.erl
+++ b/src/aws_cognito_sync.erl
@@ -1,0 +1,672 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Cognito Sync
+%%
+%% Amazon Cognito Sync provides an AWS service and client library that enable
+%% cross-device syncing of application-related user data.
+%%
+%% High-level client libraries are available for both iOS and Android. You
+%% can use these libraries to persist data locally so that it's available
+%% even if the device is offline. Developer credentials don't need to be
+%% stored on the mobile device to access the service. You can use Amazon
+%% Cognito to obtain a normalized user ID and credentials. User data is
+%% persisted in a dataset that can store up to 1 MB of key-value pairs, and
+%% you can have up to 20 datasets per user identity.
+%%
+%% With Amazon Cognito Sync, the data stored for each identity is accessible
+%% only to credentials assigned to that identity. In order to use the Cognito
+%% Sync service, you need to make API calls using credentials retrieved with
+%% Amazon Cognito Identity service.
+%%
+%% If you want to use Cognito Sync in an Android or iOS application, you will
+%% probably want to make API calls via the AWS Mobile SDK. To learn more, see
+%% the Developer Guide for Android and the Developer Guide for iOS.
+-module(aws_cognito_sync).
+
+-export([bulk_publish/3,
+         bulk_publish/4,
+         delete_dataset/5,
+         delete_dataset/6,
+         describe_dataset/4,
+         describe_dataset/6,
+         describe_dataset/7,
+         describe_identity_pool_usage/2,
+         describe_identity_pool_usage/4,
+         describe_identity_pool_usage/5,
+         describe_identity_usage/3,
+         describe_identity_usage/5,
+         describe_identity_usage/6,
+         get_bulk_publish_details/3,
+         get_bulk_publish_details/4,
+         get_cognito_events/2,
+         get_cognito_events/4,
+         get_cognito_events/5,
+         get_identity_pool_configuration/2,
+         get_identity_pool_configuration/4,
+         get_identity_pool_configuration/5,
+         list_datasets/3,
+         list_datasets/5,
+         list_datasets/6,
+         list_identity_pool_usage/1,
+         list_identity_pool_usage/3,
+         list_identity_pool_usage/4,
+         list_records/4,
+         list_records/6,
+         list_records/7,
+         register_device/4,
+         register_device/5,
+         set_cognito_events/3,
+         set_cognito_events/4,
+         set_identity_pool_configuration/3,
+         set_identity_pool_configuration/4,
+         subscribe_to_dataset/6,
+         subscribe_to_dataset/7,
+         unsubscribe_from_dataset/6,
+         unsubscribe_from_dataset/7,
+         update_records/5,
+         update_records/6]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Initiates a bulk publish of all existing datasets for an Identity
+%% Pool to the configured stream.
+%%
+%% Customers are limited to one successful bulk publish per 24 hours. Bulk
+%% publish is an asynchronous request, customers can see the status of the
+%% request via the GetBulkPublishDetails operation.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+bulk_publish(Client, IdentityPoolId, Input) ->
+    bulk_publish(Client, IdentityPoolId, Input, []).
+bulk_publish(Client, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/bulkpublish"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specific dataset.
+%%
+%% The dataset will be deleted permanently, and the action can't be undone.
+%% Datasets that this dataset was merged with will no longer report the
+%% merge. Any subsequent operation on this dataset will result in a
+%% ResourceNotFoundException.
+%%
+%% This API can be called with temporary user credentials provided by Cognito
+%% Identity or with developer credentials.
+delete_dataset(Client, DatasetName, IdentityId, IdentityPoolId, Input) ->
+    delete_dataset(Client, DatasetName, IdentityId, IdentityPoolId, Input, []).
+delete_dataset(Client, DatasetName, IdentityId, IdentityPoolId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets meta data about a dataset by identity and dataset name.
+%%
+%% With Amazon Cognito Sync, each identity has access only to its own data.
+%% Thus, the credentials used to make this API call need to have access to
+%% the identity data.
+%%
+%% This API can be called with temporary user credentials provided by Cognito
+%% Identity or with developer credentials. You should use Cognito Identity
+%% credentials to make this API call.
+describe_dataset(Client, DatasetName, IdentityId, IdentityPoolId)
+  when is_map(Client) ->
+    describe_dataset(Client, DatasetName, IdentityId, IdentityPoolId, #{}, #{}).
+
+describe_dataset(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_dataset(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap, []).
+
+describe_dataset(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets usage details (for example, data storage) about a particular
+%% identity pool.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+describe_identity_pool_usage(Client, IdentityPoolId)
+  when is_map(Client) ->
+    describe_identity_pool_usage(Client, IdentityPoolId, #{}, #{}).
+
+describe_identity_pool_usage(Client, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_identity_pool_usage(Client, IdentityPoolId, QueryMap, HeadersMap, []).
+
+describe_identity_pool_usage(Client, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets usage information for an identity, including number of datasets
+%% and data usage.
+%%
+%% This API can be called with temporary user credentials provided by Cognito
+%% Identity or with developer credentials.
+describe_identity_usage(Client, IdentityId, IdentityPoolId)
+  when is_map(Client) ->
+    describe_identity_usage(Client, IdentityId, IdentityPoolId, #{}, #{}).
+
+describe_identity_usage(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_identity_usage(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap, []).
+
+describe_identity_usage(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get the status of the last BulkPublish operation for an identity
+%% pool.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+get_bulk_publish_details(Client, IdentityPoolId, Input) ->
+    get_bulk_publish_details(Client, IdentityPoolId, Input, []).
+get_bulk_publish_details(Client, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/getBulkPublishDetails"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets the events and the corresponding Lambda functions associated
+%% with an identity pool.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+get_cognito_events(Client, IdentityPoolId)
+  when is_map(Client) ->
+    get_cognito_events(Client, IdentityPoolId, #{}, #{}).
+
+get_cognito_events(Client, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_cognito_events(Client, IdentityPoolId, QueryMap, HeadersMap, []).
+
+get_cognito_events(Client, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/events"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the configuration settings of an identity pool.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+get_identity_pool_configuration(Client, IdentityPoolId)
+  when is_map(Client) ->
+    get_identity_pool_configuration(Client, IdentityPoolId, #{}, #{}).
+
+get_identity_pool_configuration(Client, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_identity_pool_configuration(Client, IdentityPoolId, QueryMap, HeadersMap, []).
+
+get_identity_pool_configuration(Client, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/configuration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists datasets for an identity.
+%%
+%% With Amazon Cognito Sync, each identity has access only to its own data.
+%% Thus, the credentials used to make this API call need to have access to
+%% the identity data.
+%%
+%% ListDatasets can be called with temporary user credentials provided by
+%% Cognito Identity or with developer credentials. You should use the Cognito
+%% Identity credentials to make this API call.
+list_datasets(Client, IdentityId, IdentityPoolId)
+  when is_map(Client) ->
+    list_datasets(Client, IdentityId, IdentityPoolId, #{}, #{}).
+
+list_datasets(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_datasets(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap, []).
+
+list_datasets(Client, IdentityId, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets a list of identity pools registered with Cognito.
+%%
+%% ListIdentityPoolUsage can only be called with developer credentials. You
+%% cannot make this API call with the temporary user credentials provided by
+%% Cognito Identity.
+list_identity_pool_usage(Client)
+  when is_map(Client) ->
+    list_identity_pool_usage(Client, #{}, #{}).
+
+list_identity_pool_usage(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_identity_pool_usage(Client, QueryMap, HeadersMap, []).
+
+list_identity_pool_usage(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets paginated records, optionally changed after a particular sync
+%% count for a dataset and identity.
+%%
+%% With Amazon Cognito Sync, each identity has access only to its own data.
+%% Thus, the credentials used to make this API call need to have access to
+%% the identity data.
+%%
+%% ListRecords can be called with temporary user credentials provided by
+%% Cognito Identity or with developer credentials. You should use Cognito
+%% Identity credentials to make this API call.
+list_records(Client, DatasetName, IdentityId, IdentityPoolId)
+  when is_map(Client) ->
+    list_records(Client, DatasetName, IdentityId, IdentityPoolId, #{}, #{}).
+
+list_records(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_records(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap, []).
+
+list_records(Client, DatasetName, IdentityId, IdentityPoolId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), "/records"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"lastSyncCount">>, maps:get(<<"lastSyncCount">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"syncSessionToken">>, maps:get(<<"syncSessionToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Registers a device to receive push sync notifications.
+%%
+%% This API can only be called with temporary credentials provided by Cognito
+%% Identity. You cannot call this API with developer credentials.
+register_device(Client, IdentityId, IdentityPoolId, Input) ->
+    register_device(Client, IdentityId, IdentityPoolId, Input, []).
+register_device(Client, IdentityId, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identity/", aws_util:encode_uri(IdentityId), "/device"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Sets the AWS Lambda function for a given event type for an identity
+%% pool.
+%%
+%% This request only updates the key/value pair specified. Other key/values
+%% pairs are not updated. To remove a key value pair, pass a empty value for
+%% the particular key.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+set_cognito_events(Client, IdentityPoolId, Input) ->
+    set_cognito_events(Client, IdentityPoolId, Input, []).
+set_cognito_events(Client, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/events"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Sets the necessary configuration for push sync.
+%%
+%% This API can only be called with developer credentials. You cannot call
+%% this API with the temporary user credentials provided by Cognito Identity.
+set_identity_pool_configuration(Client, IdentityPoolId, Input) ->
+    set_identity_pool_configuration(Client, IdentityPoolId, Input, []).
+set_identity_pool_configuration(Client, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/configuration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Subscribes to receive notifications when a dataset is modified by
+%% another device.
+%%
+%% This API can only be called with temporary credentials provided by Cognito
+%% Identity. You cannot call this API with developer credentials.
+subscribe_to_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input) ->
+    subscribe_to_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input, []).
+subscribe_to_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), "/subscriptions/", aws_util:encode_uri(DeviceId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Unsubscribes from receiving notifications when a dataset is modified
+%% by another device.
+%%
+%% This API can only be called with temporary credentials provided by Cognito
+%% Identity. You cannot call this API with developer credentials.
+unsubscribe_from_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input) ->
+    unsubscribe_from_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input, []).
+unsubscribe_from_dataset(Client, DatasetName, DeviceId, IdentityId, IdentityPoolId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), "/subscriptions/", aws_util:encode_uri(DeviceId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Posts updates to records and adds and deletes records for a dataset
+%% and user.
+%%
+%% The sync count in the record patch is your last known sync count for that
+%% record. The server will reject an UpdateRecords request with a
+%% ResourceConflictException if you try to patch a record with a new value
+%% but a stale sync count.
+%%
+%% For example, if the sync count on the server is 5 for a key called
+%% highScore and you try and submit a new highScore with sync count of 4, the
+%% request will be rejected. To obtain the current sync count for a record,
+%% call ListRecords. On a successful update of the record, the response
+%% returns the new sync count for that record. You should present that sync
+%% count the next time you try to update that same record. When the record
+%% does not exist, specify the sync count as 0.
+%%
+%% This API can be called with temporary user credentials provided by Cognito
+%% Identity or with developer credentials.
+update_records(Client, DatasetName, IdentityId, IdentityPoolId, Input) ->
+    update_records(Client, DatasetName, IdentityId, IdentityPoolId, Input, []).
+update_records(Client, DatasetName, IdentityId, IdentityPoolId, Input0, Options0) ->
+    Method = post,
+    Path = ["/identitypools/", aws_util:encode_uri(IdentityPoolId), "/identities/", aws_util:encode_uri(IdentityId), "/datasets/", aws_util:encode_uri(DatasetName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-Client-Context">>, <<"ClientContext">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"cognito-sync">>},
+    Host = build_host(<<"cognito-sync">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_comprehend.erl
+++ b/src/aws_comprehend.erl
@@ -21,6 +21,8 @@
          batch_detect_syntax/3,
          classify_document/2,
          classify_document/3,
+         contains_pii_entities/2,
+         contains_pii_entities/3,
          create_document_classifier/2,
          create_document_classifier/3,
          create_endpoint/2,
@@ -69,6 +71,8 @@
          detect_syntax/3,
          list_document_classification_jobs/2,
          list_document_classification_jobs/3,
+         list_document_classifier_summaries/2,
+         list_document_classifier_summaries/3,
          list_document_classifiers/2,
          list_document_classifiers/3,
          list_dominant_language_detection_jobs/2,
@@ -77,6 +81,8 @@
          list_endpoints/3,
          list_entities_detection_jobs/2,
          list_entities_detection_jobs/3,
+         list_entity_recognizer_summaries/2,
+         list_entity_recognizer_summaries/3,
          list_entity_recognizers/2,
          list_entity_recognizers/3,
          list_events_detection_jobs/2,
@@ -197,6 +203,16 @@ classify_document(Client, Input)
 classify_document(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ClassifyDocument">>, Input, Options).
+
+%% @doc Analyzes input text for the presence of personally identifiable
+%% information (PII) and returns the labels of identified PII entity types
+%% such as name, address, bank account number, or phone number.
+contains_pii_entities(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    contains_pii_entities(Client, Input, []).
+contains_pii_entities(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ContainsPiiEntities">>, Input, Options).
 
 %% @doc Creates a new document classifier that you can use to categorize
 %% documents.
@@ -452,6 +468,15 @@ list_document_classification_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListDocumentClassificationJobs">>, Input, Options).
 
+%% @doc Gets a list of summaries of the document classifiers that you have
+%% created
+list_document_classifier_summaries(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_document_classifier_summaries(Client, Input, []).
+list_document_classifier_summaries(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDocumentClassifierSummaries">>, Input, Options).
+
 %% @doc Gets a list of the document classifiers that you have created.
 list_document_classifiers(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -484,6 +509,15 @@ list_entities_detection_jobs(Client, Input)
 list_entities_detection_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListEntitiesDetectionJobs">>, Input, Options).
+
+%% @doc Gets a list of summaries for the entity recognizers that you have
+%% created.
+list_entity_recognizer_summaries(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_entity_recognizer_summaries(Client, Input, []).
+list_entity_recognizer_summaries(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEntityRecognizerSummaries">>, Input, Options).
 
 %% @doc Gets a list of the properties of all entity recognizers that you
 %% created, including recognizers currently in training.

--- a/src/aws_compute_optimizer.erl
+++ b/src/aws_compute_optimizer.erl
@@ -1,29 +1,33 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Compute Optimizer is a service that analyzes the configuration
-%% and utilization metrics of your AWS compute resources, such as EC2
-%% instances, Auto Scaling groups, AWS Lambda functions, and Amazon EBS
-%% volumes.
+%% @doc Compute Optimizer is a service that analyzes the configuration and
+%% utilization metrics of your Amazon Web Services compute resources, such as
+%% Amazon EC2 instances, Amazon EC2 Auto Scaling groups, Lambda functions,
+%% and Amazon EBS volumes.
 %%
 %% It reports whether your resources are optimal, and generates optimization
 %% recommendations to reduce the cost and improve the performance of your
 %% workloads. Compute Optimizer also provides recent utilization metric data,
-%% as well as projected utilization metric data for the recommendations,
+%% in addition to projected utilization metric data for the recommendations,
 %% which you can use to evaluate which recommendation provides the best
 %% price-performance trade-off. The analysis of your usage patterns can help
 %% you decide when to move or resize your running resources, and still meet
 %% your performance and capacity requirements. For more information about
 %% Compute Optimizer, including the required permissions to use the service,
-%% see the AWS Compute Optimizer User Guide.
+%% see the Compute Optimizer User Guide.
 -module(aws_compute_optimizer).
 
 -export([describe_recommendation_export_jobs/2,
          describe_recommendation_export_jobs/3,
          export_auto_scaling_group_recommendations/2,
          export_auto_scaling_group_recommendations/3,
+         export_ebs_volume_recommendations/2,
+         export_ebs_volume_recommendations/3,
          export_ec2_instance_recommendations/2,
          export_ec2_instance_recommendations/3,
+         export_lambda_function_recommendations/2,
+         export_lambda_function_recommendations/3,
          get_auto_scaling_group_recommendations/2,
          get_auto_scaling_group_recommendations/3,
          get_ebs_volume_recommendations/2,
@@ -34,6 +38,8 @@
          get_ec2_recommendation_projected_metrics/3,
          get_enrollment_status/2,
          get_enrollment_status/3,
+         get_enrollment_statuses_for_organization/2,
+         get_enrollment_statuses_for_organization/3,
          get_lambda_function_recommendations/2,
          get_lambda_function_recommendations/3,
          get_recommendation_summaries/2,
@@ -63,13 +69,13 @@ describe_recommendation_export_jobs(Client, Input, Options)
 %% @doc Exports optimization recommendations for Auto Scaling groups.
 %%
 %% Recommendations are exported in a comma-separated values (.csv) file, and
-%% its metadata in a JavaScript Object Notation (.json) file, to an existing
-%% Amazon Simple Storage Service (Amazon S3) bucket that you specify. For
-%% more information, see Exporting Recommendations in the Compute Optimizer
-%% User Guide.
+%% its metadata in a JavaScript Object Notation (JSON) (.json) file, to an
+%% existing Amazon Simple Storage Service (Amazon S3) bucket that you
+%% specify. For more information, see Exporting Recommendations in the
+%% Compute Optimizer User Guide.
 %%
-%% You can have only one Auto Scaling group export job in progress per AWS
-%% Region.
+%% You can have only one Auto Scaling group export job in progress per Amazon
+%% Web Services Region.
 export_auto_scaling_group_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
     export_auto_scaling_group_recommendations(Client, Input, []).
@@ -77,16 +83,33 @@ export_auto_scaling_group_recommendations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ExportAutoScalingGroupRecommendations">>, Input, Options).
 
+%% @doc Exports optimization recommendations for Amazon EBS volumes.
+%%
+%% Recommendations are exported in a comma-separated values (.csv) file, and
+%% its metadata in a JavaScript Object Notation (JSON) (.json) file, to an
+%% existing Amazon Simple Storage Service (Amazon S3) bucket that you
+%% specify. For more information, see Exporting Recommendations in the
+%% Compute Optimizer User Guide.
+%%
+%% You can have only one Amazon EBS volume export job in progress per Amazon
+%% Web Services Region.
+export_ebs_volume_recommendations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    export_ebs_volume_recommendations(Client, Input, []).
+export_ebs_volume_recommendations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ExportEBSVolumeRecommendations">>, Input, Options).
+
 %% @doc Exports optimization recommendations for Amazon EC2 instances.
 %%
 %% Recommendations are exported in a comma-separated values (.csv) file, and
-%% its metadata in a JavaScript Object Notation (.json) file, to an existing
-%% Amazon Simple Storage Service (Amazon S3) bucket that you specify. For
-%% more information, see Exporting Recommendations in the Compute Optimizer
-%% User Guide.
+%% its metadata in a JavaScript Object Notation (JSON) (.json) file, to an
+%% existing Amazon Simple Storage Service (Amazon S3) bucket that you
+%% specify. For more information, see Exporting Recommendations in the
+%% Compute Optimizer User Guide.
 %%
-%% You can have only one Amazon EC2 instance export job in progress per AWS
-%% Region.
+%% You can have only one Amazon EC2 instance export job in progress per
+%% Amazon Web Services Region.
 export_ec2_instance_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
     export_ec2_instance_recommendations(Client, Input, []).
@@ -94,12 +117,29 @@ export_ec2_instance_recommendations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ExportEC2InstanceRecommendations">>, Input, Options).
 
+%% @doc Exports optimization recommendations for Lambda functions.
+%%
+%% Recommendations are exported in a comma-separated values (.csv) file, and
+%% its metadata in a JavaScript Object Notation (JSON) (.json) file, to an
+%% existing Amazon Simple Storage Service (Amazon S3) bucket that you
+%% specify. For more information, see Exporting Recommendations in the
+%% Compute Optimizer User Guide.
+%%
+%% You can have only one Lambda function export job in progress per Amazon
+%% Web Services Region.
+export_lambda_function_recommendations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    export_lambda_function_recommendations(Client, Input, []).
+export_lambda_function_recommendations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ExportLambdaFunctionRecommendations">>, Input, Options).
+
 %% @doc Returns Auto Scaling group recommendations.
 %%
-%% AWS Compute Optimizer generates recommendations for Amazon EC2 Auto
-%% Scaling groups that meet a specific set of requirements. For more
-%% information, see the Supported resources and requirements in the AWS
-%% Compute Optimizer User Guide.
+%% Compute Optimizer generates recommendations for Amazon EC2 Auto Scaling
+%% groups that meet a specific set of requirements. For more information, see
+%% the Supported resources and requirements in the Compute Optimizer User
+%% Guide.
 get_auto_scaling_group_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_auto_scaling_group_recommendations(Client, Input, []).
@@ -110,10 +150,9 @@ get_auto_scaling_group_recommendations(Client, Input, Options)
 %% @doc Returns Amazon Elastic Block Store (Amazon EBS) volume
 %% recommendations.
 %%
-%% AWS Compute Optimizer generates recommendations for Amazon EBS volumes
-%% that meet a specific set of requirements. For more information, see the
-%% Supported resources and requirements in the AWS Compute Optimizer User
-%% Guide.
+%% Compute Optimizer generates recommendations for Amazon EBS volumes that
+%% meet a specific set of requirements. For more information, see the
+%% Supported resources and requirements in the Compute Optimizer User Guide.
 get_ebs_volume_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ebs_volume_recommendations(Client, Input, []).
@@ -123,9 +162,9 @@ get_ebs_volume_recommendations(Client, Input, Options)
 
 %% @doc Returns Amazon EC2 instance recommendations.
 %%
-%% AWS Compute Optimizer generates recommendations for Amazon Elastic Compute
+%% Compute Optimizer generates recommendations for Amazon Elastic Compute
 %% Cloud (Amazon EC2) instances that meet a specific set of requirements. For
-%% more information, see the Supported resources and requirements in the AWS
+%% more information, see the Supported resources and requirements in the
 %% Compute Optimizer User Guide.
 get_ec2_instance_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -149,11 +188,13 @@ get_ec2_recommendation_projected_metrics(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetEC2RecommendationProjectedMetrics">>, Input, Options).
 
-%% @doc Returns the enrollment (opt in) status of an account to the AWS
-%% Compute Optimizer service.
+%% @doc Returns the enrollment (opt in) status of an account to the Compute
+%% Optimizer service.
 %%
 %% If the account is the management account of an organization, this action
-%% also confirms the enrollment status of member accounts within the
+%% also confirms the enrollment status of member accounts of the
+%% organization. Use the `GetEnrollmentStatusesForOrganization' action to get
+%% detailed information about the enrollment status of member accounts of an
 %% organization.
 get_enrollment_status(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -162,11 +203,24 @@ get_enrollment_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetEnrollmentStatus">>, Input, Options).
 
-%% @doc Returns AWS Lambda function recommendations.
+%% @doc Returns the Compute Optimizer enrollment (opt-in) status of
+%% organization member accounts, if your account is an organization
+%% management account.
 %%
-%% AWS Compute Optimizer generates recommendations for functions that meet a
+%% To get the enrollment status of standalone accounts, use the
+%% `GetEnrollmentStatus' action.
+get_enrollment_statuses_for_organization(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_enrollment_statuses_for_organization(Client, Input, []).
+get_enrollment_statuses_for_organization(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEnrollmentStatusesForOrganization">>, Input, Options).
+
+%% @doc Returns Lambda function recommendations.
+%%
+%% Compute Optimizer generates recommendations for functions that meet a
 %% specific set of requirements. For more information, see the Supported
-%% resources and requirements in the AWS Compute Optimizer User Guide.
+%% resources and requirements in the Compute Optimizer User Guide.
 get_lambda_function_recommendations(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_lambda_function_recommendations(Client, Input, []).
@@ -199,20 +253,20 @@ get_recommendation_summaries(Client, Input, Options)
     request(Client, <<"GetRecommendationSummaries">>, Input, Options).
 
 %% @doc Updates the enrollment (opt in and opt out) status of an account to
-%% the AWS Compute Optimizer service.
+%% the Compute Optimizer service.
 %%
 %% If the account is a management account of an organization, this action can
-%% also be used to enroll member accounts within the organization.
+%% also be used to enroll member accounts of the organization.
 %%
 %% You must have the appropriate permissions to opt in to Compute Optimizer,
 %% to view its recommendations, and to opt out. For more information, see
-%% Controlling access with AWS Identity and Access Management in the Compute
-%% Optimizer User Guide.
+%% Controlling access with Amazon Web Services Identity and Access Management
+%% in the Compute Optimizer User Guide.
 %%
-%% When you opt in, Compute Optimizer automatically creates a Service-Linked
-%% Role in your account to access its data. For more information, see Using
-%% Service-Linked Roles for AWS Compute Optimizer in the Compute Optimizer
-%% User Guide.
+%% When you opt in, Compute Optimizer automatically creates a service-linked
+%% role in your account to access its data. For more information, see Using
+%% Service-Linked Roles for Compute Optimizer in the Compute Optimizer User
+%% Guide.
 update_enrollment_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_enrollment_status(Client, Input, []).

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -1,28 +1,31 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Config
+%% @doc Config
 %%
-%% AWS Config provides a way to keep track of the configurations of all the
-%% AWS resources associated with your AWS account.
+%% Config provides a way to keep track of the configurations of all the
+%% Amazon Web Services resources associated with your Amazon Web Services
+%% account.
 %%
-%% You can use AWS Config to get the current and historical configurations of
-%% each AWS resource and also to get information about the relationship
-%% between the resources. An AWS resource can be an Amazon Compute Cloud
-%% (Amazon EC2) instance, an Elastic Block Store (EBS) volume, an elastic
-%% network Interface (ENI), or a security group. For a complete list of
-%% resources currently supported by AWS Config, see Supported AWS Resources.
+%% You can use Config to get the current and historical configurations of
+%% each Amazon Web Services resource and also to get information about the
+%% relationship between the resources. An Amazon Web Services resource can be
+%% an Amazon Compute Cloud (Amazon EC2) instance, an Elastic Block Store
+%% (EBS) volume, an elastic network Interface (ENI), or a security group. For
+%% a complete list of resources currently supported by Config, see Supported
+%% Amazon Web Services resources.
 %%
-%% You can access and manage AWS Config through the AWS Management Console,
-%% the AWS Command Line Interface (AWS CLI), the AWS Config API, or the AWS
-%% SDKs for AWS Config. This reference guide contains documentation for the
-%% AWS Config API and the AWS CLI commands that you can use to manage AWS
-%% Config. The AWS Config API uses the Signature Version 4 protocol for
-%% signing requests. For more information about how to sign a request with
-%% this protocol, see Signature Version 4 Signing Process. For detailed
-%% information about AWS Config features and their associated actions or
-%% commands, as well as how to work with AWS Management Console, see What Is
-%% AWS Config in the AWS Config Developer Guide.
+%% You can access and manage Config through the Amazon Web Services
+%% Management Console, the Amazon Web Services Command Line Interface (Amazon
+%% Web Services CLI), the Config API, or the Amazon Web Services SDKs for
+%% Config. This reference guide contains documentation for the Config API and
+%% the Amazon Web Services CLI commands that you can use to manage Config.
+%% The Config API uses the Signature Version 4 protocol for signing requests.
+%% For more information about how to sign a request with this protocol, see
+%% Signature Version 4 Signing Process. For detailed information about Config
+%% features and their associated actions or commands, as well as how to work
+%% with Amazon Web Services Management Console, see What Is Config in the
+%% Config Developer Guide.
 -module(aws_config).
 
 -export([batch_get_aggregate_resource_config/2,
@@ -63,6 +66,8 @@
          deliver_config_snapshot/3,
          describe_aggregate_compliance_by_config_rules/2,
          describe_aggregate_compliance_by_config_rules/3,
+         describe_aggregate_compliance_by_conformance_packs/2,
+         describe_aggregate_compliance_by_conformance_packs/3,
          describe_aggregation_authorizations/2,
          describe_aggregation_authorizations/3,
          describe_compliance_by_config_rule/2,
@@ -113,6 +118,8 @@
          get_aggregate_compliance_details_by_config_rule/3,
          get_aggregate_config_rule_compliance_summary/2,
          get_aggregate_config_rule_compliance_summary/3,
+         get_aggregate_conformance_pack_compliance_summary/2,
+         get_aggregate_conformance_pack_compliance_summary/3,
          get_aggregate_discovered_resource_counts/2,
          get_aggregate_discovered_resource_counts/3,
          get_aggregate_resource_config/2,
@@ -201,7 +208,7 @@
 %%====================================================================
 
 %% @doc Returns the current configuration items for resources that are
-%% present in your AWS Config aggregator.
+%% present in your Config aggregator.
 %%
 %% The operation also returns a list of resources that are not processed in
 %% the current request. If there are no unprocessed resources, the operation
@@ -217,7 +224,7 @@ batch_get_aggregate_resource_config(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchGetAggregateResourceConfig">>, Input, Options).
 
-%% @doc Returns the current configuration for one or more requested
+%% @doc Returns the `BaseConfigurationItem' for one or more requested
 %% resources.
 %%
 %% The operation also returns a list of resources that are not processed in
@@ -245,10 +252,9 @@ delete_aggregation_authorization(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAggregationAuthorization">>, Input, Options).
 
-%% @doc Deletes the specified AWS Config rule and all of its evaluation
-%% results.
+%% @doc Deletes the specified Config rule and all of its evaluation results.
 %%
-%% AWS Config sets the state of a rule to `DELETING' until the deletion is
+%% Config sets the state of a rule to `DELETING' until the deletion is
 %% complete. You cannot update a rule while it is in this state. If you make
 %% a `PutConfigRule' or `DeleteConfigRule' request for the rule, you will
 %% receive a `ResourceInUseException'.
@@ -273,14 +279,14 @@ delete_configuration_aggregator(Client, Input, Options)
 
 %% @doc Deletes the configuration recorder.
 %%
-%% After the configuration recorder is deleted, AWS Config will not record
+%% After the configuration recorder is deleted, Config will not record
 %% resource configuration changes until you create a new configuration
 %% recorder.
 %%
 %% This action does not delete the configuration information that was
 %% previously recorded. You will be able to access the previously recorded
 %% information by using the `GetResourceConfigHistory' action, but you will
-%% not be able to access this information in the AWS Config console until you
+%% not be able to access this information in the Config console until you
 %% create a new configuration recorder.
 delete_configuration_recorder(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -289,11 +295,11 @@ delete_configuration_recorder(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteConfigurationRecorder">>, Input, Options).
 
-%% @doc Deletes the specified conformance pack and all the AWS Config rules,
+%% @doc Deletes the specified conformance pack and all the Config rules,
 %% remediation actions, and all evaluation results within that conformance
 %% pack.
 %%
-%% AWS Config sets the conformance pack to `DELETE_IN_PROGRESS' until the
+%% Config sets the conformance pack to `DELETE_IN_PROGRESS' until the
 %% deletion is complete. You cannot update a conformance pack while it is in
 %% this state.
 delete_conformance_pack(Client, Input)
@@ -314,11 +320,11 @@ delete_delivery_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteDeliveryChannel">>, Input, Options).
 
-%% @doc Deletes the evaluation results for the specified AWS Config rule.
+%% @doc Deletes the evaluation results for the specified Config rule.
 %%
-%% You can specify one AWS Config rule per request. After you delete the
+%% You can specify one Config rule per request. After you delete the
 %% evaluation results, you can call the `StartConfigRulesEvaluation' API to
-%% start evaluating your AWS resources against the rule.
+%% start evaluating your Amazon Web Services resources against the rule.
 delete_evaluation_results(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_evaluation_results(Client, Input, []).
@@ -331,11 +337,11 @@ delete_evaluation_results(Client, Input, Options)
 %%
 %% Only a master account and a delegated administrator account can delete an
 %% organization config rule. When calling this API with a delegated
-%% administrator, you must ensure AWS Organizations
-%% `ListDelegatedAdministrator' permissions are added.
+%% administrator, you must ensure Organizations `ListDelegatedAdministrator'
+%% permissions are added.
 %%
-%% AWS Config sets the state of a rule to DELETE_IN_PROGRESS until the
-%% deletion is complete. You cannot update a rule while it is in this state.
+%% Config sets the state of a rule to DELETE_IN_PROGRESS until the deletion
+%% is complete. You cannot update a rule while it is in this state.
 delete_organization_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_organization_config_rule(Client, Input, []).
@@ -349,12 +355,12 @@ delete_organization_config_rule(Client, Input, Options)
 %%
 %% Only a master account or a delegated administrator account can delete an
 %% organization conformance pack. When calling this API with a delegated
-%% administrator, you must ensure AWS Organizations
-%% `ListDelegatedAdministrator' permissions are added.
+%% administrator, you must ensure Organizations `ListDelegatedAdministrator'
+%% permissions are added.
 %%
-%% AWS Config sets the state of a conformance pack to DELETE_IN_PROGRESS
-%% until the deletion is complete. You cannot update a conformance pack while
-%% it is in this state.
+%% Config sets the state of a conformance pack to DELETE_IN_PROGRESS until
+%% the deletion is complete. You cannot update a conformance pack while it is
+%% in this state.
 delete_organization_conformance_pack(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_organization_conformance_pack(Client, Input, []).
@@ -382,9 +388,9 @@ delete_remediation_configuration(Client, Input, Options)
 %% @doc Deletes one or more remediation exceptions mentioned in the resource
 %% keys.
 %%
-%% AWS Config generates a remediation exception when a problem occurs
-%% executing a remediation action to a specific resource. Remediation
-%% exceptions blocks auto-remediation until the exception is cleared.
+%% Config generates a remediation exception when a problem occurs executing a
+%% remediation action to a specific resource. Remediation exceptions blocks
+%% auto-remediation until the exception is cleared.
 delete_remediation_exceptions(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_remediation_exceptions(Client, Input, []).
@@ -397,7 +403,7 @@ delete_remediation_exceptions(Client, Input, Options)
 %%
 %% This API records a new ConfigurationItem with a ResourceDeleted status.
 %% You can retrieve the ConfigurationItems recorded for this resource in your
-%% AWS Config History.
+%% Config History.
 delete_resource_config(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_resource_config(Client, Input, []).
@@ -413,8 +419,8 @@ delete_retention_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteRetentionConfiguration">>, Input, Options).
 
-%% @doc Deletes the stored query for a single AWS account and a single AWS
-%% Region.
+%% @doc Deletes the stored query for a single Amazon Web Services account and
+%% a single Amazon Web Services Region.
 delete_stored_query(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_stored_query(Client, Input, []).
@@ -425,8 +431,8 @@ delete_stored_query(Client, Input, Options)
 %% @doc Schedules delivery of a configuration snapshot to the Amazon S3
 %% bucket in the specified delivery channel.
 %%
-%% After the delivery has started, AWS Config sends the following
-%% notifications using an Amazon SNS topic that you have specified.
+%% After the delivery has started, Config sends the following notifications
+%% using an Amazon SNS topic that you have specified.
 %%
 %% <ul> <li> Notification of the start of the delivery.
 %%
@@ -446,6 +452,8 @@ deliver_config_snapshot(Client, Input, Options)
 %% @doc Returns a list of compliant and noncompliant rules with the number of
 %% resources for compliant and noncompliant rules.
 %%
+%% Does not display rules that do not have compliance results.
+%%
 %% The results can return an empty result page, but if you have a
 %% `nextToken', the results are displayed on the next page.
 describe_aggregate_compliance_by_config_rules(Client, Input)
@@ -454,6 +462,23 @@ describe_aggregate_compliance_by_config_rules(Client, Input)
 describe_aggregate_compliance_by_config_rules(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAggregateComplianceByConfigRules">>, Input, Options).
+
+%% @doc Returns a list of the conformance packs and their associated
+%% compliance status with the count of compliant and noncompliant Config
+%% rules within each conformance pack.
+%%
+%% Also returns the total rule count which includes compliant rules,
+%% noncompliant rules, and rules that cannot be evaluated due to insufficient
+%% data.
+%%
+%% The results can return an empty result page, but if you have a
+%% `nextToken', the results are displayed on the next page.
+describe_aggregate_compliance_by_conformance_packs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_aggregate_compliance_by_conformance_packs(Client, Input, []).
+describe_aggregate_compliance_by_conformance_packs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeAggregateComplianceByConformancePacks">>, Input, Options).
 
 %% @doc Returns a list of authorizations granted to various aggregator
 %% accounts and regions.
@@ -464,31 +489,31 @@ describe_aggregation_authorizations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAggregationAuthorizations">>, Input, Options).
 
-%% @doc Indicates whether the specified AWS Config rules are compliant.
+%% @doc Indicates whether the specified Config rules are compliant.
 %%
-%% If a rule is noncompliant, this action returns the number of AWS resources
-%% that do not comply with the rule.
+%% If a rule is noncompliant, this action returns the number of Amazon Web
+%% Services resources that do not comply with the rule.
 %%
 %% A rule is compliant if all of the evaluated resources comply with it. It
 %% is noncompliant if any of these resources do not comply.
 %%
-%% If AWS Config has no current evaluation results for the rule, it returns
+%% If Config has no current evaluation results for the rule, it returns
 %% `INSUFFICIENT_DATA'. This result might indicate one of the following
 %% conditions:
 %%
-%% <ul> <li> AWS Config has never invoked an evaluation for the rule. To
-%% check whether it has, use the `DescribeConfigRuleEvaluationStatus' action
-%% to get the `LastSuccessfulInvocationTime' and `LastFailedInvocationTime'.
+%% <ul> <li> Config has never invoked an evaluation for the rule. To check
+%% whether it has, use the `DescribeConfigRuleEvaluationStatus' action to get
+%% the `LastSuccessfulInvocationTime' and `LastFailedInvocationTime'.
 %%
-%% </li> <li> The rule's AWS Lambda function is failing to send evaluation
-%% results to AWS Config. Verify that the role you assigned to your
-%% configuration recorder includes the `config:PutEvaluations' permission. If
-%% the rule is a custom rule, verify that the AWS Lambda execution role
-%% includes the `config:PutEvaluations' permission.
+%% </li> <li> The rule's Lambda function is failing to send evaluation
+%% results to Config. Verify that the role you assigned to your configuration
+%% recorder includes the `config:PutEvaluations' permission. If the rule is a
+%% custom rule, verify that the Lambda execution role includes the
+%% `config:PutEvaluations' permission.
 %%
-%% </li> <li> The rule's AWS Lambda function has returned `NOT_APPLICABLE'
-%% for all evaluation results. This can occur if the resources were deleted
-%% or removed from the rule's scope.
+%% </li> <li> The rule's Lambda function has returned `NOT_APPLICABLE' for
+%% all evaluation results. This can occur if the resources were deleted or
+%% removed from the rule's scope.
 %%
 %% </li> </ul>
 describe_compliance_by_config_rule(Client, Input)
@@ -498,32 +523,33 @@ describe_compliance_by_config_rule(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeComplianceByConfigRule">>, Input, Options).
 
-%% @doc Indicates whether the specified AWS resources are compliant.
+%% @doc Indicates whether the specified Amazon Web Services resources are
+%% compliant.
 %%
-%% If a resource is noncompliant, this action returns the number of AWS
-%% Config rules that the resource does not comply with.
+%% If a resource is noncompliant, this action returns the number of Config
+%% rules that the resource does not comply with.
 %%
-%% A resource is compliant if it complies with all the AWS Config rules that
+%% A resource is compliant if it complies with all the Config rules that
 %% evaluate it. It is noncompliant if it does not comply with one or more of
 %% these rules.
 %%
-%% If AWS Config has no current evaluation results for the resource, it
-%% returns `INSUFFICIENT_DATA'. This result might indicate one of the
-%% following conditions about the rules that evaluate the resource:
+%% If Config has no current evaluation results for the resource, it returns
+%% `INSUFFICIENT_DATA'. This result might indicate one of the following
+%% conditions about the rules that evaluate the resource:
 %%
-%% <ul> <li> AWS Config has never invoked an evaluation for the rule. To
-%% check whether it has, use the `DescribeConfigRuleEvaluationStatus' action
-%% to get the `LastSuccessfulInvocationTime' and `LastFailedInvocationTime'.
+%% <ul> <li> Config has never invoked an evaluation for the rule. To check
+%% whether it has, use the `DescribeConfigRuleEvaluationStatus' action to get
+%% the `LastSuccessfulInvocationTime' and `LastFailedInvocationTime'.
 %%
-%% </li> <li> The rule's AWS Lambda function is failing to send evaluation
-%% results to AWS Config. Verify that the role that you assigned to your
+%% </li> <li> The rule's Lambda function is failing to send evaluation
+%% results to Config. Verify that the role that you assigned to your
 %% configuration recorder includes the `config:PutEvaluations' permission. If
-%% the rule is a custom rule, verify that the AWS Lambda execution role
-%% includes the `config:PutEvaluations' permission.
+%% the rule is a custom rule, verify that the Lambda execution role includes
+%% the `config:PutEvaluations' permission.
 %%
-%% </li> <li> The rule's AWS Lambda function has returned `NOT_APPLICABLE'
-%% for all evaluation results. This can occur if the resources were deleted
-%% or removed from the rule's scope.
+%% </li> <li> The rule's Lambda function has returned `NOT_APPLICABLE' for
+%% all evaluation results. This can occur if the resources were deleted or
+%% removed from the rule's scope.
 %%
 %% </li> </ul>
 describe_compliance_by_resource(Client, Input)
@@ -533,11 +559,11 @@ describe_compliance_by_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeComplianceByResource">>, Input, Options).
 
-%% @doc Returns status information for each of your AWS managed Config rules.
+%% @doc Returns status information for each of your Config managed rules.
 %%
-%% The status includes information such as the last time AWS Config invoked
-%% the rule, the last time AWS Config failed to invoke the rule, and the
-%% related error for the last failure.
+%% The status includes information such as the last time Config invoked the
+%% rule, the last time Config failed to invoke the rule, and the related
+%% error for the last failure.
 describe_config_rule_evaluation_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_config_rule_evaluation_status(Client, Input, []).
@@ -545,7 +571,7 @@ describe_config_rule_evaluation_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeConfigRuleEvaluationStatus">>, Input, Options).
 
-%% @doc Returns details about your AWS Config rules.
+%% @doc Returns details about your Config rules.
 describe_config_rules(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_config_rules(Client, Input, []).
@@ -555,7 +581,7 @@ describe_config_rules(Client, Input, Options)
 
 %% @doc Returns status information for sources within an aggregator.
 %%
-%% The status includes information about the last time AWS Config verified
+%% The status includes information about the last time Config verified
 %% authorization between the source account and an aggregator account. In
 %% case of a failure, the status contains the related error code or message.
 describe_configuration_aggregator_sources_status(Client, Input)
@@ -747,9 +773,9 @@ describe_remediation_configurations(Client, Input, Options)
 %% will be deleted. When you specify the limit and the next token, you
 %% receive a paginated response.
 %%
-%% AWS Config generates a remediation exception when a problem occurs
-%% executing a remediation action to a specific resource. Remediation
-%% exceptions blocks auto-remediation until the exception is cleared.
+%% Config generates a remediation exception when a problem occurs executing a
+%% remediation action to a specific resource. Remediation exceptions blocks
+%% auto-remediation until the exception is cleared.
 %%
 %% When you specify the limit and the next token, you receive a paginated
 %% response.
@@ -781,8 +807,8 @@ describe_remediation_execution_status(Client, Input, Options)
 %% If the retention configuration name is not specified, this action returns
 %% the details for all the retention configurations for that account.
 %%
-%% Currently, AWS Config supports only one retention configuration per region
-%% in your account.
+%% Currently, Config supports only one retention configuration per region in
+%% your account.
 describe_retention_configurations(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_retention_configurations(Client, Input, []).
@@ -790,12 +816,12 @@ describe_retention_configurations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeRetentionConfigurations">>, Input, Options).
 
-%% @doc Returns the evaluation results for the specified AWS Config rule for
-%% a specific resource in a rule.
+%% @doc Returns the evaluation results for the specified Config rule for a
+%% specific resource in a rule.
 %%
-%% The results indicate which AWS resources were evaluated by the rule, when
-%% each resource was last evaluated, and whether each resource complies with
-%% the rule.
+%% The results indicate which Amazon Web Services resources were evaluated by
+%% the rule, when each resource was last evaluated, and whether each resource
+%% complies with the rule.
 %%
 %% The results can return an empty result page. But if you have a
 %% `nextToken', the results are displayed on the next page.
@@ -818,8 +844,24 @@ get_aggregate_config_rule_compliance_summary(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetAggregateConfigRuleComplianceSummary">>, Input, Options).
 
+%% @doc Returns the count of compliant and noncompliant conformance packs
+%% across all Amazon Web Services accounts and Amazon Web Services Regions in
+%% an aggregator.
+%%
+%% You can filter based on Amazon Web Services account ID or Amazon Web
+%% Services Region.
+%%
+%% The results can return an empty result page, but if you have a nextToken,
+%% the results are displayed on the next page.
+get_aggregate_conformance_pack_compliance_summary(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_aggregate_conformance_pack_compliance_summary(Client, Input, []).
+get_aggregate_conformance_pack_compliance_summary(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetAggregateConformancePackComplianceSummary">>, Input, Options).
+
 %% @doc Returns the resource counts across accounts and regions that are
-%% present in your AWS Config aggregator.
+%% present in your Config aggregator.
 %%
 %% You can request the resource counts by providing filters and GroupByKey.
 %%
@@ -844,11 +886,11 @@ get_aggregate_resource_config(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetAggregateResourceConfig">>, Input, Options).
 
-%% @doc Returns the evaluation results for the specified AWS Config rule.
+%% @doc Returns the evaluation results for the specified Config rule.
 %%
-%% The results indicate which AWS resources were evaluated by the rule, when
-%% each resource was last evaluated, and whether each resource complies with
-%% the rule.
+%% The results indicate which Amazon Web Services resources were evaluated by
+%% the rule, when each resource was last evaluated, and whether each resource
+%% complies with the rule.
 get_compliance_details_by_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_compliance_details_by_config_rule(Client, Input, []).
@@ -856,9 +898,10 @@ get_compliance_details_by_config_rule(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetComplianceDetailsByConfigRule">>, Input, Options).
 
-%% @doc Returns the evaluation results for the specified AWS resource.
+%% @doc Returns the evaluation results for the specified Amazon Web Services
+%% resource.
 %%
-%% The results indicate which AWS Config rules were used to evaluate the
+%% The results indicate which Config rules were used to evaluate the
 %% resource, when each rule was last used, and whether the resource complies
 %% with each rule.
 get_compliance_details_by_resource(Client, Input)
@@ -868,7 +911,7 @@ get_compliance_details_by_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetComplianceDetailsByResource">>, Input, Options).
 
-%% @doc Returns the number of AWS Config rules that are compliant and
+%% @doc Returns the number of Config rules that are compliant and
 %% noncompliant, up to a maximum of 25 for each.
 get_compliance_summary_by_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -889,8 +932,8 @@ get_compliance_summary_by_resource_type(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetComplianceSummaryByResourceType">>, Input, Options).
 
-%% @doc Returns compliance details of a conformance pack for all AWS
-%% resources that are monitered by conformance pack.
+%% @doc Returns compliance details of a conformance pack for all Amazon Web
+%% Services resources that are monitered by conformance pack.
 get_conformance_pack_compliance_details(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_conformance_pack_compliance_details(Client, Input, []).
@@ -908,19 +951,19 @@ get_conformance_pack_compliance_summary(Client, Input, Options)
     request(Client, <<"GetConformancePackComplianceSummary">>, Input, Options).
 
 %% @doc Returns the resource types, the number of each resource type, and the
-%% total number of resources that AWS Config is recording in this region for
-%% your AWS account.
+%% total number of resources that Config is recording in this region for your
+%% Amazon Web Services account.
 %%
 %% == Example ==
 %%
-%% <ol> <li> AWS Config is recording three resource types in the US East
-%% (Ohio) Region for your account: 25 EC2 instances, 20 IAM users, and 15 S3
+%% <ol> <li> Config is recording three resource types in the US East (Ohio)
+%% Region for your account: 25 EC2 instances, 20 IAM users, and 15 S3
 %% buckets.
 %%
 %% </li> <li> You make a call to the `GetDiscoveredResourceCounts' action and
 %% specify that you want all resource types.
 %%
-%% </li> <li> AWS Config returns the following:
+%% </li> <li> Config returns the following:
 %%
 %% <ul> <li> The resource types (EC2 instances, IAM users, and S3 buckets).
 %%
@@ -928,7 +971,7 @@ get_conformance_pack_compliance_summary(Client, Input, Options)
 %%
 %% </li> <li> The total number of all resources (60).
 %%
-%% </li> </ul> </li> </ol> The response is paginated. By default, AWS Config
+%% </li> </ul> </li> </ol> The response is paginated. By default, Config
 %% lists 100 `ResourceCount' objects on each page. You can customize this
 %% number with the `limit' parameter. The response includes a `nextToken'
 %% string. To get the next page of results, run the request again and specify
@@ -937,13 +980,13 @@ get_conformance_pack_compliance_summary(Client, Input, Options)
 %% If you make a call to the `GetDiscoveredResourceCounts' action, you might
 %% not immediately receive resource counts in the following situations:
 %%
-%% You are a new AWS Config customer.
+%% You are a new Config customer.
 %%
 %% You just enabled resource recording.
 %%
-%% It might take a few minutes for AWS Config to record and count your
-%% resources. Wait a few minutes and then retry the
-%% `GetDiscoveredResourceCounts' action.
+%% It might take a few minutes for Config to record and count your resources.
+%% Wait a few minutes and then retry the `GetDiscoveredResourceCounts'
+%% action.
 get_discovered_resource_counts(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_discovered_resource_counts(Client, Input, []).
@@ -969,15 +1012,15 @@ get_organization_conformance_pack_detailed_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetOrganizationConformancePackDetailedStatus">>, Input, Options).
 
-%% @doc Returns a list of configuration items for the specified resource.
+%% @doc Returns a list of `ConfigurationItems' for the specified resource.
 %%
 %% The list contains details about each state of the resource during the
 %% specified time interval. If you specified a retention period to retain
 %% your `ConfigurationItems' between a minimum of 30 days and a maximum of 7
-%% years (2557 days), AWS Config returns the `ConfigurationItems' for the
+%% years (2557 days), Config returns the `ConfigurationItems' for the
 %% specified retention period.
 %%
-%% The response is paginated. By default, AWS Config returns a limit of 10
+%% The response is paginated. By default, Config returns a limit of 10
 %% configuration items per page. You can customize this number with the
 %% `limit' parameter. The response includes a `nextToken' string. To get the
 %% next page of results, run the request again and specify the string for the
@@ -1025,15 +1068,15 @@ list_aggregate_discovered_resources(Client, Input, Options)
 %% for the resources of that type.
 %%
 %% A resource identifier includes the resource type, ID, and (if available)
-%% the custom resource name. The results consist of resources that AWS Config
-%% has discovered, including those that AWS Config is not currently
-%% recording. You can narrow the results to include only resources that have
-%% specific resource IDs or a resource name.
+%% the custom resource name. The results consist of resources that Config has
+%% discovered, including those that Config is not currently recording. You
+%% can narrow the results to include only resources that have specific
+%% resource IDs or a resource name.
 %%
 %% You can specify either resource IDs or a resource name, but not both, in
 %% the same request.
 %%
-%% The response is paginated. By default, AWS Config lists 100 resource
+%% The response is paginated. By default, Config lists 100 resource
 %% identifiers on each page. You can customize this number with the `limit'
 %% parameter. The response includes a `nextToken' string. To get the next
 %% page of results, run the request again and specify the string for the
@@ -1045,8 +1088,8 @@ list_discovered_resources(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListDiscoveredResources">>, Input, Options).
 
-%% @doc Lists the stored queries for a single AWS account and a single AWS
-%% Region.
+%% @doc Lists the stored queries for a single Amazon Web Services account and
+%% a single Amazon Web Services Region.
 %%
 %% The default is 100.
 list_stored_queries(Client, Input)
@@ -1056,7 +1099,7 @@ list_stored_queries(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListStoredQueries">>, Input, Options).
 
-%% @doc List the tags for AWS Config resource.
+%% @doc List the tags for Config resource.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -1073,41 +1116,40 @@ put_aggregation_authorization(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutAggregationAuthorization">>, Input, Options).
 
-%% @doc Adds or updates an AWS Config rule for evaluating whether your AWS
-%% resources comply with your desired configurations.
+%% @doc Adds or updates an Config rule for evaluating whether your Amazon Web
+%% Services resources comply with your desired configurations.
 %%
-%% You can use this action for custom AWS Config rules and AWS managed Config
-%% rules. A custom AWS Config rule is a rule that you develop and maintain.
-%% An AWS managed Config rule is a customizable, predefined rule that AWS
-%% Config provides.
+%% You can use this action for custom Config rules and Config managed rules.
+%% A custom Config rule is a rule that you develop and maintain. An Config
+%% managed rule is a customizable, predefined rule that Config provides.
 %%
-%% If you are adding a new custom AWS Config rule, you must first create the
-%% AWS Lambda function that the rule invokes to evaluate your resources. When
-%% you use the `PutConfigRule' action to add the rule to AWS Config, you must
-%% specify the Amazon Resource Name (ARN) that AWS Lambda assigns to the
-%% function. Specify the ARN for the `SourceIdentifier' key. This key is part
-%% of the `Source' object, which is part of the `ConfigRule' object.
+%% If you are adding a new custom Config rule, you must first create the
+%% Lambda function that the rule invokes to evaluate your resources. When you
+%% use the `PutConfigRule' action to add the rule to Config, you must specify
+%% the Amazon Resource Name (ARN) that Lambda assigns to the function.
+%% Specify the ARN for the `SourceIdentifier' key. This key is part of the
+%% `Source' object, which is part of the `ConfigRule' object.
 %%
-%% If you are adding an AWS managed Config rule, specify the rule's
-%% identifier for the `SourceIdentifier' key. To reference AWS managed Config
-%% rule identifiers, see About AWS Managed Config Rules.
+%% If you are adding an Config managed rule, specify the rule's identifier
+%% for the `SourceIdentifier' key. To reference Config managed rule
+%% identifiers, see About Config managed rules.
 %%
 %% For any new rule that you add, specify the `ConfigRuleName' in the
 %% `ConfigRule' object. Do not specify the `ConfigRuleArn' or the
-%% `ConfigRuleId'. These values are generated by AWS Config for new rules.
+%% `ConfigRuleId'. These values are generated by Config for new rules.
 %%
 %% If you are updating a rule that you added previously, you can specify the
 %% rule by `ConfigRuleName', `ConfigRuleId', or `ConfigRuleArn' in the
 %% `ConfigRule' data type that you use in this request.
 %%
-%% The maximum number of rules that AWS Config supports is 150.
+%% The maximum number of rules that Config supports is 150.
 %%
-%% For information about requesting a rule limit increase, see AWS Config
-%% Limits in the AWS General Reference Guide.
+%% For information about requesting a rule limit increase, see Config Limits
+%% in the Amazon Web Services General Reference Guide.
 %%
-%% For more information about developing and using AWS Config rules, see
-%% Evaluating AWS Resource Configurations with AWS Config in the AWS Config
-%% Developer Guide.
+%% For more information about developing and using Config rules, see
+%% Evaluating Amazon Web Services resource Configurations with Config in the
+%% Config Developer Guide.
 put_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_config_rule(Client, Input, []).
@@ -1125,20 +1167,20 @@ put_config_rule(Client, Input, Options)
 %% `DescribeAggregator' to get the previous accounts and then append new
 %% ones.
 %%
-%% AWS Config should be enabled in source accounts and regions you want to
+%% Config should be enabled in source accounts and regions you want to
 %% aggregate.
 %%
 %% If your source type is an organization, you must be signed in to the
 %% management account or a registered delegated administrator and all the
 %% features must be enabled in your organization. If the caller is a
-%% management account, AWS Config calls `EnableAwsServiceAccess' API to
-%% enable integration between AWS Config and AWS Organizations. If the caller
-%% is a registered delegated administrator, AWS Config calls
+%% management account, Config calls `EnableAwsServiceAccess' API to enable
+%% integration between Config and Organizations. If the caller is a
+%% registered delegated administrator, Config calls
 %% `ListDelegatedAdministrators' API to verify whether the caller is a valid
 %% delegated administrator.
 %%
 %% To register a delegated administrator, see Register a Delegated
-%% Administrator in the AWS Config developer guide.
+%% Administrator in the Config developer guide.
 put_configuration_aggregator(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_configuration_aggregator(Client, Input, []).
@@ -1167,15 +1209,16 @@ put_configuration_recorder(Client, Input, Options)
 
 %% @doc Creates or updates a conformance pack.
 %%
-%% A conformance pack is a collection of AWS Config rules that can be easily
-%% deployed in an account and a region and across AWS Organization.
+%% A conformance pack is a collection of Config rules that can be easily
+%% deployed in an account and a region and across Amazon Web Services
+%% Organization.
 %%
 %% This API creates a service linked role `AWSServiceRoleForConfigConforms'
 %% in your account. The service linked role is created only when the role
 %% does not exist in your account.
 %%
 %% You must specify either the `TemplateS3Uri' or the `TemplateBody'
-%% parameter, but not both. If you provide both AWS Config uses the
+%% parameter, but not both. If you provide both Config uses the
 %% `TemplateS3Uri' parameter and ignores the `TemplateBody' parameter.
 put_conformance_pack(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1205,11 +1248,10 @@ put_delivery_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutDeliveryChannel">>, Input, Options).
 
-%% @doc Used by an AWS Lambda function to deliver evaluation results to AWS
-%% Config.
+%% @doc Used by an Lambda function to deliver evaluation results to Config.
 %%
-%% This action is required in every AWS Lambda function that is invoked by an
-%% AWS Config rule.
+%% This action is required in every Lambda function that is invoked by an
+%% Config rule.
 put_evaluations(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_evaluations(Client, Input, []).
@@ -1219,8 +1261,8 @@ put_evaluations(Client, Input, Options)
 
 %% @doc Add or updates the evaluations for process checks.
 %%
-%% This API checks if the rule is a process check when the name of the AWS
-%% Config rule is provided.
+%% This API checks if the rule is a process check when the name of the Config
+%% rule is provided.
 put_external_evaluation(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_external_evaluation(Client, Input, []).
@@ -1229,37 +1271,38 @@ put_external_evaluation(Client, Input, Options)
     request(Client, <<"PutExternalEvaluation">>, Input, Options).
 
 %% @doc Adds or updates organization config rule for your entire organization
-%% evaluating whether your AWS resources comply with your desired
-%% configurations.
+%% evaluating whether your Amazon Web Services resources comply with your
+%% desired configurations.
 %%
 %% Only a master account and a delegated administrator can create or update
 %% an organization config rule. When calling this API with a delegated
-%% administrator, you must ensure AWS Organizations
-%% `ListDelegatedAdministrator' permissions are added.
+%% administrator, you must ensure Organizations `ListDelegatedAdministrator'
+%% permissions are added.
 %%
 %% This API enables organization service access through the
 %% `EnableAWSServiceAccess' action and creates a service linked role
 %% `AWSServiceRoleForConfigMultiAccountSetup' in the master or delegated
 %% administrator account of your organization. The service linked role is
-%% created only when the role does not exist in the caller account. AWS
-%% Config verifies the existence of role with `GetRole' action.
+%% created only when the role does not exist in the caller account. Config
+%% verifies the existence of role with `GetRole' action.
 %%
 %% To use this API with delegated administrator, register a delegated
-%% administrator by calling AWS Organization
+%% administrator by calling Amazon Web Services Organization
 %% `register-delegated-administrator' for
 %% `config-multiaccountsetup.amazonaws.com'.
 %%
-%% You can use this action to create both custom AWS Config rules and AWS
-%% managed Config rules. If you are adding a new custom AWS Config rule, you
-%% must first create AWS Lambda function in the master account or a delegated
-%% administrator that the rule invokes to evaluate your resources. When you
-%% use the `PutOrganizationConfigRule' action to add the rule to AWS Config,
-%% you must specify the Amazon Resource Name (ARN) that AWS Lambda assigns to
-%% the function. If you are adding an AWS managed Config rule, specify the
-%% rule's identifier for the `RuleIdentifier' key.
+%% You can use this action to create both custom Config rules and Config
+%% managed rules. If you are adding a new custom Config rule, you must first
+%% create Lambda function in the master account or a delegated administrator
+%% that the rule invokes to evaluate your resources. You also need to create
+%% an IAM role in the managed-account that can be assumed by the Lambda
+%% function. When you use the `PutOrganizationConfigRule' action to add the
+%% rule to Config, you must specify the Amazon Resource Name (ARN) that
+%% Lambda assigns to the function. If you are adding an Config managed rule,
+%% specify the rule's identifier for the `RuleIdentifier' key.
 %%
-%% The maximum number of organization config rules that AWS Config supports
-%% is 150 and 3 delegated administrator per organization.
+%% The maximum number of organization config rules that Config supports is
+%% 150 and 3 delegated administrator per organization.
 %%
 %% Prerequisite: Ensure you call `EnableAllFeatures' API to enable all
 %% features in an organization.
@@ -1273,11 +1316,11 @@ put_organization_config_rule(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutOrganizationConfigRule">>, Input, Options).
 
-%% @doc Deploys conformance packs across member accounts in an AWS
-%% Organization.
+%% @doc Deploys conformance packs across member accounts in an Amazon Web
+%% Services Organization.
 %%
 %% Only a master account and a delegated administrator can call this API.
-%% When calling this API with a delegated administrator, you must ensure AWS
+%% When calling this API with a delegated administrator, you must ensure
 %% Organizations `ListDelegatedAdministrator' permissions are added.
 %%
 %% This API enables organization service access for
@@ -1287,22 +1330,22 @@ put_organization_config_rule(Client, Input, Options)
 %% administrator account of your organization. The service linked role is
 %% created only when the role does not exist in the caller account. To use
 %% this API with delegated administrator, register a delegated administrator
-%% by calling AWS Organization `register-delegate-admin' for
+%% by calling Amazon Web Services Organization `register-delegate-admin' for
 %% `config-multiaccountsetup.amazonaws.com'.
 %%
 %% Prerequisite: Ensure you call `EnableAllFeatures' API to enable all
 %% features in an organization.
 %%
 %% You must specify either the `TemplateS3Uri' or the `TemplateBody'
-%% parameter, but not both. If you provide both AWS Config uses the
+%% parameter, but not both. If you provide both Config uses the
 %% `TemplateS3Uri' parameter and ignores the `TemplateBody' parameter.
 %%
-%% AWS Config sets the state of a conformance pack to CREATE_IN_PROGRESS and
+%% Config sets the state of a conformance pack to CREATE_IN_PROGRESS and
 %% UPDATE_IN_PROGRESS until the conformance pack is created or updated. You
 %% cannot update a conformance pack while it is in this state.
 %%
-%% You can create 6 conformance packs with 25 AWS Config rules in each pack
-%% and 3 delegated administrator per organization.
+%% You can create 50 conformance packs with 25 Config rules in each pack and
+%% 3 delegated administrator per organization.
 put_organization_conformance_pack(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_organization_conformance_pack(Client, Input, []).
@@ -1310,11 +1353,11 @@ put_organization_conformance_pack(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutOrganizationConformancePack">>, Input, Options).
 
-%% @doc Adds or updates the remediation configuration with a specific AWS
-%% Config rule with the selected target or action.
+%% @doc Adds or updates the remediation configuration with a specific Config
+%% rule with the selected target or action.
 %%
-%% The API creates the `RemediationConfiguration' object for the AWS Config
-%% rule. The AWS Config rule must already exist for you to add a remediation
+%% The API creates the `RemediationConfiguration' object for the Config rule.
+%% The Config rule must already exist for you to add a remediation
 %% configuration. The target (SSM document) must exist and have permissions
 %% to use the target.
 %%
@@ -1322,9 +1365,9 @@ put_organization_conformance_pack(Client, Input, Options)
 %% call this again to ensure the remediations can run.
 %%
 %% This API does not support adding remediation configurations for
-%% service-linked AWS Config Rules such as Organization Config rules, the
-%% rules deployed by conformance packs, and rules deployed by AWS Security
-%% Hub.
+%% service-linked Config Rules such as Organization Config rules, the rules
+%% deployed by conformance packs, and rules deployed by Amazon Web Services
+%% Security Hub.
 put_remediation_configurations(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_remediation_configurations(Client, Input, []).
@@ -1336,11 +1379,11 @@ put_remediation_configurations(Client, Input, Options)
 %% considered for auto-remediation.
 %%
 %% This API adds a new exception or updates an existing exception for a
-%% specific resource with a specific AWS Config rule.
+%% specific resource with a specific Config rule.
 %%
-%% AWS Config generates a remediation exception when a problem occurs
-%% executing a remediation action to a specific resource. Remediation
-%% exceptions blocks auto-remediation until the exception is cleared.
+%% Config generates a remediation exception when a problem occurs executing a
+%% remediation action to a specific resource. Remediation exceptions blocks
+%% auto-remediation until the exception is cleared.
 put_remediation_exceptions(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_remediation_exceptions(Client, Input, []).
@@ -1351,15 +1394,15 @@ put_remediation_exceptions(Client, Input, Options)
 %% @doc Records the configuration state for the resource provided in the
 %% request.
 %%
-%% The configuration state of a resource is represented in AWS Config as
+%% The configuration state of a resource is represented in Config as
 %% Configuration Items. Once this API records the configuration item, you can
 %% retrieve the list of configuration items for the custom resource type
-%% using existing AWS Config APIs.
+%% using existing Config APIs.
 %%
-%% The custom resource type must be registered with AWS CloudFormation. This
-%% API accepts the configuration item registered with AWS CloudFormation.
+%% The custom resource type must be registered with CloudFormation. This API
+%% accepts the configuration item registered with CloudFormation.
 %%
-%% When you call this API, AWS Config only stores configuration state of the
+%% When you call this API, Config only stores configuration state of the
 %% resource provided in the request. This API does not change or remediate
 %% the configuration of the resource.
 %%
@@ -1373,15 +1416,15 @@ put_resource_config(Client, Input, Options)
     request(Client, <<"PutResourceConfig">>, Input, Options).
 
 %% @doc Creates and updates the retention configuration with details about
-%% retention period (number of days) that AWS Config stores your historical
+%% retention period (number of days) that Config stores your historical
 %% information.
 %%
 %% The API creates the `RetentionConfiguration' object and names the object
 %% as default. When you have a `RetentionConfiguration' object named default,
 %% calling the API modifies the default object.
 %%
-%% Currently, AWS Config supports only one retention configuration per region
-%% in your account.
+%% Currently, Config supports only one retention configuration per region in
+%% your account.
 put_retention_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_retention_configuration(Client, Input, []).
@@ -1391,9 +1434,10 @@ put_retention_configuration(Client, Input, Options)
 
 %% @doc Saves a new query or updates an existing saved query.
 %%
-%% The `QueryName' must be unique for a single AWS account and a single AWS
-%% Region. You can create upto 300 queries in a single AWS account and a
-%% single AWS Region.
+%% The `QueryName' must be unique for a single Amazon Web Services account
+%% and a single Amazon Web Services Region. You can create upto 300 queries
+%% in a single Amazon Web Services account and a single Amazon Web Services
+%% Region.
 put_stored_query(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_stored_query(Client, Input, []).
@@ -1402,12 +1446,23 @@ put_stored_query(Client, Input, Options)
     request(Client, <<"PutStoredQuery">>, Input, Options).
 
 %% @doc Accepts a structured query language (SQL) SELECT command and an
-%% aggregator to query configuration state of AWS resources across multiple
-%% accounts and regions, performs the corresponding search, and returns
-%% resource configurations matching the properties.
+%% aggregator to query configuration state of Amazon Web Services resources
+%% across multiple accounts and regions, performs the corresponding search,
+%% and returns resource configurations matching the properties.
 %%
 %% For more information about query components, see the Query Components
-%% section in the AWS Config Developer Guide.
+%% section in the Config Developer Guide.
+%%
+%% If you run an aggregation query (i.e., using `GROUP BY' or using aggregate
+%% functions such as `COUNT'; e.g., `SELECT resourceId, COUNT(*) WHERE
+%% resourceType = 'AWS::IAM::Role' GROUP BY resourceId') and do not specify
+%% the `MaxResults' or the `Limit' query parameters, the default page size is
+%% set to 500.
+%%
+%% If you run a non-aggregation query (i.e., not using `GROUP BY' or
+%% aggregate function; e.g., `SELECT * WHERE resourceType =
+%% 'AWS::IAM::Role'') and do not specify the `MaxResults' or the `Limit'
+%% query parameters, the default page size is set to 25.
 select_aggregate_resource_config(Client, Input)
   when is_map(Client), is_map(Input) ->
     select_aggregate_resource_config(Client, Input, []).
@@ -1420,7 +1475,7 @@ select_aggregate_resource_config(Client, Input, Options)
 %% properties.
 %%
 %% For more information about query components, see the Query Components
-%% section in the AWS Config Developer Guide.
+%% section in the Config Developer Guide.
 select_resource_config(Client, Input)
   when is_map(Client), is_map(Input) ->
     select_resource_config(Client, Input, []).
@@ -1428,24 +1483,24 @@ select_resource_config(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SelectResourceConfig">>, Input, Options).
 
-%% @doc Runs an on-demand evaluation for the specified AWS Config rules
-%% against the last known configuration state of the resources.
+%% @doc Runs an on-demand evaluation for the specified Config rules against
+%% the last known configuration state of the resources.
 %%
 %% Use `StartConfigRulesEvaluation' when you want to test that a rule you
 %% updated is working as expected. `StartConfigRulesEvaluation' does not
 %% re-record the latest configuration state for your resources. It re-runs an
 %% evaluation against the last known state of your resources.
 %%
-%% You can specify up to 25 AWS Config rules per request.
+%% You can specify up to 25 Config rules per request.
 %%
 %% An existing `StartConfigRulesEvaluation' call for the specified rules must
-%% complete before you can call the API again. If you chose to have AWS
-%% Config stream to an Amazon SNS topic, you will receive a
+%% complete before you can call the API again. If you chose to have Config
+%% stream to an Amazon SNS topic, you will receive a
 %% `ConfigRuleEvaluationStarted' notification when the evaluation starts.
 %%
 %% You don't need to call the `StartConfigRulesEvaluation' API to run an
-%% evaluation for a new rule. When you create a rule, AWS Config evaluates
-%% your resources against the rule automatically.
+%% evaluation for a new rule. When you create a rule, Config evaluates your
+%% resources against the rule automatically.
 %%
 %% The `StartConfigRulesEvaluation' API is useful if you want to run
 %% on-demand evaluations, such as the following example:
@@ -1459,7 +1514,7 @@ select_resource_config(Client, Input, Options)
 %% </li> <li> Instead of waiting for the next periodic evaluation, you call
 %% the `StartConfigRulesEvaluation' API.
 %%
-%% </li> <li> AWS Config invokes your Lambda function and evaluates your IAM
+%% </li> <li> Config invokes your Lambda function and evaluates your IAM
 %% resources.
 %%
 %% </li> <li> Your custom rule will still run periodic evaluations every 24
@@ -1473,8 +1528,8 @@ start_config_rules_evaluation(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartConfigRulesEvaluation">>, Input, Options).
 
-%% @doc Starts recording configurations of the AWS resources you have
-%% selected to record in your AWS account.
+%% @doc Starts recording configurations of the Amazon Web Services resources
+%% you have selected to record in your Amazon Web Services account.
 %%
 %% You must have created at least one delivery channel to successfully start
 %% the configuration recorder.
@@ -1485,8 +1540,8 @@ start_configuration_recorder(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartConfigurationRecorder">>, Input, Options).
 
-%% @doc Runs an on-demand remediation for the specified AWS Config rules
-%% against the last known remediation configuration.
+%% @doc Runs an on-demand remediation for the specified Config rules against
+%% the last known remediation configuration.
 %%
 %% It runs an execution against the current state of your resources.
 %% Remediation execution is asynchronous.
@@ -1501,8 +1556,8 @@ start_remediation_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartRemediationExecution">>, Input, Options).
 
-%% @doc Stops recording configurations of the AWS resources you have selected
-%% to record in your AWS account.
+%% @doc Stops recording configurations of the Amazon Web Services resources
+%% you have selected to record in your Amazon Web Services account.
 stop_configuration_recorder(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_configuration_recorder(Client, Input, []).

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -14,14 +14,17 @@
 %% per second. For more information, see Amazon Connect Service Quotas in the
 %% Amazon Connect Administrator Guide.
 %%
-%% You can connect programmatically to an AWS service by using an endpoint.
-%% For a list of Amazon Connect endpoints, see Amazon Connect Endpoints.
+%% You can connect programmatically to an Amazon Web Services service by
+%% using an endpoint. For a list of Amazon Connect endpoints, see Amazon
+%% Connect Endpoints.
 %%
 %% Working with contact flows? Check out the Amazon Connect Flow language.
 -module(aws_connect).
 
 -export([associate_approved_origin/3,
          associate_approved_origin/4,
+         associate_bot/3,
+         associate_bot/4,
          associate_instance_storage_config/3,
          associate_instance_storage_config/4,
          associate_lambda_function/3,
@@ -34,8 +37,12 @@
          associate_routing_profile_queues/5,
          associate_security_key/3,
          associate_security_key/4,
+         create_agent_status/3,
+         create_agent_status/4,
          create_contact_flow/3,
          create_contact_flow/4,
+         create_hours_of_operation/3,
+         create_hours_of_operation/4,
          create_instance/2,
          create_instance/3,
          create_integration_association/3,
@@ -46,24 +53,33 @@
          create_quick_connect/4,
          create_routing_profile/3,
          create_routing_profile/4,
+         create_security_profile/3,
+         create_security_profile/4,
          create_use_case/4,
          create_use_case/5,
          create_user/3,
          create_user/4,
          create_user_hierarchy_group/3,
          create_user_hierarchy_group/4,
+         delete_hours_of_operation/4,
+         delete_hours_of_operation/5,
          delete_instance/3,
          delete_instance/4,
          delete_integration_association/4,
          delete_integration_association/5,
          delete_quick_connect/4,
          delete_quick_connect/5,
+         delete_security_profile/4,
+         delete_security_profile/5,
          delete_use_case/5,
          delete_use_case/6,
          delete_user/4,
          delete_user/5,
          delete_user_hierarchy_group/4,
          delete_user_hierarchy_group/5,
+         describe_agent_status/3,
+         describe_agent_status/5,
+         describe_agent_status/6,
          describe_contact_flow/3,
          describe_contact_flow/5,
          describe_contact_flow/6,
@@ -88,6 +104,9 @@
          describe_routing_profile/3,
          describe_routing_profile/5,
          describe_routing_profile/6,
+         describe_security_profile/3,
+         describe_security_profile/5,
+         describe_security_profile/6,
          describe_user/3,
          describe_user/5,
          describe_user/6,
@@ -99,6 +118,8 @@
          describe_user_hierarchy_structure/5,
          disassociate_approved_origin/3,
          disassociate_approved_origin/4,
+         disassociate_bot/3,
+         disassociate_bot/4,
          disassociate_instance_storage_config/4,
          disassociate_instance_storage_config/5,
          disassociate_lambda_function/3,
@@ -121,9 +142,15 @@
          get_federation_token/5,
          get_metric_data/3,
          get_metric_data/4,
+         list_agent_statuses/2,
+         list_agent_statuses/4,
+         list_agent_statuses/5,
          list_approved_origins/2,
          list_approved_origins/4,
          list_approved_origins/5,
+         list_bots/3,
+         list_bots/5,
+         list_bots/6,
          list_contact_flows/2,
          list_contact_flows/4,
          list_contact_flows/5,
@@ -172,6 +199,9 @@
          list_security_keys/2,
          list_security_keys/4,
          list_security_keys/5,
+         list_security_profile_permissions/3,
+         list_security_profile_permissions/5,
+         list_security_profile_permissions/6,
          list_security_profiles/2,
          list_security_profiles/4,
          list_security_profiles/5,
@@ -193,6 +223,8 @@
          start_chat_contact/3,
          start_contact_recording/2,
          start_contact_recording/3,
+         start_contact_streaming/2,
+         start_contact_streaming/3,
          start_outbound_voice_contact/2,
          start_outbound_voice_contact/3,
          start_task_contact/2,
@@ -201,18 +233,24 @@
          stop_contact/3,
          stop_contact_recording/2,
          stop_contact_recording/3,
+         stop_contact_streaming/2,
+         stop_contact_streaming/3,
          suspend_contact_recording/2,
          suspend_contact_recording/3,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
          untag_resource/4,
+         update_agent_status/4,
+         update_agent_status/5,
          update_contact_attributes/2,
          update_contact_attributes/3,
          update_contact_flow_content/4,
          update_contact_flow_content/5,
          update_contact_flow_name/4,
          update_contact_flow_name/5,
+         update_hours_of_operation/4,
+         update_hours_of_operation/5,
          update_instance_attribute/4,
          update_instance_attribute/5,
          update_instance_storage_config/4,
@@ -239,6 +277,8 @@
          update_routing_profile_name/5,
          update_routing_profile_queues/4,
          update_routing_profile_queues/5,
+         update_security_profile/4,
+         update_security_profile/5,
          update_user_hierarchy/4,
          update_user_hierarchy/5,
          update_user_hierarchy_group_name/4,
@@ -269,6 +309,33 @@ associate_approved_origin(Client, InstanceId, Input) ->
 associate_approved_origin(Client, InstanceId, Input0, Options0) ->
     Method = put,
     Path = ["/instance/", aws_util:encode_uri(InstanceId), "/approved-origin"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Allows the specified Amazon Connect instance to access the specified
+%% Amazon Lex or Amazon Lex V2 bot.
+associate_bot(Client, InstanceId, Input) ->
+    associate_bot(Client, InstanceId, Input, []).
+associate_bot(Client, InstanceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/instance/", aws_util:encode_uri(InstanceId), "/bot"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -449,6 +516,32 @@ associate_security_key(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Creates an agent status for the specified Amazon Connect instance.
+create_agent_status(Client, InstanceId, Input) ->
+    create_agent_status(Client, InstanceId, Input, []).
+create_agent_status(Client, InstanceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/agent-status/", aws_util:encode_uri(InstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a contact flow for the specified Amazon Connect instance.
 %%
 %% You can also create and update contact flows using the Amazon Connect Flow
@@ -475,6 +568,29 @@ create_contact_flow(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates hours of operation.
+create_hours_of_operation(Client, InstanceId, Input) ->
+    create_hours_of_operation(Client, InstanceId, Input, []).
+create_hours_of_operation(Client, InstanceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/hours-of-operations/", aws_util:encode_uri(InstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc This API is in preview release for Amazon Connect and is subject to
 %% change.
 %%
@@ -482,6 +598,12 @@ create_contact_flow(Client, InstanceId, Input0, Options0) ->
 %% enabled. It does not attach any storage, such as Amazon Simple Storage
 %% Service (Amazon S3) or Amazon Kinesis. It also does not allow for any
 %% configurations on features, such as Contact Lens for Amazon Connect.
+%%
+%% Amazon Connect enforces a limit on the total number of instances that you
+%% can create or delete in 30 days. If you exceed this limit, you will get an
+%% error message indicating there has been an excessive number of attempts at
+%% creating or deleting instances. You must wait 30 days before you can
+%% restart creating and deleting instances in your account.
 create_instance(Client, Input) ->
     create_instance(Client, Input, []).
 create_instance(Client, Input0, Options0) ->
@@ -504,10 +626,8 @@ create_instance(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Create an AppIntegration association with an Amazon Connect instance.
+%% @doc Creates an Amazon Web Services resource association with an Amazon
+%% Connect instance.
 create_integration_association(Client, InstanceId, Input) ->
     create_integration_association(Client, InstanceId, Input, []).
 create_integration_association(Client, InstanceId, Input0, Options0) ->
@@ -556,10 +676,7 @@ create_queue(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Creates a quick connect for the specified Amazon Connect instance.
+%% @doc Creates a quick connect for the specified Amazon Connect instance.
 create_quick_connect(Client, InstanceId, Input) ->
     create_quick_connect(Client, InstanceId, Input, []).
 create_quick_connect(Client, InstanceId, Input0, Options0) ->
@@ -608,7 +725,30 @@ create_routing_profile(Client, InstanceId, Input0, Options0) ->
 %% @doc This API is in preview release for Amazon Connect and is subject to
 %% change.
 %%
-%% Creates a use case for an AppIntegration association.
+%% Creates a security profile.
+create_security_profile(Client, InstanceId, Input) ->
+    create_security_profile(Client, InstanceId, Input, []).
+create_security_profile(Client, InstanceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/security-profiles/", aws_util:encode_uri(InstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a use case for an integration association.
 create_use_case(Client, InstanceId, IntegrationAssociationId, Input) ->
     create_use_case(Client, InstanceId, IntegrationAssociationId, Input, []).
 create_use_case(Client, InstanceId, IntegrationAssociationId, Input0, Options0) ->
@@ -680,10 +820,39 @@ create_user_hierarchy_group(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes an hours of operation.
+delete_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input) ->
+    delete_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input, []).
+delete_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/hours-of-operations/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(HoursOfOperationId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc This API is in preview release for Amazon Connect and is subject to
 %% change.
 %%
 %% Deletes the Amazon Connect instance.
+%%
+%% Amazon Connect enforces a limit on the total number of instances that you
+%% can create or delete in 30 days. If you exceed this limit, you will get an
+%% error message indicating there has been an excessive number of attempts at
+%% creating or deleting instances. You must wait 30 days before you can
+%% restart creating and deleting instances in your account.
 delete_instance(Client, InstanceId, Input) ->
     delete_instance(Client, InstanceId, Input, []).
 delete_instance(Client, InstanceId, Input0, Options0) ->
@@ -706,11 +875,10 @@ delete_instance(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
+%% @doc Deletes an Amazon Web Services resource association from an Amazon
+%% Connect instance.
 %%
-%% Deletes an AppIntegration association from an Amazon Connect instance. The
-%% association must not have any use cases associated with it.
+%% The association must not have any use cases associated with it.
 delete_integration_association(Client, InstanceId, IntegrationAssociationId, Input) ->
     delete_integration_association(Client, InstanceId, IntegrationAssociationId, Input, []).
 delete_integration_association(Client, InstanceId, IntegrationAssociationId, Input0, Options0) ->
@@ -733,10 +901,7 @@ delete_integration_association(Client, InstanceId, IntegrationAssociationId, Inp
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Deletes a quick connect.
+%% @doc Deletes a quick connect.
 delete_quick_connect(Client, InstanceId, QuickConnectId, Input) ->
     delete_quick_connect(Client, InstanceId, QuickConnectId, Input, []).
 delete_quick_connect(Client, InstanceId, QuickConnectId, Input0, Options0) ->
@@ -762,7 +927,30 @@ delete_quick_connect(Client, InstanceId, QuickConnectId, Input0, Options0) ->
 %% @doc This API is in preview release for Amazon Connect and is subject to
 %% change.
 %%
-%% Deletes a use case from an AppIntegration association.
+%% Deletes a security profile.
+delete_security_profile(Client, InstanceId, SecurityProfileId, Input) ->
+    delete_security_profile(Client, InstanceId, SecurityProfileId, Input, []).
+delete_security_profile(Client, InstanceId, SecurityProfileId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/security-profiles/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(SecurityProfileId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a use case from an integration association.
 delete_use_case(Client, InstanceId, IntegrationAssociationId, UseCaseId, Input) ->
     delete_use_case(Client, InstanceId, IntegrationAssociationId, UseCaseId, Input, []).
 delete_use_case(Client, InstanceId, IntegrationAssociationId, UseCaseId, Input0, Options0) ->
@@ -837,6 +1025,32 @@ delete_user_hierarchy_group(Client, HierarchyGroupId, InstanceId, Input0, Option
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Describes an agent status.
+describe_agent_status(Client, AgentStatusId, InstanceId)
+  when is_map(Client) ->
+    describe_agent_status(Client, AgentStatusId, InstanceId, #{}, #{}).
+
+describe_agent_status(Client, AgentStatusId, InstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_agent_status(Client, AgentStatusId, InstanceId, QueryMap, HeadersMap, []).
+
+describe_agent_status(Client, AgentStatusId, InstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/agent-status/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(AgentStatusId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Describes the specified contact flow.
 %%
 %% You can also create and update contact flows using the Amazon Connect Flow
@@ -863,10 +1077,7 @@ describe_contact_flow(Client, ContactFlowId, InstanceId, QueryMap, HeadersMap, O
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Describes the hours of operation.
+%% @doc Describes the hours of operation.
 describe_hours_of_operation(Client, HoursOfOperationId, InstanceId)
   when is_map(Client) ->
     describe_hours_of_operation(Client, HoursOfOperationId, InstanceId, #{}, #{}).
@@ -1005,10 +1216,7 @@ describe_queue(Client, InstanceId, QueueId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Describes the quick connect.
+%% @doc Describes the quick connect.
 describe_quick_connect(Client, InstanceId, QuickConnectId)
   when is_map(Client) ->
     describe_quick_connect(Client, InstanceId, QuickConnectId, #{}, #{}).
@@ -1043,6 +1251,32 @@ describe_routing_profile(Client, InstanceId, RoutingProfileId, QueryMap, Headers
 describe_routing_profile(Client, InstanceId, RoutingProfileId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/routing-profiles/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(RoutingProfileId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Gets basic information about the security profle.
+describe_security_profile(Client, InstanceId, SecurityProfileId)
+  when is_map(Client) ->
+    describe_security_profile(Client, InstanceId, SecurityProfileId, #{}, #{}).
+
+describe_security_profile(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_security_profile(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap, []).
+
+describe_security_profile(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/security-profiles/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(SecurityProfileId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1153,6 +1387,33 @@ disassociate_approved_origin(Client, InstanceId, Input0, Options0) ->
                      {<<"origin">>, <<"Origin">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Revokes authorization from the specified instance to access the specified
+%% Amazon Lex or Amazon Lex V2 bot.
+disassociate_bot(Client, InstanceId, Input) ->
+    disassociate_bot(Client, InstanceId, Input, []).
+disassociate_bot(Client, InstanceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/instance/", aws_util:encode_uri(InstanceId), "/bot"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc This API is in preview release for Amazon Connect and is subject to
@@ -1366,6 +1627,13 @@ get_current_metric_data(Client, InstanceId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Retrieves a token for federation.
+%%
+%% This API doesn't support root users. If you try to invoke
+%% GetFederationToken with root credentials, an error message similar to the
+%% following one appears:
+%%
+%% `Provided identity: Principal: .... User: .... cannot be used for
+%% federation with Amazon Connect'
 get_federation_token(Client, InstanceId)
   when is_map(Client) ->
     get_federation_token(Client, InstanceId, #{}, #{}).
@@ -1418,6 +1686,38 @@ get_metric_data(Client, InstanceId, Input0, Options0) ->
 %% @doc This API is in preview release for Amazon Connect and is subject to
 %% change.
 %%
+%% Lists agent statuses.
+list_agent_statuses(Client, InstanceId)
+  when is_map(Client) ->
+    list_agent_statuses(Client, InstanceId, #{}, #{}).
+
+list_agent_statuses(Client, InstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_agent_statuses(Client, InstanceId, QueryMap, HeadersMap, []).
+
+list_agent_statuses(Client, InstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/agent-status/", aws_util:encode_uri(InstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"AgentStatusTypes">>, maps:get(<<"AgentStatusTypes">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
 %% Returns a paginated list of all approved origins associated with the
 %% instance.
 list_approved_origins(Client, InstanceId)
@@ -1440,6 +1740,39 @@ list_approved_origins(Client, InstanceId, QueryMap, HeadersMap, Options0)
 
     Query0_ =
       [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% For the specified version of Amazon Lex, returns a paginated list of all
+%% the Amazon Lex bots currently associated with the instance.
+list_bots(Client, InstanceId, LexVersion)
+  when is_map(Client) ->
+    list_bots(Client, InstanceId, LexVersion, #{}, #{}).
+
+list_bots(Client, InstanceId, LexVersion, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_bots(Client, InstanceId, LexVersion, QueryMap, HeadersMap, []).
+
+list_bots(Client, InstanceId, LexVersion, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/instance/", aws_util:encode_uri(InstanceId), "/bots"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"lexVersion">>, LexVersion},
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
       ],
@@ -1613,11 +1946,8 @@ list_instances(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Provides summary information about the AppIntegration associations for the
-%% specified Amazon Connect instance.
+%% @doc Provides summary information about the Amazon Web Services resource
+%% associations for the specified Amazon Connect instance.
 list_integration_associations(Client, InstanceId)
   when is_map(Client) ->
     list_integration_associations(Client, InstanceId, #{}, #{}).
@@ -1638,6 +1968,7 @@ list_integration_associations(Client, InstanceId, QueryMap, HeadersMap, Options0
 
     Query0_ =
       [
+        {<<"integrationType">>, maps:get(<<"integrationType">>, QueryMap, undefined)},
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
       ],
@@ -1806,6 +2137,11 @@ list_queue_quick_connects(Client, InstanceId, QueueId, QueryMap, HeadersMap, Opt
 %% @doc Provides information about the queues for the specified Amazon
 %% Connect instance.
 %%
+%% If you do not specify a `QueueTypes' parameter, both standard and agent
+%% queues are returned. This might cause an unexpected truncation of results
+%% if you have more than 1000 agents and you limit the number of results of
+%% the API call in code.
+%%
 %% For more information about queues, see Queues: Standard and Agent in the
 %% Amazon Connect Administrator Guide.
 list_queues(Client, InstanceId)
@@ -1836,11 +2172,8 @@ list_queues(Client, InstanceId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Provides information about the quick connects for the specified Amazon
-%% Connect instance.
+%% @doc Provides information about the quick connects for the specified
+%% Amazon Connect instance.
 list_quick_connects(Client, InstanceId)
   when is_map(Client) ->
     list_quick_connects(Client, InstanceId, #{}, #{}).
@@ -1961,8 +2294,42 @@ list_security_keys(Client, InstanceId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Provides summary information about the security profiles for the
-%% specified Amazon Connect instance.
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Lists the permissions granted to a security profile.
+list_security_profile_permissions(Client, InstanceId, SecurityProfileId)
+  when is_map(Client) ->
+    list_security_profile_permissions(Client, InstanceId, SecurityProfileId, #{}, #{}).
+
+list_security_profile_permissions(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_security_profile_permissions(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap, []).
+
+list_security_profile_permissions(Client, InstanceId, SecurityProfileId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/security-profiles-permissions/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(SecurityProfileId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Provides summary information about the security profiles for the specified
+%% Amazon Connect instance.
 %%
 %% For more information about security profiles, see Security Profiles in the
 %% Amazon Connect Administrator Guide.
@@ -2019,10 +2386,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Lists the use cases.
+%% @doc Lists the use cases for the integration association.
 list_use_cases(Client, InstanceId, IntegrationAssociationId)
   when is_map(Client) ->
     list_use_cases(Client, InstanceId, IntegrationAssociationId, #{}, #{}).
@@ -2152,7 +2516,7 @@ resume_contact_recording(Client, Input0, Options0) ->
 %% A 429 error occurs in two situations:
 %%
 %% <ul> <li> API rate limit is exceeded. API TPS throttling returns a
-%% `TooManyRequests' exception from the API Gateway.
+%% `TooManyRequests' exception.
 %%
 %% </li> <li> The quota for concurrent active chats is exceeded. Active chat
 %% throttling returns a `LimitExceededException'.
@@ -2216,6 +2580,32 @@ start_contact_recording(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Initiates real-time message streaming for a new chat contact.
+%%
+%% For more information about message streaming, see Enable real-time chat
+%% message streaming in the Amazon Connect Administrator Guide.
+start_contact_streaming(Client, Input) ->
+    start_contact_streaming(Client, Input, []).
+start_contact_streaming(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/contact/start-streaming"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Places an outbound call to a contact, and then initiates the contact
 %% flow.
 %%
@@ -2232,6 +2622,11 @@ start_contact_recording(Client, Input0, Options0) ->
 %%
 %% UK numbers with a 447 prefix are not allowed by default. Before you can
 %% dial these UK mobile numbers, you must submit a service quota increase
+%% request. For more information, see Amazon Connect Service Quotas in the
+%% Amazon Connect Administrator Guide.
+%%
+%% Campaign calls are not allowed by default. Before you can make a call with
+%% `TrafficType' = `CAMPAIGN', you must submit a service quota increase
 %% request. For more information, see Amazon Connect Service Quotas in the
 %% Amazon Connect Administrator Guide.
 start_outbound_voice_contact(Client, Input) ->
@@ -2334,6 +2729,32 @@ stop_contact_recording(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Ends message streaming on a specified contact.
+%%
+%% To restart message streaming on that contact, call the
+%% StartContactStreaming API.
+stop_contact_streaming(Client, Input) ->
+    stop_contact_streaming(Client, Input, []).
+stop_contact_streaming(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/contact/stop-streaming"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc When a contact is being recorded, this API suspends recording the
 %% call.
 %%
@@ -2370,7 +2791,7 @@ suspend_contact_recording(Client, Input0, Options0) ->
 %% @doc Adds the specified tags to the specified resource.
 %%
 %% The supported resource types are users, routing profiles, queues, quick
-%% connects, and contact flows.
+%% connects, contact flows, agent status, and hours of operation.
 %%
 %% For sample policies that use tags, see Amazon Connect Identity-Based
 %% Policy Examples in the Amazon Connect Administrator Guide.
@@ -2420,20 +2841,48 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates or updates the contact attributes associated with the
-%% specified contact.
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
 %%
-%% You can add or update attributes for both ongoing and completed contacts.
-%% For example, while the call is active, you can update the customer's name
-%% or the reason the customer called. You can add notes about steps that the
-%% agent took during the call that display to the next agent that takes the
-%% call. You can also update attributes for a contact using data from your
-%% CRM application and save the data with the contact in Amazon Connect. You
-%% could also flag calls for additional analysis, such as legal review or to
-%% identify abusive callers.
+%% Updates agent status.
+update_agent_status(Client, AgentStatusId, InstanceId, Input) ->
+    update_agent_status(Client, AgentStatusId, InstanceId, Input, []).
+update_agent_status(Client, AgentStatusId, InstanceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/agent-status/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(AgentStatusId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates or updates user-defined contact attributes associated with
+%% the specified contact.
+%%
+%% You can create or update user-defined attributes for both ongoing and
+%% completed contacts. For example, while the call is active, you can update
+%% the customer's name or the reason the customer called. You can add notes
+%% about steps that the agent took during the call that display to the next
+%% agent that takes the call. You can also update attributes for a contact
+%% using data from your CRM application and save the data with the contact in
+%% Amazon Connect. You could also flag calls for additional analysis, such as
+%% legal review or to identify abusive callers.
 %%
 %% Contact attributes are available in Amazon Connect for 24 months, and are
-%% then deleted.
+%% then deleted. For information about CTR retention and the maximum size of
+%% the CTR attributes section, see Feature specifications in the Amazon
+%% Connect Administrator Guide.
 %%
 %% Important: You cannot use the operation to update attributes for contacts
 %% that occurred prior to the release of the API, which was September 12,
@@ -2499,6 +2948,29 @@ update_contact_flow_name(Client, ContactFlowId, InstanceId, Input) ->
 update_contact_flow_name(Client, ContactFlowId, InstanceId, Input0, Options0) ->
     Method = post,
     Path = ["/contact-flows/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(ContactFlowId), "/name"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the hours of operation.
+update_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input) ->
+    update_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input, []).
+update_hours_of_operation(Client, HoursOfOperationId, InstanceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/hours-of-operations/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(HoursOfOperationId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -2703,10 +3175,7 @@ update_queue_status(Client, InstanceId, QueueId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Updates the configuration settings for the specified quick connect.
+%% @doc Updates the configuration settings for the specified quick connect.
 update_quick_connect_config(Client, InstanceId, QuickConnectId, Input) ->
     update_quick_connect_config(Client, InstanceId, QuickConnectId, Input, []).
 update_quick_connect_config(Client, InstanceId, QuickConnectId, Input0, Options0) ->
@@ -2729,12 +3198,10 @@ update_quick_connect_config(Client, InstanceId, QuickConnectId, Input0, Options0
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
+%% @doc Updates the name and description of a quick connect.
 %%
-%% Updates the name and description of a quick connect. The request accepts
-%% the following data in JSON format. At least `Name' or `Description' must
-%% be provided.
+%% The request accepts the following data in JSON format. At least `Name' or
+%% `Description' must be provided.
 update_quick_connect_name(Client, InstanceId, QuickConnectId, Input) ->
     update_quick_connect_name(Client, InstanceId, QuickConnectId, Input, []).
 update_quick_connect_name(Client, InstanceId, QuickConnectId, Input0, Options0) ->
@@ -2837,6 +3304,32 @@ update_routing_profile_queues(Client, InstanceId, RoutingProfileId, Input) ->
 update_routing_profile_queues(Client, InstanceId, RoutingProfileId, Input0, Options0) ->
     Method = post,
     Path = ["/routing-profiles/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(RoutingProfileId), "/queues"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Updates a security profile.
+update_security_profile(Client, InstanceId, SecurityProfileId, Input) ->
+    update_security_profile(Client, InstanceId, SecurityProfileId, Input, []).
+update_security_profile(Client, InstanceId, SecurityProfileId, Input0, Options0) ->
+    Method = post,
+    Path = ["/security-profiles/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(SecurityProfileId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -3059,6 +3552,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_connect_contact_lens.erl
+++ b/src/aws_connect_contact_lens.erl
@@ -82,6 +82,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -36,6 +36,9 @@
 
 %% @doc Allows you to confirm that the attachment has been uploaded using the
 %% pre-signed URL provided in StartAttachmentUpload API.
+%%
+%% The Amazon Connect Participant Service APIs do not use Signature Version 4
+%% authentication.
 complete_attachment_upload(Client, Input) ->
     complete_attachment_upload(Client, Input, []).
 complete_attachment_upload(Client, Input0, Options0) ->
@@ -80,6 +83,16 @@ complete_attachment_upload(Client, Input0, Options0) ->
 %% Upon websocket URL expiry, as specified in the response ConnectionExpiry
 %% parameter, clients need to call this API again to obtain a new websocket
 %% URL and perform the same steps as before.
+%%
+%% Message streaming support: This API can also be used together with the
+%% StartContactStreaming API to create a participant connection for chat
+%% contacts that are not using a websocket. For more information about
+%% message streaming, Enable real-time chat message streaming in the Amazon
+%% Connect Administrator Guide.
+%%
+%% Feature specifications: For information about feature specifications, such
+%% as the allowed number of open websocket connections per participant, see
+%% Feature specifications in the Amazon Connect Administrator Guide.
 %%
 %% The Amazon Connect Participant Service APIs do not use Signature Version 4
 %% authentication.
@@ -141,6 +154,9 @@ disconnect_participant(Client, Input0, Options0) ->
 %% @doc Provides a pre-signed URL for download of a completed attachment.
 %%
 %% This is an asynchronous API for use with active contacts.
+%%
+%% The Amazon Connect Participant Service APIs do not use Signature Version 4
+%% authentication.
 get_attachment(Client, Input) ->
     get_attachment(Client, Input, []).
 get_attachment(Client, Input0, Options0) ->
@@ -261,6 +277,9 @@ send_message(Client, Input0, Options0) ->
 
 %% @doc Provides a pre-signed Amazon S3 URL in response for uploading the
 %% file directly to S3.
+%%
+%% The Amazon Connect Participant Service APIs do not use Signature Version 4
+%% authentication.
 start_attachment_upload(Client, Input) ->
     start_attachment_upload(Client, Input, []).
 start_attachment_upload(Client, Input0, Options0) ->
@@ -320,6 +339,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_cost_explorer.erl
+++ b/src/aws_cost_explorer.erl
@@ -1,13 +1,13 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc The Cost Explorer API enables you to programmatically query your cost
+%% @doc You can use the Cost Explorer API to programmatically query your cost
 %% and usage data.
 %%
 %% You can query for aggregated data such as total monthly costs or total
-%% daily usage. You can also query for granular data, such as the number of
-%% daily write operations for Amazon DynamoDB database tables in your
-%% production environment.
+%% daily usage. You can also query for granular data. This might include the
+%% number of daily write operations for Amazon DynamoDB database tables in
+%% your production environment.
 %%
 %% Service Endpoint
 %%
@@ -15,8 +15,8 @@
 %%
 %% <ul> <li> `https://ce.us-east-1.amazonaws.com'
 %%
-%% </li> </ul> For information about costs associated with the Cost Explorer
-%% API, see AWS Cost Management Pricing.
+%% </li> </ul> For information about the costs that are associated with the
+%% Cost Explorer API, see Amazon Web Services Cost Management Pricing.
 -module(aws_cost_explorer).
 
 -export([create_anomaly_monitor/2,
@@ -156,8 +156,8 @@ describe_cost_category_definition(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeCostCategoryDefinition">>, Input, Options).
 
-%% @doc Retrieves all of the cost anomalies detected on your account, during
-%% the time period specified by the `DateInterval' object.
+%% @doc Retrieves all of the cost anomalies detected on your account during
+%% the time period that's specified by the `DateInterval' object.
 get_anomalies(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_anomalies(Client, Input, []).
@@ -189,12 +189,13 @@ get_anomaly_subscriptions(Client, Input, Options)
 
 %% @doc Retrieves cost and usage metrics for your account.
 %%
-%% You can specify which cost and usage-related metric, such as
-%% `BlendedCosts' or `UsageQuantity', that you want the request to return.
-%% You can also filter and group your data by various dimensions, such as
-%% `SERVICE' or `AZ', in a specific time range. For a complete list of valid
-%% dimensions, see the GetDimensionValues operation. Management account in an
-%% organization in AWS Organizations have access to all member accounts.
+%% You can specify which cost and usage-related metric that you want the
+%% request to return. For example, you can specify `BlendedCosts' or
+%% `UsageQuantity'. You can also filter and group your data by various
+%% dimensions, such as `SERVICE' or `AZ', in a specific time range. For a
+%% complete list of valid dimensions, see the GetDimensionValues operation.
+%% Management account in an organization in Organizations have access to all
+%% member accounts.
 %%
 %% For information about filter limitations, see Quotas and restrictions in
 %% the Billing and Cost Management User Guide.
@@ -212,13 +213,13 @@ get_cost_and_usage(Client, Input, Options)
 %% You can also filter and group your data by various dimensions, such as
 %% `SERVICE' or `AZ', in a specific time range. For a complete list of valid
 %% dimensions, see the GetDimensionValues operation. Management account in an
-%% organization in AWS Organizations have access to all member accounts. This
-%% API is currently available for the Amazon Elastic Compute Cloud – Compute
+%% organization in Organizations have access to all member accounts. This API
+%% is currently available for the Amazon Elastic Compute Cloud – Compute
 %% service only.
 %%
 %% This is an opt-in only feature. You can enable this feature from the Cost
 %% Explorer Settings page. For information on how to access the Settings
-%% page, see Controlling Access for Cost Explorer in the AWS Billing and Cost
+%% page, see Controlling Access for Cost Explorer in the Billing and Cost
 %% Management User Guide.
 get_cost_and_usage_with_resources(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -307,22 +308,22 @@ get_reservation_coverage(Client, Input, Options)
 %% provide a discounted hourly rate (up to 75%) compared to On-Demand
 %% pricing.
 %%
-%% AWS generates your recommendations by identifying your On-Demand usage
-%% during a specific time period and collecting your usage into categories
-%% that are eligible for a reservation. After AWS has these categories, it
-%% simulates every combination of reservations in each category of usage to
-%% identify the best number of each type of RI to purchase to maximize your
-%% estimated savings.
+%% Amazon Web Services generates your recommendations by identifying your
+%% On-Demand usage during a specific time period and collecting your usage
+%% into categories that are eligible for a reservation. After Amazon Web
+%% Services has these categories, it simulates every combination of
+%% reservations in each category of usage to identify the best number of each
+%% type of RI to purchase to maximize your estimated savings.
 %%
-%% For example, AWS automatically aggregates your Amazon EC2 Linux, shared
-%% tenancy, and c4 family usage in the US West (Oregon) Region and recommends
-%% that you buy size-flexible regional reservations to apply to the c4 family
-%% usage. AWS recommends the smallest size instance in an instance family.
-%% This makes it easier to purchase a size-flexible RI. AWS also shows the
-%% equal number of normalized units so that you can purchase any instance
-%% size that you want. For this example, your RI recommendation would be for
-%% `c4.large' because that is the smallest size instance in the c4 instance
-%% family.
+%% For example, Amazon Web Services automatically aggregates your Amazon EC2
+%% Linux, shared tenancy, and c4 family usage in the US West (Oregon) Region
+%% and recommends that you buy size-flexible regional reservations to apply
+%% to the c4 family usage. Amazon Web Services recommends the smallest size
+%% instance in an instance family. This makes it easier to purchase a
+%% size-flexible RI. Amazon Web Services also shows the equal number of
+%% normalized units so that you can purchase any instance size that you want.
+%% For this example, your RI recommendation would be for `c4.large' because
+%% that is the smallest size instance in the c4 instance family.
 get_reservation_purchase_recommendation(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_reservation_purchase_recommendation(Client, Input, []).
@@ -349,7 +350,7 @@ get_reservation_utilization(Client, Input, Options)
 %% Recommendations are generated to either downsize or terminate instances,
 %% along with providing savings detail and metrics. For details on
 %% calculation and function, see Optimizing Your Cost with Rightsizing
-%% Recommendations in the AWS Billing and Cost Management User Guide.
+%% Recommendations in the Billing and Cost Management User Guide.
 get_rightsizing_recommendation(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_rightsizing_recommendation(Client, Input, []).
@@ -471,7 +472,7 @@ provide_anomaly_feedback(Client, Input, Options)
 
 %% @doc Updates an existing cost anomaly monitor.
 %%
-%% The changes made are applied going forward, and does not change anomalies
+%% The changes made are applied going forward, and doesn'tt change anomalies
 %% detected in the past.
 update_anomaly_monitor(Client, Input)
   when is_map(Client), is_map(Input) ->

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -1,0 +1,387 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc AWS Data Pipeline configures and manages a data-driven workflow
+%% called a pipeline.
+%%
+%% AWS Data Pipeline handles the details of scheduling and ensuring that data
+%% dependencies are met so that your application can focus on processing the
+%% data.
+%%
+%% AWS Data Pipeline provides a JAR implementation of a task runner called
+%% AWS Data Pipeline Task Runner. AWS Data Pipeline Task Runner provides
+%% logic for common data management scenarios, such as performing database
+%% queries and running data analysis using Amazon Elastic MapReduce (Amazon
+%% EMR). You can use AWS Data Pipeline Task Runner as your task runner, or
+%% you can write your own task runner to provide custom data management.
+%%
+%% AWS Data Pipeline implements two main sets of functionality. Use the first
+%% set to create a pipeline and define data sources, schedules, dependencies,
+%% and the transforms to be performed on the data. Use the second set in your
+%% task runner application to receive the next task ready for processing. The
+%% logic for performing the task, such as querying the data, running data
+%% analysis, or converting the data from one format to another, is contained
+%% within the task runner. The task runner performs the task assigned to it
+%% by the web service, reporting progress to the web service as it does so.
+%% When the task is done, the task runner reports the final success or
+%% failure of the task to the web service.
+-module(aws_data_pipeline).
+
+-export([activate_pipeline/2,
+         activate_pipeline/3,
+         add_tags/2,
+         add_tags/3,
+         create_pipeline/2,
+         create_pipeline/3,
+         deactivate_pipeline/2,
+         deactivate_pipeline/3,
+         delete_pipeline/2,
+         delete_pipeline/3,
+         describe_objects/2,
+         describe_objects/3,
+         describe_pipelines/2,
+         describe_pipelines/3,
+         evaluate_expression/2,
+         evaluate_expression/3,
+         get_pipeline_definition/2,
+         get_pipeline_definition/3,
+         list_pipelines/2,
+         list_pipelines/3,
+         poll_for_task/2,
+         poll_for_task/3,
+         put_pipeline_definition/2,
+         put_pipeline_definition/3,
+         query_objects/2,
+         query_objects/3,
+         remove_tags/2,
+         remove_tags/3,
+         report_task_progress/2,
+         report_task_progress/3,
+         report_task_runner_heartbeat/2,
+         report_task_runner_heartbeat/3,
+         set_status/2,
+         set_status/3,
+         set_task_status/2,
+         set_task_status/3,
+         validate_pipeline_definition/2,
+         validate_pipeline_definition/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Validates the specified pipeline and starts processing pipeline
+%% tasks.
+%%
+%% If the pipeline does not pass validation, activation fails.
+%%
+%% If you need to pause the pipeline to investigate an issue with a
+%% component, such as a data source or script, call `DeactivatePipeline'.
+%%
+%% To activate a finished pipeline, modify the end date for the pipeline and
+%% then activate it.
+activate_pipeline(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    activate_pipeline(Client, Input, []).
+activate_pipeline(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ActivatePipeline">>, Input, Options).
+
+%% @doc Adds or modifies tags for the specified pipeline.
+add_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    add_tags(Client, Input, []).
+add_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AddTags">>, Input, Options).
+
+%% @doc Creates a new, empty pipeline.
+%%
+%% Use `PutPipelineDefinition' to populate the pipeline.
+create_pipeline(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_pipeline(Client, Input, []).
+create_pipeline(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreatePipeline">>, Input, Options).
+
+%% @doc Deactivates the specified running pipeline.
+%%
+%% The pipeline is set to the `DEACTIVATING' state until the deactivation
+%% process completes.
+%%
+%% To resume a deactivated pipeline, use `ActivatePipeline'. By default, the
+%% pipeline resumes from the last completed execution. Optionally, you can
+%% specify the date and time to resume the pipeline.
+deactivate_pipeline(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    deactivate_pipeline(Client, Input, []).
+deactivate_pipeline(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeactivatePipeline">>, Input, Options).
+
+%% @doc Deletes a pipeline, its pipeline definition, and its run history.
+%%
+%% AWS Data Pipeline attempts to cancel instances associated with the
+%% pipeline that are currently being processed by task runners.
+%%
+%% Deleting a pipeline cannot be undone. You cannot query or restore a
+%% deleted pipeline. To temporarily pause a pipeline instead of deleting it,
+%% call `SetStatus' with the status set to `PAUSE' on individual components.
+%% Components that are paused by `SetStatus' can be resumed.
+delete_pipeline(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_pipeline(Client, Input, []).
+delete_pipeline(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeletePipeline">>, Input, Options).
+
+%% @doc Gets the object definitions for a set of objects associated with the
+%% pipeline.
+%%
+%% Object definitions are composed of a set of fields that define the
+%% properties of the object.
+describe_objects(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_objects(Client, Input, []).
+describe_objects(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeObjects">>, Input, Options).
+
+%% @doc Retrieves metadata about one or more pipelines.
+%%
+%% The information retrieved includes the name of the pipeline, the pipeline
+%% identifier, its current state, and the user account that owns the
+%% pipeline. Using account credentials, you can retrieve metadata about
+%% pipelines that you or your IAM users have created. If you are using an IAM
+%% user account, you can retrieve metadata about only those pipelines for
+%% which you have read permissions.
+%%
+%% To retrieve the full pipeline definition instead of metadata about the
+%% pipeline, call `GetPipelineDefinition'.
+describe_pipelines(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_pipelines(Client, Input, []).
+describe_pipelines(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribePipelines">>, Input, Options).
+
+%% @doc Task runners call `EvaluateExpression' to evaluate a string in the
+%% context of the specified object.
+%%
+%% For example, a task runner can evaluate SQL queries stored in Amazon S3.
+evaluate_expression(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    evaluate_expression(Client, Input, []).
+evaluate_expression(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"EvaluateExpression">>, Input, Options).
+
+%% @doc Gets the definition of the specified pipeline.
+%%
+%% You can call `GetPipelineDefinition' to retrieve the pipeline definition
+%% that you provided using `PutPipelineDefinition'.
+get_pipeline_definition(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_pipeline_definition(Client, Input, []).
+get_pipeline_definition(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetPipelineDefinition">>, Input, Options).
+
+%% @doc Lists the pipeline identifiers for all active pipelines that you have
+%% permission to access.
+list_pipelines(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_pipelines(Client, Input, []).
+list_pipelines(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListPipelines">>, Input, Options).
+
+%% @doc Task runners call `PollForTask' to receive a task to perform from AWS
+%% Data Pipeline.
+%%
+%% The task runner specifies which tasks it can perform by setting a value
+%% for the `workerGroup' parameter. The task returned can come from any of
+%% the pipelines that match the `workerGroup' value passed in by the task
+%% runner and that was launched using the IAM user credentials specified by
+%% the task runner.
+%%
+%% If tasks are ready in the work queue, `PollForTask' returns a response
+%% immediately. If no tasks are available in the queue, `PollForTask' uses
+%% long-polling and holds on to a poll connection for up to a 90 seconds,
+%% during which time the first newly scheduled task is handed to the task
+%% runner. To accomodate this, set the socket timeout in your task runner to
+%% 90 seconds. The task runner should not call `PollForTask' again on the
+%% same `workerGroup' until it receives a response, and this can take up to
+%% 90 seconds.
+poll_for_task(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    poll_for_task(Client, Input, []).
+poll_for_task(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PollForTask">>, Input, Options).
+
+%% @doc Adds tasks, schedules, and preconditions to the specified pipeline.
+%%
+%% You can use `PutPipelineDefinition' to populate a new pipeline.
+%%
+%% `PutPipelineDefinition' also validates the configuration as it adds it to
+%% the pipeline. Changes to the pipeline are saved unless one of the
+%% following three validation errors exists in the pipeline.
+%%
+%% <ol> <li>An object is missing a name or identifier field.</li> <li>A
+%% string or reference field is empty.</li> <li>The number of objects in the
+%% pipeline exceeds the maximum allowed objects.</li> <li>The pipeline is in
+%% a FINISHED state.</li> </ol> Pipeline object definitions are passed to the
+%% `PutPipelineDefinition' action and returned by the `GetPipelineDefinition'
+%% action.
+put_pipeline_definition(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_pipeline_definition(Client, Input, []).
+put_pipeline_definition(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutPipelineDefinition">>, Input, Options).
+
+%% @doc Queries the specified pipeline for the names of objects that match
+%% the specified set of conditions.
+query_objects(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    query_objects(Client, Input, []).
+query_objects(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"QueryObjects">>, Input, Options).
+
+%% @doc Removes existing tags from the specified pipeline.
+remove_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    remove_tags(Client, Input, []).
+remove_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RemoveTags">>, Input, Options).
+
+%% @doc Task runners call `ReportTaskProgress' when assigned a task to
+%% acknowledge that it has the task.
+%%
+%% If the web service does not receive this acknowledgement within 2 minutes,
+%% it assigns the task in a subsequent `PollForTask' call. After this initial
+%% acknowledgement, the task runner only needs to report progress every 15
+%% minutes to maintain its ownership of the task. You can change this
+%% reporting time from 15 minutes by specifying a `reportProgressTimeout'
+%% field in your pipeline.
+%%
+%% If a task runner does not report its status after 5 minutes, AWS Data
+%% Pipeline assumes that the task runner is unable to process the task and
+%% reassigns the task in a subsequent response to `PollForTask'. Task runners
+%% should call `ReportTaskProgress' every 60 seconds.
+report_task_progress(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    report_task_progress(Client, Input, []).
+report_task_progress(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ReportTaskProgress">>, Input, Options).
+
+%% @doc Task runners call `ReportTaskRunnerHeartbeat' every 15 minutes to
+%% indicate that they are operational.
+%%
+%% If the AWS Data Pipeline Task Runner is launched on a resource managed by
+%% AWS Data Pipeline, the web service can use this call to detect when the
+%% task runner application has failed and restart a new instance.
+report_task_runner_heartbeat(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    report_task_runner_heartbeat(Client, Input, []).
+report_task_runner_heartbeat(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ReportTaskRunnerHeartbeat">>, Input, Options).
+
+%% @doc Requests that the status of the specified physical or logical
+%% pipeline objects be updated in the specified pipeline.
+%%
+%% This update might not occur immediately, but is eventually consistent. The
+%% status that can be set depends on the type of object (for example,
+%% DataNode or Activity). You cannot perform this operation on `FINISHED'
+%% pipelines and attempting to do so returns `InvalidRequestException'.
+set_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    set_status(Client, Input, []).
+set_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SetStatus">>, Input, Options).
+
+%% @doc Task runners call `SetTaskStatus' to notify AWS Data Pipeline that a
+%% task is completed and provide information about the final status.
+%%
+%% A task runner makes this call regardless of whether the task was
+%% sucessful. A task runner does not need to call `SetTaskStatus' for tasks
+%% that are canceled by the web service during a call to
+%% `ReportTaskProgress'.
+set_task_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    set_task_status(Client, Input, []).
+set_task_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SetTaskStatus">>, Input, Options).
+
+%% @doc Validates the specified pipeline definition to ensure that it is well
+%% formed and can be run without error.
+validate_pipeline_definition(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    validate_pipeline_definition(Client, Input, []).
+validate_pipeline_definition(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ValidatePipelineDefinition">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"datapipeline">>},
+    Host = build_host(<<"datapipeline">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
+        {<<"X-Amz-Target">>, <<"DataPipeline.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_database_migration.erl
+++ b/src/aws_database_migration.erl
@@ -1,10 +1,10 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Database Migration Service
+%% @doc Database Migration Service
 %%
-%% AWS Database Migration Service (AWS DMS) can migrate your data to and from
-%% the most widely used commercial and open-source databases such as Oracle,
+%% Database Migration Service (DMS) can migrate your data to and from the
+%% most widely used commercial and open-source databases such as Oracle,
 %% PostgreSQL, Microsoft SQL Server, Amazon Redshift, MariaDB, Amazon Aurora,
 %% MySQL, and SAP Adaptive Server Enterprise (ASE).
 %%
@@ -12,8 +12,8 @@
 %% well as heterogeneous migrations between different database platforms,
 %% such as Oracle to MySQL or SQL Server to PostgreSQL.
 %%
-%% For more information about AWS DMS, see What Is AWS Database Migration
-%% Service? in the AWS Database Migration User Guide.
+%% For more information about DMS, see What Is Database Migration Service? in
+%% the Database Migration Service User Guide.
 -module(aws_database_migration).
 
 -export([add_tags_to_resource/2,
@@ -56,6 +56,8 @@
          describe_certificates/3,
          describe_connections/2,
          describe_connections/3,
+         describe_endpoint_settings/2,
+         describe_endpoint_settings/3,
          describe_endpoint_types/2,
          describe_endpoint_types/3,
          describe_endpoints/2,
@@ -131,7 +133,7 @@
 %% API
 %%====================================================================
 
-%% @doc Adds metadata tags to an AWS DMS resource, including replication
+%% @doc Adds metadata tags to an DMS resource, including replication
 %% instance, endpoint, security group, and migration task.
 %%
 %% These tags can also be used with cost allocation reporting to track cost
@@ -166,6 +168,13 @@ cancel_replication_task_assessment_run(Client, Input, Options)
     request(Client, <<"CancelReplicationTaskAssessmentRun">>, Input, Options).
 
 %% @doc Creates an endpoint using the provided settings.
+%%
+%% For a MySQL source or target endpoint, don't explicitly specify the
+%% database using the `DatabaseName' request parameter on the
+%% `CreateEndpoint' API call. Specifying `DatabaseName' when you create a
+%% MySQL endpoint replicates all the task tables to this single database. For
+%% MySQL endpoints, you specify the database only when you specify the schema
+%% in the table-mapping rules of the DMS task.
 create_endpoint(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_endpoint(Client, Input, []).
@@ -173,23 +182,23 @@ create_endpoint(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateEndpoint">>, Input, Options).
 
-%% @doc Creates an AWS DMS event notification subscription.
+%% @doc Creates an DMS event notification subscription.
 %%
 %% You can specify the type of source (`SourceType') you want to be notified
-%% of, provide a list of AWS DMS source IDs (`SourceIds') that triggers the
+%% of, provide a list of DMS source IDs (`SourceIds') that triggers the
 %% events, and provide a list of event categories (`EventCategories') for
 %% events you want to be notified of. If you specify both the `SourceType'
 %% and `SourceIds', such as `SourceType = replication-instance' and
 %% `SourceIdentifier = my-replinstance', you will be notified of all the
 %% replication instance events for the specified source. If you specify a
 %% `SourceType' but don't specify a `SourceIdentifier', you receive notice of
-%% the events for that source type for all your AWS DMS sources. If you don't
+%% the events for that source type for all your DMS sources. If you don't
 %% specify either `SourceType' nor `SourceIdentifier', you will be notified
-%% of events generated from all AWS DMS sources belonging to your customer
+%% of events generated from all DMS sources belonging to your customer
 %% account.
 %%
-%% For more information about AWS DMS events, see Working with Events and
-%% Notifications in the AWS Database Migration Service User Guide.
+%% For more information about DMS events, see Working with Events and
+%% Notifications in the Database Migration Service User Guide.
 create_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_event_subscription(Client, Input, []).
@@ -199,11 +208,11 @@ create_event_subscription(Client, Input, Options)
 
 %% @doc Creates the replication instance using the specified parameters.
 %%
-%% AWS DMS requires that your account have certain roles with appropriate
+%% DMS requires that your account have certain roles with appropriate
 %% permissions before you can create a replication instance. For information
-%% on the required roles, see Creating the IAM Roles to Use With the AWS CLI
-%% and AWS DMS API. For information on the required permissions, see IAM
-%% Permissions Needed to Use AWS DMS.
+%% on the required roles, see Creating the IAM Roles to Use With the CLI and
+%% DMS API. For information on the required permissions, see IAM Permissions
+%% Needed to Use DMS.
 create_replication_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_replication_instance(Client, Input, []).
@@ -213,6 +222,10 @@ create_replication_instance(Client, Input, Options)
 
 %% @doc Creates a replication subnet group given a list of the subnet IDs in
 %% a VPC.
+%%
+%% The VPC needs to have at least one subnet in at least two availability
+%% zones in the Amazon Web Services Region, otherwise the service will throw
+%% a `ReplicationSubnetGroupDoesNotCoverEnoughAZs' exception.
 create_replication_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_replication_subnet_group(Client, Input, []).
@@ -256,7 +269,7 @@ delete_endpoint(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteEndpoint">>, Input, Options).
 
-%% @doc Deletes an AWS DMS event subscription.
+%% @doc Deletes an DMS event subscription.
 delete_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_event_subscription(Client, Input, []).
@@ -293,7 +306,7 @@ delete_replication_task(Client, Input, Options)
 
 %% @doc Deletes the record of a single premigration assessment run.
 %%
-%% This operation removes all metadata that AWS DMS maintains about this
+%% This operation removes all metadata that DMS maintains about this
 %% assessment run. However, the operation leaves untouched all information
 %% about this assessment run that is stored in your Amazon S3 bucket.
 delete_replication_task_assessment_run(Client, Input)
@@ -303,11 +316,11 @@ delete_replication_task_assessment_run(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteReplicationTaskAssessmentRun">>, Input, Options).
 
-%% @doc Lists all of the AWS DMS attributes for a customer account.
+%% @doc Lists all of the DMS attributes for a customer account.
 %%
-%% These attributes include AWS DMS quotas for the account and a unique
-%% account identifier in a particular DMS region. DMS quotas include a list
-%% of resource quotas supported by the account, such as the number of
+%% These attributes include DMS quotas for the account and a unique account
+%% identifier in a particular DMS region. DMS quotas include a list of
+%% resource quotas supported by the account, such as the number of
 %% replication instances allowed. The description for each resource quota,
 %% includes the quota name, current usage toward that quota, and the quota's
 %% maximum value. DMS uses the unique account identifier to name each
@@ -369,6 +382,15 @@ describe_connections(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeConnections">>, Input, Options).
 
+%% @doc Returns information about the possible endpoint settings available
+%% when you create an endpoint for a specific database engine.
+describe_endpoint_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_endpoint_settings(Client, Input, []).
+describe_endpoint_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEndpointSettings">>, Input, Options).
+
 %% @doc Returns information about the type of endpoints available.
 describe_endpoint_types(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -390,7 +412,7 @@ describe_endpoints(Client, Input, Options)
 %% specified source type.
 %%
 %% You can see a list of the event categories and source types in Working
-%% with Events and Notifications in the AWS Database Migration Service User
+%% with Events and Notifications in the Database Migration Service User
 %% Guide.
 describe_event_categories(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -416,9 +438,9 @@ describe_event_subscriptions(Client, Input, Options)
 
 %% @doc Lists events for a given source identifier and source type.
 %%
-%% You can also specify a start and end time. For more information on AWS DMS
-%% events, see Working with Events and Notifications in the AWS Database
-%% Migration User Guide.
+%% You can also specify a start and end time. For more information on DMS
+%% events, see Working with Events and Notifications in the Database
+%% Migration Service User Guide.
 describe_events(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_events(Client, Input, []).
@@ -476,9 +498,13 @@ describe_replication_subnet_groups(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeReplicationSubnetGroups">>, Input, Options).
 
-%% @doc Returns the task assessment results from Amazon S3.
+%% @doc Returns the task assessment results from the Amazon S3 bucket that
+%% DMS creates in your Amazon Web Services account.
 %%
 %% This action always returns the latest results.
+%%
+%% For more information about DMS task assessments, see Creating a task
+%% assessment report in the Database Migration Service User Guide.
 describe_replication_task_assessment_results(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_replication_task_assessment_results(Client, Input, []).
@@ -536,7 +562,7 @@ describe_schemas(Client, Input, Options)
 %% table name, rows inserted, rows updated, and rows deleted.
 %%
 %% Note that the "last updated" column the DMS console only indicates the
-%% time that AWS DMS last updated the table statistics record for a table. It
+%% time that DMS last updated the table statistics record for a table. It
 %% does not indicate the time of the last update to the table.
 describe_table_statistics(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -553,7 +579,7 @@ import_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ImportCertificate">>, Input, Options).
 
-%% @doc Lists all metadata tags attached to an AWS DMS resource, including
+%% @doc Lists all metadata tags attached to an DMS resource, including
 %% replication instance, endpoint, security group, and migration task.
 %%
 %% For more information, see `Tag' data type description.
@@ -565,6 +591,13 @@ list_tags_for_resource(Client, Input, Options)
     request(Client, <<"ListTagsForResource">>, Input, Options).
 
 %% @doc Modifies the specified endpoint.
+%%
+%% For a MySQL source or target endpoint, don't explicitly specify the
+%% database using the `DatabaseName' request parameter on the
+%% `ModifyEndpoint' API call. Specifying `DatabaseName' when you modify a
+%% MySQL endpoint replicates all the task tables to this single database. For
+%% MySQL endpoints, you specify the database only when you specify the schema
+%% in the table-mapping rules of the DMS task.
 modify_endpoint(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_endpoint(Client, Input, []).
@@ -572,7 +605,7 @@ modify_endpoint(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyEndpoint">>, Input, Options).
 
-%% @doc Modifies an existing AWS DMS event notification subscription.
+%% @doc Modifies an existing DMS event notification subscription.
 modify_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_event_subscription(Client, Input, []).
@@ -606,8 +639,8 @@ modify_replication_subnet_group(Client, Input, Options)
 %% You can't modify the task endpoints. The task must be stopped before you
 %% can modify it.
 %%
-%% For more information about AWS DMS tasks, see Working with Migration Tasks
-%% in the AWS Database Migration Service User Guide.
+%% For more information about DMS tasks, see Working with Migration Tasks in
+%% the Database Migration Service User Guide.
 modify_replication_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_replication_task(Client, Input, []).
@@ -618,8 +651,8 @@ modify_replication_task(Client, Input, Options)
 %% @doc Moves a replication task from its current replication instance to a
 %% different target replication instance using the specified parameters.
 %%
-%% The target replication instance must be created with the same or later AWS
-%% DMS version as the current replication instance.
+%% The target replication instance must be created with the same or later DMS
+%% version as the current replication instance.
 move_replication_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     move_replication_task(Client, Input, []).
@@ -651,6 +684,9 @@ refresh_schemas(Client, Input, Options)
     request(Client, <<"RefreshSchemas">>, Input, Options).
 
 %% @doc Reloads the target database table with the source data.
+%%
+%% You can only use this operation with a task in the `RUNNING' state,
+%% otherwise the service will throw an `InvalidResourceStateFault' exception.
 reload_tables(Client, Input)
   when is_map(Client), is_map(Input) ->
     reload_tables(Client, Input, []).
@@ -658,7 +694,7 @@ reload_tables(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ReloadTables">>, Input, Options).
 
-%% @doc Removes metadata tags from an AWS DMS resource, including replication
+%% @doc Removes metadata tags from an DMS resource, including replication
 %% instance, endpoint, security group, and migration task.
 %%
 %% For more information, see `Tag' data type description.
@@ -671,8 +707,8 @@ remove_tags_from_resource(Client, Input, Options)
 
 %% @doc Starts the replication task.
 %%
-%% For more information about AWS DMS tasks, see Working with Migration Tasks
-%% in the AWS Database Migration Service User Guide.
+%% For more information about DMS tasks, see Working with Migration Tasks in
+%% the Database Migration Service User Guide.
 start_replication_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_replication_task(Client, Input, []).

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -1,7 +1,7 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Glue DataBrew is a visual, cloud-scale data-preparation service.
+%% @doc Glue DataBrew is a visual, cloud-scale data-preparation service.
 %%
 %% DataBrew simplifies data preparation tasks, targeting data issues that are
 %% hard to spot and time-consuming to fix. DataBrew empowers users of all
@@ -252,7 +252,7 @@ create_recipe(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a new job to transform input data, using steps defined in an
-%% existing AWS Glue DataBrew recipe
+%% existing Glue DataBrew recipe
 create_recipe_job(Client, Input) ->
     create_recipe_job(Client, Input, []).
 create_recipe_job(Client, Input0, Options0) ->
@@ -1122,6 +1122,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -8,6 +8,8 @@
          cancel_job/4,
          create_data_set/2,
          create_data_set/3,
+         create_event_action/2,
+         create_event_action/3,
          create_job/2,
          create_job/3,
          create_revision/3,
@@ -16,6 +18,8 @@
          delete_asset/6,
          delete_data_set/3,
          delete_data_set/4,
+         delete_event_action/3,
+         delete_event_action/4,
          delete_revision/4,
          delete_revision/5,
          get_asset/4,
@@ -24,6 +28,9 @@
          get_data_set/2,
          get_data_set/4,
          get_data_set/5,
+         get_event_action/2,
+         get_event_action/4,
+         get_event_action/5,
          get_job/2,
          get_job/4,
          get_job/5,
@@ -36,6 +43,9 @@
          list_data_sets/1,
          list_data_sets/3,
          list_data_sets/4,
+         list_event_actions/1,
+         list_event_actions/3,
+         list_event_actions/4,
          list_jobs/1,
          list_jobs/3,
          list_jobs/4,
@@ -55,6 +65,8 @@
          update_asset/6,
          update_data_set/3,
          update_data_set/4,
+         update_event_action/3,
+         update_event_action/4,
          update_revision/4,
          update_revision/5]).
 
@@ -95,6 +107,29 @@ create_data_set(Client, Input) ->
 create_data_set(Client, Input0, Options0) ->
     Method = post,
     Path = ["/v1/data-sets"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This operation creates an event action.
+create_event_action(Client, Input) ->
+    create_event_action(Client, Input, []).
+create_event_action(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/event-actions"],
     SuccessStatusCode = 201,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -204,6 +239,29 @@ delete_data_set(Client, DataSetId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc This operation deletes the event action.
+delete_event_action(Client, EventActionId, Input) ->
+    delete_event_action(Client, EventActionId, Input, []).
+delete_event_action(Client, EventActionId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v1/event-actions/", aws_util:encode_uri(EventActionId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc This operation deletes a revision.
 delete_revision(Client, DataSetId, RevisionId, Input) ->
     delete_revision(Client, DataSetId, RevisionId, Input, []).
@@ -262,6 +320,29 @@ get_data_set(Client, DataSetId, QueryMap, HeadersMap)
 get_data_set(Client, DataSetId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/v1/data-sets/", aws_util:encode_uri(DataSetId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This operation retrieves information about an event action.
+get_event_action(Client, EventActionId)
+  when is_map(Client) ->
+    get_event_action(Client, EventActionId, #{}, #{}).
+
+get_event_action(Client, EventActionId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_event_action(Client, EventActionId, QueryMap, HeadersMap, []).
+
+get_event_action(Client, EventActionId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/event-actions/", aws_util:encode_uri(EventActionId), ""],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -376,6 +457,35 @@ list_data_sets(Client, QueryMap, HeadersMap, Options0)
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
         {<<"origin">>, maps:get(<<"origin">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This operation lists your event actions.
+list_event_actions(Client)
+  when is_map(Client) ->
+    list_event_actions(Client, #{}, #{}).
+
+list_event_actions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_event_actions(Client, QueryMap, HeadersMap, []).
+
+list_event_actions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/event-actions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"eventSourceId">>, maps:get(<<"eventSourceId">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -580,6 +690,29 @@ update_data_set(Client, DataSetId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc This operation updates the event action.
+update_event_action(Client, EventActionId, Input) ->
+    update_event_action(Client, EventActionId, Input, []).
+update_event_action(Client, EventActionId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/v1/event-actions/", aws_util:encode_uri(EventActionId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc This operation updates a revision.
 update_revision(Client, DataSetId, RevisionId, Input) ->
     update_revision(Client, DataSetId, RevisionId, Input, []).
@@ -638,6 +771,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_datasync.erl
+++ b/src/aws_datasync.erl
@@ -1,14 +1,14 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS DataSync
+%% @doc DataSync
 %%
-%% AWS DataSync is a managed data transfer service that makes it simpler for
-%% you to automate moving data between on-premises storage and Amazon Simple
+%% DataSync is a managed data transfer service that makes it simpler for you
+%% to automate moving data between on-premises storage and Amazon Simple
 %% Storage Service (Amazon S3) or Amazon Elastic File System (Amazon EFS).
 %%
-%% This API interface reference for AWS DataSync contains documentation for a
-%% programming interface that you can use to manage AWS DataSync.
+%% This API interface reference for DataSync contains documentation for a
+%% programming interface that you can use to manage DataSync.
 -module(aws_datasync).
 
 -export([cancel_task_execution/2,
@@ -19,6 +19,8 @@
          create_location_efs/3,
          create_location_fsx_windows/2,
          create_location_fsx_windows/3,
+         create_location_hdfs/2,
+         create_location_hdfs/3,
          create_location_nfs/2,
          create_location_nfs/3,
          create_location_object_storage/2,
@@ -41,6 +43,8 @@
          describe_location_efs/3,
          describe_location_fsx_windows/2,
          describe_location_fsx_windows/3,
+         describe_location_hdfs/2,
+         describe_location_hdfs/3,
          describe_location_nfs/2,
          describe_location_nfs/3,
          describe_location_object_storage/2,
@@ -71,6 +75,8 @@
          untag_resource/3,
          update_agent/2,
          update_agent/3,
+         update_location_hdfs/2,
+         update_location_hdfs/3,
          update_location_nfs/2,
          update_location_nfs/3,
          update_location_object_storage/2,
@@ -96,8 +102,8 @@
 %% start a new task execution on the same task and you allow the task
 %% execution to complete, file content on the destination is complete and
 %% consistent. This applies to other unexpected failures that interrupt a
-%% task execution. In all of these cases, AWS DataSync successfully complete
-%% the transfer when you start the next task execution.
+%% task execution. In all of these cases, DataSync successfully complete the
+%% transfer when you start the next task execution.
 cancel_task_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     cancel_task_execution(Client, Input, []).
@@ -105,13 +111,14 @@ cancel_task_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CancelTaskExecution">>, Input, Options).
 
-%% @doc Activates an AWS DataSync agent that you have deployed on your host.
+%% @doc Activates an DataSync agent that you have deployed on your host.
 %%
 %% The activation process associates your agent with your account. In the
-%% activation process, you specify information such as the AWS Region that
-%% you want to activate the agent in. You activate the agent in the AWS
-%% Region where your target locations (in Amazon S3 or Amazon EFS) reside.
-%% Your tasks are created in this AWS Region.
+%% activation process, you specify information such as the Amazon Web
+%% Services Region that you want to activate the agent in. You activate the
+%% agent in the Amazon Web Services Region where your target locations (in
+%% Amazon S3 or Amazon EFS) reside. Your tasks are created in this Amazon Web
+%% Services Region.
 %%
 %% You can activate the agent in a VPC (virtual private cloud) or provide the
 %% agent access to a VPC endpoint so you can run tasks without going over the
@@ -122,8 +129,8 @@ cancel_task_execution(Client, Input, Options)
 %% you use multiple agents for a source location, the status of all the
 %% agents must be AVAILABLE for the task to run.
 %%
-%% Agents are automatically updated by AWS on a regular basis, using a
-%% mechanism that ensures minimal interruption to your tasks.
+%% Agents are automatically updated by Amazon Web Services on a regular
+%% basis, using a mechanism that ensures minimal interruption to your tasks.
 create_agent(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_agent(Client, Input, []).
@@ -148,6 +155,14 @@ create_location_fsx_windows(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateLocationFsxWindows">>, Input, Options).
 
+%% @doc Creates an endpoint for a Hadoop Distributed File System (HDFS).
+create_location_hdfs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_location_hdfs(Client, Input, []).
+create_location_hdfs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateLocationHdfs">>, Input, Options).
+
 %% @doc Defines a file system on a Network File System (NFS) server that can
 %% be read from or written to.
 create_location_nfs(Client, Input)
@@ -160,7 +175,7 @@ create_location_nfs(Client, Input, Options)
 %% @doc Creates an endpoint for a self-managed object storage bucket.
 %%
 %% For more information about self-managed object storage locations, see
-%% `create-object-location'.
+%% Creating a location for object storage.
 create_location_object_storage(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_location_object_storage(Client, Input, []).
@@ -170,9 +185,8 @@ create_location_object_storage(Client, Input, Options)
 
 %% @doc Creates an endpoint for an Amazon S3 bucket.
 %%
-%% For more information, see
-%% https://docs.aws.amazon.com/datasync/latest/userguide/create-locations-cli.html#create-location-s3-cli
-%% in the AWS DataSync User Guide.
+%% For more information, see Create an Amazon S3 location in the DataSync
+%% User Guide.
 create_location_s3(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_location_s3(Client, Input, []).
@@ -197,18 +211,18 @@ create_location_smb(Client, Input, Options)
 %% configuration specifies options such as task scheduling, bandwidth limits,
 %% etc. A task is the complete definition of a data transfer.
 %%
-%% When you create a task that transfers data between AWS services in
-%% different AWS Regions, one of the two locations that you specify must
-%% reside in the Region where DataSync is being used. The other location must
-%% be specified in a different Region.
+%% When you create a task that transfers data between Amazon Web Services
+%% services in different Amazon Web Services Regions, one of the two
+%% locations that you specify must reside in the Region where DataSync is
+%% being used. The other location must be specified in a different Region.
 %%
-%% You can transfer data between commercial AWS Regions except for China, or
-%% between AWS GovCloud (US-East and US-West) Regions.
+%% You can transfer data between commercial Amazon Web Services Regions
+%% except for China, or between Amazon Web Services GovCloud (US) Regions.
 %%
-%% When you use DataSync to copy files or objects between AWS Regions, you
-%% pay for data transfer between Regions. This is billed as data transfer OUT
-%% from your source Region to your destination Region. For more information,
-%% see Data Transfer pricing.
+%% When you use DataSync to copy files or objects between Amazon Web Services
+%% Regions, you pay for data transfer between Regions. This is billed as data
+%% transfer OUT from your source Region to your destination Region. For more
+%% information, see Data Transfer pricing.
 create_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_task(Client, Input, []).
@@ -220,8 +234,8 @@ create_task(Client, Input, Options)
 %%
 %% To specify which agent to delete, use the Amazon Resource Name (ARN) of
 %% the agent in your request. The operation disassociates the agent from your
-%% AWS account. However, it doesn't delete the agent virtual machine (VM)
-%% from your on-premises environment.
+%% Amazon Web Services account. However, it doesn't delete the agent virtual
+%% machine (VM) from your on-premises environment.
 delete_agent(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_agent(Client, Input, []).
@@ -229,7 +243,7 @@ delete_agent(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAgent">>, Input, Options).
 
-%% @doc Deletes the configuration of a location used by AWS DataSync.
+%% @doc Deletes the configuration of a location used by DataSync.
 delete_location(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_location(Client, Input, []).
@@ -275,6 +289,15 @@ describe_location_fsx_windows(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeLocationFsxWindows">>, Input, Options).
 
+%% @doc Returns metadata, such as the authentication information about the
+%% Hadoop Distributed File System (HDFS) location.
+describe_location_hdfs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_location_hdfs(Client, Input, []).
+describe_location_hdfs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeLocationHdfs">>, Input, Options).
+
 %% @doc Returns metadata, such as the path information, about an NFS
 %% location.
 describe_location_nfs(Client, Input)
@@ -287,7 +310,7 @@ describe_location_nfs(Client, Input, Options)
 %% @doc Returns metadata about a self-managed object storage server location.
 %%
 %% For more information about self-managed object storage locations, see
-%% `create-object-location'.
+%% Creating a location for object storage.
 describe_location_object_storage(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_location_object_storage(Client, Input, []).
@@ -329,8 +352,8 @@ describe_task_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeTaskExecution">>, Input, Options).
 
-%% @doc Returns a list of agents owned by an AWS account in the AWS Region
-%% specified in the request.
+%% @doc Returns a list of agents owned by an Amazon Web Services account in
+%% the Amazon Web Services Region specified in the request.
 %%
 %% The returned list is ordered by agent Amazon Resource Name (ARN).
 %%
@@ -395,7 +418,7 @@ list_tasks(Client, Input, Options)
 %% PREPARING | TRANSFERRING | VERIFYING | SUCCESS/FAILURE.
 %%
 %% For detailed information, see the Task Execution section in the Components
-%% and Terminology topic in the AWS DataSync User Guide.
+%% and Terminology topic in the DataSync User Guide.
 start_task_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_task_execution(Client, Input, []).
@@ -403,7 +426,7 @@ start_task_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartTaskExecution">>, Input, Options).
 
-%% @doc Applies a key-value pair to an AWS resource.
+%% @doc Applies a key-value pair to an Amazon Web Services resource.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -411,7 +434,7 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Removes a tag from an AWS resource.
+%% @doc Removes a tag from an Amazon Web Services resource.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
@@ -427,10 +450,20 @@ update_agent(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateAgent">>, Input, Options).
 
+%% @doc Updates some parameters of a previously created location for a Hadoop
+%% Distributed File System cluster.
+update_location_hdfs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_location_hdfs(Client, Input, []).
+update_location_hdfs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateLocationHdfs">>, Input, Options).
+
 %% @doc Updates some of the parameters of a previously created location for
 %% Network File System (NFS) access.
 %%
-%% For information about creating an NFS location, see `create-nfs-location'.
+%% For information about creating an NFS location, see Creating a location
+%% for NFS.
 update_location_nfs(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_location_nfs(Client, Input, []).
@@ -442,7 +475,7 @@ update_location_nfs(Client, Input, Options)
 %% self-managed object storage server access.
 %%
 %% For information about creating a self-managed object storage location, see
-%% `create-object-location'.
+%% Creating a location for object storage.
 update_location_object_storage(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_location_object_storage(Client, Input, []).
@@ -453,7 +486,8 @@ update_location_object_storage(Client, Input, Options)
 %% @doc Updates some of the parameters of a previously created location for
 %% Server Message Block (SMB) file system access.
 %%
-%% For information about creating an SMB location, see `create-smb-location'.
+%% For information about creating an SMB location, see Creating a location
+%% for SMB.
 update_location_smb(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_location_smb(Client, Input, []).

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -1,17 +1,17 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Direct Connect links your internal network to an AWS Direct
-%% Connect location over a standard Ethernet fiber-optic cable.
+%% @doc Direct Connect links your internal network to an Direct Connect
+%% location over a standard Ethernet fiber-optic cable.
 %%
-%% One end of the cable is connected to your router, the other to an AWS
-%% Direct Connect router. With this connection in place, you can create
-%% virtual interfaces directly to the AWS cloud (for example, to Amazon EC2
-%% and Amazon S3) and to Amazon VPC, bypassing Internet service providers in
-%% your network path. A connection provides access to all AWS Regions except
-%% the China (Beijing) and (China) Ningxia Regions. AWS resources in the
-%% China Regions can only be accessed through locations associated with those
-%% Regions.
+%% One end of the cable is connected to your router, the other to an Direct
+%% Connect router. With this connection in place, you can create virtual
+%% interfaces directly to the Amazon Web Services Cloud (for example, to
+%% Amazon EC2 and Amazon S3) and to Amazon VPC, bypassing Internet service
+%% providers in your network path. A connection provides access to all Amazon
+%% Web Services Regions except the China (Beijing) and (China) Ningxia
+%% Regions. Amazon Web Services resources in the China Regions can only be
+%% accessed through locations associated with those Regions.
 -module(aws_direct_connect).
 
 -export([accept_direct_connect_gateway_association_proposal/2,
@@ -30,10 +30,14 @@
          associate_connection_with_lag/3,
          associate_hosted_connection/2,
          associate_hosted_connection/3,
+         associate_mac_sec_key/2,
+         associate_mac_sec_key/3,
          associate_virtual_interface/2,
          associate_virtual_interface/3,
          confirm_connection/2,
          confirm_connection/3,
+         confirm_customer_agreement/2,
+         confirm_customer_agreement/3,
          confirm_private_virtual_interface/2,
          confirm_private_virtual_interface/3,
          confirm_public_virtual_interface/2,
@@ -82,6 +86,8 @@
          describe_connections/3,
          describe_connections_on_interconnect/2,
          describe_connections_on_interconnect/3,
+         describe_customer_metadata/2,
+         describe_customer_metadata/3,
          describe_direct_connect_gateway_association_proposals/2,
          describe_direct_connect_gateway_association_proposals/3,
          describe_direct_connect_gateway_associations/2,
@@ -102,6 +108,8 @@
          describe_loa/3,
          describe_locations/2,
          describe_locations/3,
+         describe_router_configuration/2,
+         describe_router_configuration/3,
          describe_tags/2,
          describe_tags/3,
          describe_virtual_gateways/2,
@@ -110,6 +118,8 @@
          describe_virtual_interfaces/3,
          disassociate_connection_from_lag/2,
          disassociate_connection_from_lag/3,
+         disassociate_mac_sec_key/2,
+         disassociate_mac_sec_key/3,
          list_virtual_interface_test_history/2,
          list_virtual_interface_test_history/3,
          start_bgp_failover_test/2,
@@ -120,6 +130,10 @@
          tag_resource/3,
          untag_resource/2,
          untag_resource/3,
+         update_connection/2,
+         update_connection/3,
+         update_direct_connect_gateway/2,
+         update_direct_connect_gateway/3,
          update_direct_connect_gateway_association/2,
          update_direct_connect_gateway_association/3,
          update_lag/2,
@@ -151,7 +165,7 @@ accept_direct_connect_gateway_association_proposal(Client, Input, Options)
 %% Allocates a VLAN number and a specified amount of bandwidth for use by a
 %% hosted connection on the specified interconnect.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 allocate_connection_on_interconnect(Client, Input)
   when is_map(Client), is_map(Input) ->
     allocate_connection_on_interconnect(Client, Input, []).
@@ -164,11 +178,11 @@ allocate_connection_on_interconnect(Client, Input, Options)
 %%
 %% Allocates a VLAN number and a specified amount of capacity (bandwidth) for
 %% use by a hosted connection on the specified interconnect or LAG of
-%% interconnects. AWS polices the hosted connection for the specified
-%% capacity and the AWS Direct Connect Partner must also police the hosted
-%% connection for the specified capacity.
+%% interconnects. Amazon Web Services polices the hosted connection for the
+%% specified capacity and the Direct Connect Partner must also police the
+%% hosted connection for the specified capacity.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 allocate_hosted_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
     allocate_hosted_connection(Client, Input, []).
@@ -177,7 +191,7 @@ allocate_hosted_connection(Client, Input, Options)
     request(Client, <<"AllocateHostedConnection">>, Input, Options).
 
 %% @doc Provisions a private virtual interface to be owned by the specified
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% Virtual interfaces created using this action must be confirmed by the
 %% owner using `ConfirmPrivateVirtualInterface'. Until then, the virtual
@@ -191,10 +205,11 @@ allocate_private_virtual_interface(Client, Input, Options)
     request(Client, <<"AllocatePrivateVirtualInterface">>, Input, Options).
 
 %% @doc Provisions a public virtual interface to be owned by the specified
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% The owner of a connection calls this function to provision a public
-%% virtual interface to be owned by the specified AWS account.
+%% virtual interface to be owned by the specified Amazon Web Services
+%% account.
 %%
 %% Virtual interfaces created using this function must be confirmed by the
 %% owner using `ConfirmPublicVirtualInterface'. Until this step has been
@@ -212,13 +227,13 @@ allocate_public_virtual_interface(Client, Input, Options)
     request(Client, <<"AllocatePublicVirtualInterface">>, Input, Options).
 
 %% @doc Provisions a transit virtual interface to be owned by the specified
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% Use this type of interface to connect a transit gateway to your Direct
 %% Connect gateway.
 %%
 %% The owner of a connection provisions a transit virtual interface to be
-%% owned by the specified AWS account.
+%% owned by the specified Amazon Web Services account.
 %%
 %% After you create a transit virtual interface, it must be confirmed by the
 %% owner using `ConfirmTransitVirtualInterface'. Until this step has been
@@ -235,12 +250,12 @@ allocate_transit_virtual_interface(Client, Input, Options)
 %% (LAG).
 %%
 %% The connection is interrupted and re-established as a member of the LAG
-%% (connectivity to AWS is interrupted). The connection must be hosted on the
-%% same AWS Direct Connect endpoint as the LAG, and its bandwidth must match
-%% the bandwidth for the LAG. You can re-associate a connection that's
-%% currently associated with a different LAG; however, if removing the
-%% connection would cause the original LAG to fall below its setting for
-%% minimum number of operational connections, the request fails.
+%% (connectivity to Amazon Web Services is interrupted). The connection must
+%% be hosted on the same Direct Connect endpoint as the LAG, and its
+%% bandwidth must match the bandwidth for the LAG. You can re-associate a
+%% connection that's currently associated with a different LAG; however, if
+%% removing the connection would cause the original LAG to fall below its
+%% setting for minimum number of operational connections, the request fails.
 %%
 %% Any virtual interfaces that are directly associated with the connection
 %% are automatically re-associated with the LAG. If the connection was
@@ -263,10 +278,10 @@ associate_connection_with_lag(Client, Input, Options)
 %%
 %% If the target interconnect or LAG has an existing hosted connection with a
 %% conflicting VLAN number or IP address, the operation fails. This action
-%% temporarily interrupts the hosted connection's connectivity to AWS as it
-%% is being migrated.
+%% temporarily interrupts the hosted connection's connectivity to Amazon Web
+%% Services as it is being migrated.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 associate_hosted_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
     associate_hosted_connection(Client, Input, []).
@@ -274,13 +289,29 @@ associate_hosted_connection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssociateHostedConnection">>, Input, Options).
 
+%% @doc Associates a MAC Security (MACsec) Connection Key Name (CKN)/
+%% Connectivity Association Key (CAK) pair with an Direct Connect dedicated
+%% connection.
+%%
+%% You must supply either the `secretARN,' or the CKN/CAK (`ckn' and `cak')
+%% pair in the request.
+%%
+%% For information about MAC Security (MACsec) key considerations, see MACsec
+%% pre-shared CKN/CAK key considerations in the Direct Connect User Guide.
+associate_mac_sec_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    associate_mac_sec_key(Client, Input, []).
+associate_mac_sec_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AssociateMacSecKey">>, Input, Options).
+
 %% @doc Associates a virtual interface with a specified link aggregation
 %% group (LAG) or connection.
 %%
-%% Connectivity to AWS is temporarily interrupted as the virtual interface is
-%% being migrated. If the target connection or LAG has an associated virtual
-%% interface with a conflicting VLAN number or a conflicting IP address, the
-%% operation fails.
+%% Connectivity to Amazon Web Services is temporarily interrupted as the
+%% virtual interface is being migrated. If the target connection or LAG has
+%% an associated virtual interface with a conflicting VLAN number or a
+%% conflicting IP address, the operation fails.
 %%
 %% Virtual interfaces associated with a hosted connection cannot be
 %% associated with a LAG; hosted connections must be migrated along with
@@ -310,8 +341,17 @@ confirm_connection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ConfirmConnection">>, Input, Options).
 
+%% @doc The confirmation of the terms of agreement when creating the
+%% connection/link aggregation group (LAG).
+confirm_customer_agreement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    confirm_customer_agreement(Client, Input, []).
+confirm_customer_agreement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ConfirmCustomerAgreement">>, Input, Options).
+
 %% @doc Accepts ownership of a private virtual interface created by another
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% After the virtual interface owner makes this call, the virtual interface
 %% is created and attached to the specified virtual private gateway or Direct
@@ -324,7 +364,7 @@ confirm_private_virtual_interface(Client, Input, Options)
     request(Client, <<"ConfirmPrivateVirtualInterface">>, Input, Options).
 
 %% @doc Accepts ownership of a public virtual interface created by another
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% After the virtual interface owner makes this call, the specified virtual
 %% interface is created and made available to handle traffic.
@@ -336,7 +376,7 @@ confirm_public_virtual_interface(Client, Input, Options)
     request(Client, <<"ConfirmPublicVirtualInterface">>, Input, Options).
 
 %% @doc Accepts ownership of a transit virtual interface created by another
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% After the owner of the transit virtual interface makes this call, the
 %% specified transit virtual interface is created and made available to
@@ -351,8 +391,8 @@ confirm_transit_virtual_interface(Client, Input, Options)
 %% @doc Creates a BGP peer on the specified virtual interface.
 %%
 %% You must create a BGP peer for the corresponding address family
-%% (IPv4/IPv6) in order to access AWS resources that also use that address
-%% family.
+%% (IPv4/IPv6) in order to access Amazon Web Services resources that also use
+%% that address family.
 %%
 %% If logical redundancy is not supported by the connection, interconnect, or
 %% LAG, the BGP peer cannot be in the same address family as an existing BGP
@@ -371,19 +411,19 @@ create_bgp_peer(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateBGPPeer">>, Input, Options).
 
-%% @doc Creates a connection between a customer network and a specific AWS
-%% Direct Connect location.
+%% @doc Creates a connection between a customer network and a specific Direct
+%% Connect location.
 %%
-%% A connection links your internal network to an AWS Direct Connect location
+%% A connection links your internal network to an Direct Connect location
 %% over a standard Ethernet fiber-optic cable. One end of the cable is
-%% connected to your router, the other to an AWS Direct Connect router.
+%% connected to your router, the other to an Direct Connect router.
 %%
 %% To find the locations for your Region, use `DescribeLocations'.
 %%
 %% You can automatically add the new connection to a link aggregation group
 %% (LAG) by specifying a LAG ID in the request. This ensures that the new
-%% connection is allocated on the same AWS Direct Connect endpoint that hosts
-%% the specified LAG. If there are no available ports on the endpoint, the
+%% connection is allocated on the same Direct Connect endpoint that hosts the
+%% specified LAG. If there are no available ports on the endpoint, the
 %% request fails and no connection is created.
 create_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -396,12 +436,12 @@ create_connection(Client, Input, Options)
 %% that enables you to connect a set of virtual interfaces and virtual
 %% private gateways.
 %%
-%% A Direct Connect gateway is global and visible in any AWS Region after it
-%% is created. The virtual interfaces and virtual private gateways that are
-%% connected through a Direct Connect gateway can be in different AWS
-%% Regions. This enables you to connect to a VPC in any Region, regardless of
-%% the Region in which the virtual interfaces are located, and pass traffic
-%% between them.
+%% A Direct Connect gateway is global and visible in any Amazon Web Services
+%% Region after it is created. The virtual interfaces and virtual private
+%% gateways that are connected through a Direct Connect gateway can be in
+%% different Amazon Web Services Regions. This enables you to connect to a
+%% VPC in any Region, regardless of the Region in which the virtual
+%% interfaces are located, and pass traffic between them.
 create_direct_connect_gateway(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_direct_connect_gateway(Client, Input, []).
@@ -425,7 +465,7 @@ create_direct_connect_gateway_association(Client, Input, Options)
 %% or transit gateway with the specified Direct Connect gateway.
 %%
 %% You can associate a Direct Connect gateway and virtual private gateway or
-%% transit gateway that is owned by any AWS account.
+%% transit gateway that is owned by any Amazon Web Services account.
 create_direct_connect_gateway_association_proposal(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_direct_connect_gateway_association_proposal(Client, Input, []).
@@ -433,30 +473,30 @@ create_direct_connect_gateway_association_proposal(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateDirectConnectGatewayAssociationProposal">>, Input, Options).
 
-%% @doc Creates an interconnect between an AWS Direct Connect Partner's
-%% network and a specific AWS Direct Connect location.
+%% @doc Creates an interconnect between an Direct Connect Partner's network
+%% and a specific Direct Connect location.
 %%
 %% An interconnect is a connection that is capable of hosting other
-%% connections. The AWS Direct Connect partner can use an interconnect to
-%% provide AWS Direct Connect hosted connections to customers through their
-%% own network services. Like a standard connection, an interconnect links
-%% the partner's network to an AWS Direct Connect location over a standard
-%% Ethernet fiber-optic cable. One end is connected to the partner's router,
-%% the other to an AWS Direct Connect router.
+%% connections. The Direct Connect Partner can use an interconnect to provide
+%% Direct Connect hosted connections to customers through their own network
+%% services. Like a standard connection, an interconnect links the partner's
+%% network to an Direct Connect location over a standard Ethernet fiber-optic
+%% cable. One end is connected to the partner's router, the other to an
+%% Direct Connect router.
 %%
 %% You can automatically add the new interconnect to a link aggregation group
 %% (LAG) by specifying a LAG ID in the request. This ensures that the new
-%% interconnect is allocated on the same AWS Direct Connect endpoint that
-%% hosts the specified LAG. If there are no available ports on the endpoint,
-%% the request fails and no interconnect is created.
+%% interconnect is allocated on the same Direct Connect endpoint that hosts
+%% the specified LAG. If there are no available ports on the endpoint, the
+%% request fails and no interconnect is created.
 %%
-%% For each end customer, the AWS Direct Connect Partner provisions a
-%% connection on their interconnect by calling `AllocateHostedConnection'.
-%% The end customer can then connect to AWS resources by creating a virtual
-%% interface on their connection, using the VLAN assigned to them by the AWS
-%% Direct Connect Partner.
+%% For each end customer, the Direct Connect Partner provisions a connection
+%% on their interconnect by calling `AllocateHostedConnection'. The end
+%% customer can then connect to Amazon Web Services resources by creating a
+%% virtual interface on their connection, using the VLAN assigned to them by
+%% the Direct Connect Partner.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 create_interconnect(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_interconnect(Client, Input, []).
@@ -466,32 +506,32 @@ create_interconnect(Client, Input, Options)
 
 %% @doc Creates a link aggregation group (LAG) with the specified number of
 %% bundled physical dedicated connections between the customer network and a
-%% specific AWS Direct Connect location.
+%% specific Direct Connect location.
 %%
 %% A LAG is a logical interface that uses the Link Aggregation Control
 %% Protocol (LACP) to aggregate multiple interfaces, enabling you to treat
 %% them as a single interface.
 %%
 %% All connections in a LAG must use the same bandwidth (either 1Gbps or
-%% 10Gbps) and must terminate at the same AWS Direct Connect endpoint.
+%% 10Gbps) and must terminate at the same Direct Connect endpoint.
 %%
 %% You can have up to 10 dedicated connections per LAG. Regardless of this
-%% limit, if you request more connections for the LAG than AWS Direct Connect
-%% can allocate on a single endpoint, no LAG is created.
+%% limit, if you request more connections for the LAG than Direct Connect can
+%% allocate on a single endpoint, no LAG is created.
 %%
 %% You can specify an existing physical dedicated connection or interconnect
 %% to include in the LAG (which counts towards the total number of
 %% connections). Doing so interrupts the current physical dedicated
 %% connection, and re-establishes them as a member of the LAG. The LAG will
-%% be created on the same AWS Direct Connect endpoint to which the dedicated
+%% be created on the same Direct Connect endpoint to which the dedicated
 %% connection terminates. Any virtual interfaces associated with the
 %% dedicated connection are automatically disassociated and re-associated
 %% with the LAG. The connection ID does not change.
 %%
-%% If the AWS account used to create a LAG is a registered AWS Direct Connect
-%% Partner, the LAG is automatically enabled to host sub-connections. For a
-%% LAG owned by a partner, any associated virtual interfaces cannot be
-%% directly configured.
+%% If the Amazon Web Services account used to create a LAG is a registered
+%% Direct Connect Partner, the LAG is automatically enabled to host
+%% sub-connections. For a LAG owned by a partner, any associated virtual
+%% interfaces cannot be directly configured.
 create_lag(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_lag(Client, Input, []).
@@ -501,13 +541,13 @@ create_lag(Client, Input, Options)
 
 %% @doc Creates a private virtual interface.
 %%
-%% A virtual interface is the VLAN that transports AWS Direct Connect
-%% traffic. A private virtual interface can be connected to either a Direct
-%% Connect gateway or a Virtual Private Gateway (VGW). Connecting the private
-%% virtual interface to a Direct Connect gateway enables the possibility for
-%% connecting to multiple VPCs, including VPCs in different AWS Regions.
-%% Connecting the private virtual interface to a VGW only provides access to
-%% a single VPC within the same Region.
+%% A virtual interface is the VLAN that transports Direct Connect traffic. A
+%% private virtual interface can be connected to either a Direct Connect
+%% gateway or a Virtual Private Gateway (VGW). Connecting the private virtual
+%% interface to a Direct Connect gateway enables the possibility for
+%% connecting to multiple VPCs, including VPCs in different Amazon Web
+%% Services Regions. Connecting the private virtual interface to a VGW only
+%% provides access to a single VPC within the same Region.
 %%
 %% Setting the MTU of a virtual interface to 9001 (jumbo frames) can cause an
 %% update to the underlying physical connection if it wasn't updated to
@@ -525,9 +565,9 @@ create_private_virtual_interface(Client, Input, Options)
 
 %% @doc Creates a public virtual interface.
 %%
-%% A virtual interface is the VLAN that transports AWS Direct Connect
-%% traffic. A public virtual interface supports sending traffic to public
-%% services of AWS such as Amazon S3.
+%% A virtual interface is the VLAN that transports Direct Connect traffic. A
+%% public virtual interface supports sending traffic to public services of
+%% Amazon Web Services such as Amazon S3.
 %%
 %% When creating an IPv6 public virtual interface (`addressFamily' is
 %% `ipv6'), leave the `customer' and `amazon' address fields blank to use
@@ -579,10 +619,10 @@ delete_bgp_peer(Client, Input, Options)
 
 %% @doc Deletes the specified connection.
 %%
-%% Deleting a connection only stops the AWS Direct Connect port hour and data
+%% Deleting a connection only stops the Direct Connect port hour and data
 %% transfer charges. If you are partnering with any third parties to connect
-%% with the AWS Direct Connect location, you must cancel your service with
-%% them separately.
+%% with the Direct Connect location, you must cancel your service with them
+%% separately.
 delete_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_connection(Client, Input, []).
@@ -627,7 +667,7 @@ delete_direct_connect_gateway_association_proposal(Client, Input, Options)
 
 %% @doc Deletes the specified interconnect.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 delete_interconnect(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_interconnect(Client, Input, []).
@@ -662,9 +702,9 @@ delete_virtual_interface(Client, Input, Options)
 %%
 %% The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is
 %% a document that your APN partner or service provider uses when
-%% establishing your cross connect to AWS at the colocation facility. For
-%% more information, see Requesting Cross Connects at AWS Direct Connect
-%% Locations in the AWS Direct Connect User Guide.
+%% establishing your cross connect to Amazon Web Services at the colocation
+%% facility. For more information, see Requesting Cross Connects at Direct
+%% Connect Locations in the Direct Connect User Guide.
 describe_connection_loa(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_connection_loa(Client, Input, []).
@@ -687,13 +727,23 @@ describe_connections(Client, Input, Options)
 %% Lists the connections that have been provisioned on the specified
 %% interconnect.
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 describe_connections_on_interconnect(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_connections_on_interconnect(Client, Input, []).
 describe_connections_on_interconnect(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeConnectionsOnInterconnect">>, Input, Options).
+
+%% @doc Get and view a list of customer agreements, along with their signed
+%% status and whether the customer is an NNIPartner, NNIPartnerV2, or a
+%% nonPartner.
+describe_customer_metadata(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_customer_metadata(Client, Input, []).
+describe_customer_metadata(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeCustomerMetadata">>, Input, Options).
 
 %% @doc Describes one or more association proposals for connection between a
 %% virtual private gateway or transit gateway and a Direct Connect gateway.
@@ -771,7 +821,7 @@ describe_direct_connect_gateways(Client, Input, Options)
 %% @doc Lists the hosted connections that have been provisioned on the
 %% specified interconnect or link aggregation group (LAG).
 %%
-%% Intended for use by AWS Direct Connect Partners only.
+%% Intended for use by Direct Connect Partners only.
 describe_hosted_connections(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_hosted_connections(Client, Input, []).
@@ -786,9 +836,10 @@ describe_hosted_connections(Client, Input, Options)
 %% Gets the LOA-CFA for the specified interconnect.
 %%
 %% The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is
-%% a document that is used when establishing your cross connect to AWS at the
-%% colocation facility. For more information, see Requesting Cross Connects
-%% at AWS Direct Connect Locations in the AWS Direct Connect User Guide.
+%% a document that is used when establishing your cross connect to Amazon Web
+%% Services at the colocation facility. For more information, see Requesting
+%% Cross Connects at Direct Connect Locations in the Direct Connect User
+%% Guide.
 describe_interconnect_loa(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_interconnect_loa(Client, Input, []).
@@ -796,8 +847,8 @@ describe_interconnect_loa(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeInterconnectLoa">>, Input, Options).
 
-%% @doc Lists the interconnects owned by the AWS account or only the
-%% specified interconnect.
+%% @doc Lists the interconnects owned by the Amazon Web Services account or
+%% only the specified interconnect.
 describe_interconnects(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_interconnects(Client, Input, []).
@@ -818,9 +869,10 @@ describe_lags(Client, Input, Options)
 %% group (LAG).
 %%
 %% The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is
-%% a document that is used when establishing your cross connect to AWS at the
-%% colocation facility. For more information, see Requesting Cross Connects
-%% at AWS Direct Connect Locations in the AWS Direct Connect User Guide.
+%% a document that is used when establishing your cross connect to Amazon Web
+%% Services at the colocation facility. For more information, see Requesting
+%% Cross Connects at Direct Connect Locations in the Direct Connect User
+%% Guide.
 describe_loa(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_loa(Client, Input, []).
@@ -828,7 +880,8 @@ describe_loa(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeLoa">>, Input, Options).
 
-%% @doc Lists the AWS Direct Connect locations in the current AWS Region.
+%% @doc Lists the Direct Connect locations in the current Amazon Web Services
+%% Region.
 %%
 %% These are the locations that can be selected when calling
 %% `CreateConnection' or `CreateInterconnect'.
@@ -839,7 +892,15 @@ describe_locations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeLocations">>, Input, Options).
 
-%% @doc Describes the tags associated with the specified AWS Direct Connect
+%% @doc Details about the router.
+describe_router_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_router_configuration(Client, Input, []).
+describe_router_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeRouterConfiguration">>, Input, Options).
+
+%% @doc Describes the tags associated with the specified Direct Connect
 %% resources.
 describe_tags(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -848,9 +909,10 @@ describe_tags(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeTags">>, Input, Options).
 
-%% @doc Lists the virtual private gateways owned by the AWS account.
+%% @doc Lists the virtual private gateways owned by the Amazon Web Services
+%% account.
 %%
-%% You can create one or more AWS Direct Connect private virtual interfaces
+%% You can create one or more Direct Connect private virtual interfaces
 %% linked to a virtual private gateway.
 describe_virtual_gateways(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -859,7 +921,7 @@ describe_virtual_gateways(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeVirtualGateways">>, Input, Options).
 
-%% @doc Displays all virtual interfaces for an AWS account.
+%% @doc Displays all virtual interfaces for an Amazon Web Services account.
 %%
 %% Virtual interfaces deleted fewer than 15 minutes before you make the
 %% request are also returned. If you specify a connection ID, only the
@@ -867,7 +929,7 @@ describe_virtual_gateways(Client, Input, Options)
 %% specify a virtual interface ID, then only a single virtual interface is
 %% returned.
 %%
-%% A virtual interface (VLAN) transmits the traffic between the AWS Direct
+%% A virtual interface (VLAN) transmits the traffic between the Direct
 %% Connect location and the customer network.
 describe_virtual_interfaces(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -882,7 +944,7 @@ describe_virtual_interfaces(Client, Input, Options)
 %% connection (the connection is not deleted; to delete the connection, use
 %% the `DeleteConnection' request). If the LAG has associated virtual
 %% interfaces or hosted connections, they remain associated with the LAG. A
-%% disassociated connection owned by an AWS Direct Connect Partner is
+%% disassociated connection owned by an Direct Connect Partner is
 %% automatically converted to an interconnect.
 %%
 %% If disassociating the connection would cause the LAG to fall below its
@@ -896,6 +958,15 @@ disassociate_connection_from_lag(Client, Input)
 disassociate_connection_from_lag(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisassociateConnectionFromLag">>, Input, Options).
+
+%% @doc Removes the association between a MAC Security (MACsec) security key
+%% and an Direct Connect dedicated connection.
+disassociate_mac_sec_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    disassociate_mac_sec_key(Client, Input, []).
+disassociate_mac_sec_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DisassociateMacSecKey">>, Input, Options).
 
 %% @doc Lists the virtual interface failover test history.
 list_virtual_interface_test_history(Client, Input)
@@ -934,7 +1005,7 @@ stop_bgp_failover_test(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StopBgpFailoverTest">>, Input, Options).
 
-%% @doc Adds the specified tags to the specified AWS Direct Connect resource.
+%% @doc Adds the specified tags to the specified Direct Connect resource.
 %%
 %% Each resource can have a maximum of 50 tags.
 %%
@@ -948,14 +1019,37 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Removes one or more tags from the specified AWS Direct Connect
-%% resource.
+%% @doc Removes one or more tags from the specified Direct Connect resource.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
 untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates the Direct Connect dedicated connection configuration.
+%%
+%% You can update the following parameters for a connection:
+%%
+%% <ul> <li> The connection name
+%%
+%% </li> <li> The connection's MAC Security (MACsec) encryption mode.
+%%
+%% </li> </ul>
+update_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_connection(Client, Input, []).
+update_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateConnection">>, Input, Options).
+
+%% @doc Updates the name of a current Direct Connect gateway.
+update_direct_connect_gateway(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_direct_connect_gateway(Client, Input, []).
+update_direct_connect_gateway(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateDirectConnectGateway">>, Input, Options).
 
 %% @doc Updates the specified attributes of the Direct Connect gateway
 %% association.
@@ -970,19 +1064,23 @@ update_direct_connect_gateway_association(Client, Input, Options)
 
 %% @doc Updates the attributes of the specified link aggregation group (LAG).
 %%
-%% You can update the following attributes:
+%% You can update the following LAG attributes:
 %%
 %% <ul> <li> The name of the LAG.
 %%
 %% </li> <li> The value for the minimum number of connections that must be
 %% operational for the LAG itself to be operational.
 %%
-%% </li> </ul> When you create a LAG, the default value for the minimum
-%% number of operational connections is zero (0). If you update this value
-%% and the number of operational connections falls below the specified value,
-%% the LAG automatically goes down to avoid over-utilization of the remaining
-%% connections. Adjust this value with care, as it could force the LAG down
-%% if it is set higher than the current number of operational connections.
+%% </li> <li> The LAG's MACsec encryption mode.
+%%
+%% Amazon Web Services assigns this value to each connection which is part of
+%% the LAG.
+%%
+%% </li> <li> The tags
+%%
+%% </li> </ul> If you adjust the threshold value for the minimum number of
+%% operational connections, ensure that the new value does not cause the LAG
+%% to fall below the threshold and become non-operational.
 update_lag(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_lag(Client, Input, []).

--- a/src/aws_directory.erl
+++ b/src/aws_directory.erl
@@ -1,23 +1,25 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Directory Service
+%% @doc Directory Service
 %%
-%% AWS Directory Service is a web service that makes it easy for you to setup
-%% and run directories in the AWS cloud, or connect your AWS resources with
-%% an existing on-premises Microsoft Active Directory.
+%% Directory Service is a web service that makes it easy for you to setup and
+%% run directories in the Amazon Web Services cloud, or connect your Amazon
+%% Web Services resources with an existing self-managed Microsoft Active
+%% Directory.
 %%
-%% This guide provides detailed information about AWS Directory Service
-%% operations, data types, parameters, and errors. For information about AWS
-%% Directory Services features, see AWS Directory Service and the AWS
-%% Directory Service Administration Guide.
+%% This guide provides detailed information about Directory Service
+%% operations, data types, parameters, and errors. For information about
+%% Directory Services features, see Directory Service and the Directory
+%% Service Administration Guide.
 %%
-%% AWS provides SDKs that consist of libraries and sample code for various
-%% programming languages and platforms (Java, Ruby, .Net, iOS, Android,
-%% etc.). The SDKs provide a convenient way to create programmatic access to
-%% AWS Directory Service and other AWS services. For more information about
-%% the AWS SDKs, including how to download and install them, see Tools for
-%% Amazon Web Services.
+%% Amazon Web Services provides SDKs that consist of libraries and sample
+%% code for various programming languages and platforms (Java, Ruby, .Net,
+%% iOS, Android, etc.). The SDKs provide a convenient way to create
+%% programmatic access to Directory Service and other Amazon Web Services
+%% services. For more information about the Amazon Web Services SDKs,
+%% including how to download and install them, see Tools for Amazon Web
+%% Services.
 -module(aws_directory).
 
 -export([accept_shared_directory/2,
@@ -64,6 +66,8 @@
          deregister_event_topic/3,
          describe_certificate/2,
          describe_certificate/3,
+         describe_client_authentication_settings/2,
+         describe_client_authentication_settings/3,
          describe_conditional_forwarders/2,
          describe_conditional_forwarders/3,
          describe_directories/2,
@@ -160,19 +164,18 @@ accept_shared_directory(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AcceptSharedDirectory">>, Input, Options).
 
-%% @doc If the DNS server for your on-premises domain uses a publicly
+%% @doc If the DNS server for your self-managed domain uses a publicly
 %% addressable IP address, you must add a CIDR address block to correctly
 %% route traffic to and from your Microsoft AD on Amazon Web Services.
 %%
 %% AddIpRoutes adds this address block. You can also use AddIpRoutes to
 %% facilitate routing traffic that uses public IP ranges from your Microsoft
-%% AD on AWS to a peer VPC.
+%% AD on Amazon Web Services to a peer VPC.
 %%
 %% Before you call AddIpRoutes, ensure that all of the required permissions
 %% have been explicitly granted through a policy. For details about what
-%% permissions are required to run the AddIpRoutes operation, see AWS
-%% Directory Service API Permissions: Actions, Resources, and Conditions
-%% Reference.
+%% permissions are required to run the AddIpRoutes operation, see Directory
+%% Service API Permissions: Actions, Resources, and Conditions Reference.
 add_ip_routes(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_ip_routes(Client, Input, []).
@@ -213,13 +216,13 @@ cancel_schema_extension(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CancelSchemaExtension">>, Input, Options).
 
-%% @doc Creates an AD Connector to connect to an on-premises directory.
+%% @doc Creates an AD Connector to connect to a self-managed directory.
 %%
 %% Before you call `ConnectDirectory', ensure that all of the required
 %% permissions have been explicitly granted through a policy. For details
 %% about what permissions are required to run the `ConnectDirectory'
-%% operation, see AWS Directory Service API Permissions: Actions, Resources,
-%% and Conditions Reference.
+%% operation, see Directory Service API Permissions: Actions, Resources, and
+%% Conditions Reference.
 connect_directory(Client, Input)
   when is_map(Client), is_map(Input) ->
     connect_directory(Client, Input, []).
@@ -251,7 +254,8 @@ create_computer(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateComputer">>, Input, Options).
 
-%% @doc Creates a conditional forwarder associated with your AWS directory.
+%% @doc Creates a conditional forwarder associated with your Amazon Web
+%% Services directory.
 %%
 %% Conditional forwarders are required in order to set up a trust
 %% relationship with another domain. The conditional forwarder points to the
@@ -265,14 +269,14 @@ create_conditional_forwarder(Client, Input, Options)
 
 %% @doc Creates a Simple AD directory.
 %%
-%% For more information, see Simple Active Directory in the AWS Directory
-%% Service Admin Guide.
+%% For more information, see Simple Active Directory in the Directory Service
+%% Admin Guide.
 %%
 %% Before you call `CreateDirectory', ensure that all of the required
 %% permissions have been explicitly granted through a policy. For details
 %% about what permissions are required to run the `CreateDirectory'
-%% operation, see AWS Directory Service API Permissions: Actions, Resources,
-%% and Conditions Reference.
+%% operation, see Directory Service API Permissions: Actions, Resources, and
+%% Conditions Reference.
 create_directory(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_directory(Client, Input, []).
@@ -282,7 +286,7 @@ create_directory(Client, Input, Options)
 
 %% @doc Creates a subscription to forward real-time Directory Service domain
 %% controller security logs to the specified Amazon CloudWatch log group in
-%% your AWS account.
+%% your Amazon Web Services account.
 create_log_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_log_subscription(Client, Input, []).
@@ -290,16 +294,16 @@ create_log_subscription(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateLogSubscription">>, Input, Options).
 
-%% @doc Creates a Microsoft AD directory in the AWS Cloud.
+%% @doc Creates a Microsoft AD directory in the Amazon Web Services Cloud.
 %%
-%% For more information, see AWS Managed Microsoft AD in the AWS Directory
-%% Service Admin Guide.
+%% For more information, see Managed Microsoft AD in the Directory Service
+%% Admin Guide.
 %%
 %% Before you call CreateMicrosoftAD, ensure that all of the required
 %% permissions have been explicitly granted through a policy. For details
 %% about what permissions are required to run the CreateMicrosoftAD
-%% operation, see AWS Directory Service API Permissions: Actions, Resources,
-%% and Conditions Reference.
+%% operation, see Directory Service API Permissions: Actions, Resources, and
+%% Conditions Reference.
 create_microsoft_ad(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_microsoft_ad(Client, Input, []).
@@ -308,7 +312,7 @@ create_microsoft_ad(Client, Input, Options)
     request(Client, <<"CreateMicrosoftAD">>, Input, Options).
 
 %% @doc Creates a snapshot of a Simple AD or Microsoft AD directory in the
-%% AWS cloud.
+%% Amazon Web Services cloud.
 %%
 %% You cannot take snapshots of AD Connector directories.
 create_snapshot(Client, Input)
@@ -318,17 +322,18 @@ create_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateSnapshot">>, Input, Options).
 
-%% @doc AWS Directory Service for Microsoft Active Directory allows you to
+%% @doc Directory Service for Microsoft Active Directory allows you to
 %% configure trust relationships.
 %%
-%% For example, you can establish a trust between your AWS Managed Microsoft
-%% AD directory, and your existing on-premises Microsoft Active Directory.
-%% This would allow you to provide users and groups access to resources in
-%% either domain, with a single set of credentials.
+%% For example, you can establish a trust between your Managed Microsoft AD
+%% directory, and your existing self-managed Microsoft Active Directory. This
+%% would allow you to provide users and groups access to resources in either
+%% domain, with a single set of credentials.
 %%
-%% This action initiates the creation of the AWS side of a trust relationship
-%% between an AWS Managed Microsoft AD directory and an external domain. You
-%% can create either a forest trust or an external trust.
+%% This action initiates the creation of the Amazon Web Services side of a
+%% trust relationship between an Managed Microsoft AD directory and an
+%% external domain. You can create either a forest trust or an external
+%% trust.
 create_trust(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_trust(Client, Input, []).
@@ -336,8 +341,8 @@ create_trust(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateTrust">>, Input, Options).
 
-%% @doc Deletes a conditional forwarder that has been set up for your AWS
-%% directory.
+%% @doc Deletes a conditional forwarder that has been set up for your Amazon
+%% Web Services directory.
 delete_conditional_forwarder(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_conditional_forwarder(Client, Input, []).
@@ -345,13 +350,13 @@ delete_conditional_forwarder(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteConditionalForwarder">>, Input, Options).
 
-%% @doc Deletes an AWS Directory Service directory.
+%% @doc Deletes an Directory Service directory.
 %%
 %% Before you call `DeleteDirectory', ensure that all of the required
 %% permissions have been explicitly granted through a policy. For details
 %% about what permissions are required to run the `DeleteDirectory'
-%% operation, see AWS Directory Service API Permissions: Actions, Resources,
-%% and Conditions Reference.
+%% operation, see Directory Service API Permissions: Actions, Resources, and
+%% Conditions Reference.
 delete_directory(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_directory(Client, Input, []).
@@ -375,8 +380,8 @@ delete_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteSnapshot">>, Input, Options).
 
-%% @doc Deletes an existing trust relationship between your AWS Managed
-%% Microsoft AD directory and an external domain.
+%% @doc Deletes an existing trust relationship between your Managed Microsoft
+%% AD directory and an external domain.
 delete_trust(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_trust(Client, Input, []).
@@ -393,8 +398,8 @@ deregister_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeregisterCertificate">>, Input, Options).
 
-%% @doc Removes the specified directory as a publisher to the specified SNS
-%% topic.
+%% @doc Removes the specified directory as a publisher to the specified
+%% Amazon SNS topic.
 deregister_event_topic(Client, Input)
   when is_map(Client), is_map(Input) ->
     deregister_event_topic(Client, Input, []).
@@ -410,6 +415,19 @@ describe_certificate(Client, Input)
 describe_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeCertificate">>, Input, Options).
+
+%% @doc Retrieves information about the type of client authentication for the
+%% specified directory, if the type is specified.
+%%
+%% If no type is specified, information about all client authentication types
+%% that are supported for the specified directory is retrieved. Currently,
+%% only `SmartCard' is supported.
+describe_client_authentication_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_client_authentication_settings(Client, Input, []).
+describe_client_authentication_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeClientAuthenticationSettings">>, Input, Options).
 
 %% @doc Obtains information about the conditional forwarders for this
 %% account.
@@ -453,8 +471,8 @@ describe_domain_controllers(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDomainControllers">>, Input, Options).
 
-%% @doc Obtains information about which SNS topics receive status messages
-%% from the specified directory.
+%% @doc Obtains information about which Amazon SNS topics receive status
+%% messages from the specified directory.
 %%
 %% If no input parameters are provided, such as DirectoryId or TopicName,
 %% this request describes all of the associations in the account.
@@ -583,9 +601,9 @@ enable_radius(Client, Input, Options)
 
 %% @doc Enables single sign-on for a directory.
 %%
-%% Single sign-on allows users in your directory to access certain AWS
-%% services from a computer joined to the directory without having to enter
-%% their credentials separately.
+%% Single sign-on allows users in your directory to access certain Amazon Web
+%% Services services from a computer joined to the directory without having
+%% to enter their credentials separately.
 enable_sso(Client, Input)
   when is_map(Client), is_map(Input) ->
     enable_sso(Client, Input, []).
@@ -626,7 +644,8 @@ list_ip_routes(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListIpRoutes">>, Input, Options).
 
-%% @doc Lists the active log subscriptions for the AWS account.
+%% @doc Lists the active log subscriptions for the Amazon Web Services
+%% account.
 list_log_subscriptions(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_log_subscriptions(Client, Input, []).
@@ -659,12 +678,12 @@ register_certificate(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RegisterCertificate">>, Input, Options).
 
-%% @doc Associates a directory with an SNS topic.
+%% @doc Associates a directory with an Amazon SNS topic.
 %%
-%% This establishes the directory as a publisher to the specified SNS topic.
-%% You can then receive email or text (SMS) messages when the status of your
-%% directory changes. You get notified if your directory goes from an Active
-%% status to an Impaired or Inoperable status. You also receive a
+%% This establishes the directory as a publisher to the specified Amazon SNS
+%% topic. You can then receive email or text (SMS) messages when the status
+%% of your directory changes. You get notified if your directory goes from an
+%% Active status to an Impaired or Inoperable status. You also receive a
 %% notification when the directory returns to an Active status.
 register_event_topic(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -710,7 +729,7 @@ remove_tags_from_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveTagsFromResource">>, Input, Options).
 
-%% @doc Resets the password for any user in your AWS Managed Microsoft AD or
+%% @doc Resets the password for any user in your Managed Microsoft AD or
 %% Simple AD directory.
 %%
 %% You can reset the password for any user in your directory with the
@@ -720,12 +739,12 @@ remove_tags_from_resource(Client, Input, Options)
 %% is a member of either the Domain Admins or Enterprise Admins group except
 %% for the administrator user.
 %%
-%% </li> <li> For AWS Managed Microsoft AD, you can only reset the password
-%% for a user that is in an OU based off of the NetBIOS name that you typed
-%% when you created your directory. For example, you cannot reset the
-%% password for a user in the AWS Reserved OU. For more information about the
-%% OU structure for an AWS Managed Microsoft AD directory, see What Gets
-%% Created in the AWS Directory Service Administration Guide.
+%% </li> <li> For Managed Microsoft AD, you can only reset the password for a
+%% user that is in an OU based off of the NetBIOS name that you typed when
+%% you created your directory. For example, you cannot reset the password for
+%% a user in the Amazon Web Services Reserved OU. For more information about
+%% the OU structure for an Managed Microsoft AD directory, see What Gets
+%% Created in the Directory Service Administration Guide.
 %%
 %% </li> </ul>
 reset_user_password(Client, Input)
@@ -752,23 +771,25 @@ restore_from_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RestoreFromSnapshot">>, Input, Options).
 
-%% @doc Shares a specified directory (`DirectoryId') in your AWS account
-%% (directory owner) with another AWS account (directory consumer).
+%% @doc Shares a specified directory (`DirectoryId') in your Amazon Web
+%% Services account (directory owner) with another Amazon Web Services
+%% account (directory consumer).
 %%
-%% With this operation you can use your directory from any AWS account and
-%% from any Amazon VPC within an AWS Region.
+%% With this operation you can use your directory from any Amazon Web
+%% Services account and from any Amazon VPC within an Amazon Web Services
+%% Region.
 %%
-%% When you share your AWS Managed Microsoft AD directory, AWS Directory
-%% Service creates a shared directory in the directory consumer account. This
-%% shared directory contains the metadata to provide access to the directory
-%% within the directory owner account. The shared directory is visible in all
-%% VPCs in the directory consumer account.
+%% When you share your Managed Microsoft AD directory, Directory Service
+%% creates a shared directory in the directory consumer account. This shared
+%% directory contains the metadata to provide access to the directory within
+%% the directory owner account. The shared directory is visible in all VPCs
+%% in the directory consumer account.
 %%
 %% The `ShareMethod' parameter determines whether the specified directory can
-%% be shared between AWS accounts inside the same AWS organization
-%% (`ORGANIZATIONS'). It also determines whether you can share the directory
-%% with any other AWS account either inside or outside of the organization
-%% (`HANDSHAKE').
+%% be shared between Amazon Web Services accounts inside the same Amazon Web
+%% Services organization (`ORGANIZATIONS'). It also determines whether you
+%% can share the directory with any other Amazon Web Services account either
+%% inside or outside of the organization (`HANDSHAKE').
 %%
 %% The `ShareNotes' parameter is only used when `HANDSHAKE' is called, which
 %% sends a directory sharing request to the directory consumer.
@@ -796,8 +817,8 @@ unshare_directory(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UnshareDirectory">>, Input, Options).
 
-%% @doc Updates a conditional forwarder that has been set up for your AWS
-%% directory.
+%% @doc Updates a conditional forwarder that has been set up for your Amazon
+%% Web Services directory.
 update_conditional_forwarder(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_conditional_forwarder(Client, Input, []).
@@ -828,8 +849,8 @@ update_radius(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateRadius">>, Input, Options).
 
-%% @doc Updates the trust that has been set up between your AWS Managed
-%% Microsoft AD directory and an on-premises Active Directory.
+%% @doc Updates the trust that has been set up between your Managed Microsoft
+%% AD directory and an self-managed Active Directory.
 update_trust(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_trust(Client, Input, []).
@@ -837,11 +858,11 @@ update_trust(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateTrust">>, Input, Options).
 
-%% @doc AWS Directory Service for Microsoft Active Directory allows you to
+%% @doc Directory Service for Microsoft Active Directory allows you to
 %% configure and verify trust relationships.
 %%
-%% This action verifies a trust relationship between your AWS Managed
-%% Microsoft AD directory and an external domain.
+%% This action verifies a trust relationship between your Managed Microsoft
+%% AD directory and an external domain.
 verify_trust(Client, Input)
   when is_map(Client), is_map(Input) ->
     verify_trust(Client, Input, []).

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -4,7 +4,7 @@
 %% @doc Amazon Data Lifecycle Manager
 %%
 %% With Amazon Data Lifecycle Manager, you can manage the lifecycle of your
-%% AWS resources.
+%% Amazon Web Services resources.
 %%
 %% You create lifecycle policies, which are used to automate operations on
 %% the specified resources.
@@ -40,8 +40,8 @@
 %% API
 %%====================================================================
 
-%% @doc Creates a policy to manage the lifecycle of the specified AWS
-%% resources.
+%% @doc Creates a policy to manage the lifecycle of the specified Amazon Web
+%% Services resources.
 %%
 %% You can create up to 100 lifecycle policies.
 create_lifecycle_policy(Client, Input) ->
@@ -275,6 +275,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_docdb.erl
+++ b/src/aws_docdb.erl
@@ -4,7 +4,9 @@
 %% @doc Amazon DocumentDB API documentation
 -module(aws_docdb).
 
--export([add_tags_to_resource/2,
+-export([add_source_identifier_to_subscription/2,
+         add_source_identifier_to_subscription/3,
+         add_tags_to_resource/2,
          add_tags_to_resource/3,
          apply_pending_maintenance_action/2,
          apply_pending_maintenance_action/3,
@@ -22,6 +24,10 @@
          create_db_instance/3,
          create_db_subnet_group/2,
          create_db_subnet_group/3,
+         create_event_subscription/2,
+         create_event_subscription/3,
+         create_global_cluster/2,
+         create_global_cluster/3,
          delete_db_cluster/2,
          delete_db_cluster/3,
          delete_db_cluster_parameter_group/2,
@@ -32,6 +38,10 @@
          delete_db_instance/3,
          delete_db_subnet_group/2,
          delete_db_subnet_group/3,
+         delete_event_subscription/2,
+         delete_event_subscription/3,
+         delete_global_cluster/2,
+         delete_global_cluster/3,
          describe_certificates/2,
          describe_certificates/3,
          describe_db_cluster_parameter_groups/2,
@@ -54,8 +64,12 @@
          describe_engine_default_cluster_parameters/3,
          describe_event_categories/2,
          describe_event_categories/3,
+         describe_event_subscriptions/2,
+         describe_event_subscriptions/3,
          describe_events/2,
          describe_events/3,
+         describe_global_clusters/2,
+         describe_global_clusters/3,
          describe_orderable_db_instance_options/2,
          describe_orderable_db_instance_options/3,
          describe_pending_maintenance_actions/2,
@@ -74,8 +88,16 @@
          modify_db_instance/3,
          modify_db_subnet_group/2,
          modify_db_subnet_group/3,
+         modify_event_subscription/2,
+         modify_event_subscription/3,
+         modify_global_cluster/2,
+         modify_global_cluster/3,
          reboot_db_instance/2,
          reboot_db_instance/3,
+         remove_from_global_cluster/2,
+         remove_from_global_cluster/3,
+         remove_source_identifier_from_subscription/2,
+         remove_source_identifier_from_subscription/3,
          remove_tags_from_resource/2,
          remove_tags_from_resource/3,
          reset_db_cluster_parameter_group/2,
@@ -95,11 +117,20 @@
 %% API
 %%====================================================================
 
+%% @doc Adds a source identifier to an existing event notification
+%% subscription.
+add_source_identifier_to_subscription(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    add_source_identifier_to_subscription(Client, Input, []).
+add_source_identifier_to_subscription(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AddSourceIdentifierToSubscription">>, Input, Options).
+
 %% @doc Adds metadata tags to an Amazon DocumentDB resource.
 %%
 %% You can use these tags with cost allocation reporting to track costs that
-%% are associated with Amazon DocumentDB resources. or in a `Condition'
-%% statement in an AWS Identity and Access Management (IAM) policy for Amazon
+%% are associated with Amazon DocumentDB resources or in a `Condition'
+%% statement in an Identity and Access Management (IAM) policy for Amazon
 %% DocumentDB.
 add_tags_to_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -130,7 +161,7 @@ copy_db_cluster_parameter_group(Client, Input, Options)
 %% To copy a cluster snapshot from a shared manual cluster snapshot,
 %% `SourceDBClusterSnapshotIdentifier' must be the Amazon Resource Name (ARN)
 %% of the shared cluster snapshot. You can only copy a shared DB cluster
-%% snapshot, whether encrypted or not, in the same AWS Region.
+%% snapshot, whether encrypted or not, in the same Region.
 %%
 %% To cancel the copy operation after it is in progress, delete the target
 %% cluster snapshot identified by `TargetDBClusterSnapshotIdentifier' while
@@ -192,13 +223,66 @@ create_db_instance(Client, Input, Options)
 %% @doc Creates a new subnet group.
 %%
 %% subnet groups must contain at least one subnet in at least two
-%% Availability Zones in the AWS Region.
+%% Availability Zones in the Region.
 create_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_db_subnet_group(Client, Input, []).
 create_db_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateDBSubnetGroup">>, Input, Options).
+
+%% @doc Creates an Amazon DocumentDB event notification subscription.
+%%
+%% This action requires a topic Amazon Resource Name (ARN) created by using
+%% the Amazon DocumentDB console, the Amazon SNS console, or the Amazon SNS
+%% API. To obtain an ARN with Amazon SNS, you must create a topic in Amazon
+%% SNS and subscribe to the topic. The ARN is displayed in the Amazon SNS
+%% console.
+%%
+%% You can specify the type of source (`SourceType') that you want to be
+%% notified of. You can also provide a list of Amazon DocumentDB sources
+%% (`SourceIds') that trigger the events, and you can provide a list of event
+%% categories (`EventCategories') for events that you want to be notified of.
+%% For example, you can specify `SourceType = db-instance', `SourceIds =
+%% mydbinstance1, mydbinstance2' and `EventCategories = Availability,
+%% Backup'.
+%%
+%% If you specify both the `SourceType' and `SourceIds' (such as `SourceType
+%% = db-instance' and `SourceIdentifier = myDBInstance1'), you are notified
+%% of all the `db-instance' events for the specified source. If you specify a
+%% `SourceType' but do not specify a `SourceIdentifier', you receive notice
+%% of the events for that source type for all your Amazon DocumentDB sources.
+%% If you do not specify either the `SourceType' or the `SourceIdentifier',
+%% you are notified of events generated from all Amazon DocumentDB sources
+%% belonging to your customer account.
+create_event_subscription(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_event_subscription(Client, Input, []).
+create_event_subscription(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEventSubscription">>, Input, Options).
+
+%% @doc Creates an Amazon DocumentDB global cluster that can span multiple
+%% multiple Regions.
+%%
+%% The global cluster contains one primary cluster with read-write
+%% capability, and up-to give read-only secondary clusters. Global clusters
+%% uses storage-based fast replication across regions with latencies less
+%% than one second, using dedicated infrastructure with no impact to your
+%% workload’s performance.
+%%
+%% You can create a global cluster that is initially empty, and then add a
+%% primary and a secondary to it. Or you can specify an existing cluster
+%% during the create operation, and this cluster becomes the primary of the
+%% global cluster.
+%%
+%% This action only applies to Amazon DocumentDB clusters.
+create_global_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_global_cluster(Client, Input, []).
+create_global_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateGlobalCluster">>, Input, Options).
 
 %% @doc Deletes a previously provisioned cluster.
 %%
@@ -254,8 +338,29 @@ delete_db_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteDBSubnetGroup">>, Input, Options).
 
+%% @doc Deletes an Amazon DocumentDB event notification subscription.
+delete_event_subscription(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_event_subscription(Client, Input, []).
+delete_event_subscription(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEventSubscription">>, Input, Options).
+
+%% @doc Deletes a global cluster.
+%%
+%% The primary and secondary clusters must already be detached or deleted
+%% before attempting to delete a global cluster.
+%%
+%% This action only applies to Amazon DocumentDB clusters.
+delete_global_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_global_cluster(Client, Input, []).
+delete_global_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteGlobalCluster">>, Input, Options).
+
 %% @doc Returns a list of certificate authority (CA) certificates provided by
-%% Amazon DocumentDB for this AWS account.
+%% Amazon DocumentDB for this account.
 describe_certificates(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_certificates(Client, Input, []).
@@ -286,12 +391,12 @@ describe_db_cluster_parameters(Client, Input, Options)
 %% @doc Returns a list of cluster snapshot attribute names and values for a
 %% manual DB cluster snapshot.
 %%
-%% When you share snapshots with other AWS accounts,
+%% When you share snapshots with other accounts,
 %% `DescribeDBClusterSnapshotAttributes' returns the `restore' attribute and
-%% a list of IDs for the AWS accounts that are authorized to copy or restore
-%% the manual cluster snapshot. If `all' is included in the list of values
-%% for the `restore' attribute, then the manual cluster snapshot is public
-%% and can be copied or restored by all AWS accounts.
+%% a list of IDs for the accounts that are authorized to copy or restore the
+%% manual cluster snapshot. If `all' is included in the list of values for
+%% the `restore' attribute, then the manual cluster snapshot is public and
+%% can be copied or restored by all accounts.
 describe_db_cluster_snapshot_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_db_cluster_snapshot_attributes(Client, Input, []).
@@ -370,6 +475,21 @@ describe_event_categories(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEventCategories">>, Input, Options).
 
+%% @doc Lists all the subscription descriptions for a customer account.
+%%
+%% The description for a subscription includes `SubscriptionName',
+%% `SNSTopicARN', `CustomerID', `SourceType', `SourceID', `CreationTime', and
+%% `Status'.
+%%
+%% If you specify a `SubscriptionName', lists the description for that
+%% subscription.
+describe_event_subscriptions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_event_subscriptions(Client, Input, []).
+describe_event_subscriptions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEventSubscriptions">>, Input, Options).
+
 %% @doc Returns events related to instances, security groups, snapshots, and
 %% DB parameter groups for the past 14 days.
 %%
@@ -382,6 +502,18 @@ describe_events(Client, Input)
 describe_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEvents">>, Input, Options).
+
+%% @doc Returns information about Amazon DocumentDB global clusters.
+%%
+%% This API supports pagination.
+%%
+%% This action only applies to Amazon DocumentDB clusters.
+describe_global_clusters(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_global_clusters(Client, Input, []).
+describe_global_clusters(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeGlobalClusters">>, Input, Options).
 
 %% @doc Returns a list of orderable instance options for the specified
 %% engine.
@@ -462,19 +594,18 @@ modify_db_cluster_parameter_group(Client, Input, Options)
     request(Client, <<"ModifyDBClusterParameterGroup">>, Input, Options).
 
 %% @doc Adds an attribute and values to, or removes an attribute and values
-%% from, a manual DB cluster snapshot.
+%% from, a manual cluster snapshot.
 %%
-%% To share a manual cluster snapshot with other AWS accounts, specify
-%% `restore' as the `AttributeName', and use the `ValuesToAdd' parameter to
-%% add a list of IDs of the AWS accounts that are authorized to restore the
-%% manual cluster snapshot. Use the value `all' to make the manual cluster
-%% snapshot public, which means that it can be copied or restored by all AWS
-%% accounts. Do not add the `all' value for any manual DB cluster snapshots
-%% that contain private information that you don't want available to all AWS
-%% accounts. If a manual cluster snapshot is encrypted, it can be shared, but
-%% only by specifying a list of authorized AWS account IDs for the
-%% `ValuesToAdd' parameter. You can't use `all' as a value for that parameter
-%% in this case.
+%% To share a manual cluster snapshot with other accounts, specify `restore'
+%% as the `AttributeName', and use the `ValuesToAdd' parameter to add a list
+%% of IDs of the accounts that are authorized to restore the manual cluster
+%% snapshot. Use the value `all' to make the manual cluster snapshot public,
+%% which means that it can be copied or restored by all accounts. Do not add
+%% the `all' value for any manual cluster snapshots that contain private
+%% information that you don't want available to all accounts. If a manual
+%% cluster snapshot is encrypted, it can be shared, but only by specifying a
+%% list of authorized account IDs for the `ValuesToAdd' parameter. You can't
+%% use `all' as a value for that parameter in this case.
 modify_db_cluster_snapshot_attribute(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_cluster_snapshot_attribute(Client, Input, []).
@@ -496,13 +627,36 @@ modify_db_instance(Client, Input, Options)
 %% @doc Modifies an existing subnet group.
 %%
 %% subnet groups must contain at least one subnet in at least two
-%% Availability Zones in the AWS Region.
+%% Availability Zones in the Region.
 modify_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_subnet_group(Client, Input, []).
 modify_db_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyDBSubnetGroup">>, Input, Options).
+
+%% @doc Modifies an existing Amazon DocumentDB event notification
+%% subscription.
+modify_event_subscription(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_event_subscription(Client, Input, []).
+modify_event_subscription(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyEventSubscription">>, Input, Options).
+
+%% @doc Modify a setting for an Amazon DocumentDB global cluster.
+%%
+%% You can change one or more configuration parameters (for example: deletion
+%% protection), or the global cluster identifier by specifying these
+%% parameters and the new values in the request.
+%%
+%% This action only applies to Amazon DocumentDB clusters.
+modify_global_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_global_cluster(Client, Input, []).
+modify_global_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyGlobalCluster">>, Input, Options).
 
 %% @doc You might need to reboot your instance, usually for maintenance
 %% reasons.
@@ -520,6 +674,30 @@ reboot_db_instance(Client, Input)
 reboot_db_instance(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RebootDBInstance">>, Input, Options).
+
+%% @doc Detaches an Amazon DocumentDB secondary cluster from a global
+%% cluster.
+%%
+%% The cluster becomes a standalone cluster with read-write capability
+%% instead of being read-only and receiving data from a primary in a
+%% different region.
+%%
+%% This action only applies to Amazon DocumentDB clusters.
+remove_from_global_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    remove_from_global_cluster(Client, Input, []).
+remove_from_global_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RemoveFromGlobalCluster">>, Input, Options).
+
+%% @doc Removes a source identifier from an existing Amazon DocumentDB event
+%% notification subscription.
+remove_source_identifier_from_subscription(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    remove_source_identifier_from_subscription(Client, Input, []).
+remove_source_identifier_from_subscription(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RemoveSourceIdentifierFromSubscription">>, Input, Options).
 
 %% @doc Removes metadata tags from an Amazon DocumentDB resource.
 remove_tags_from_resource(Client, Input)

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -2,32 +2,33 @@
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
 %% @doc You can use the Amazon Elastic Block Store (Amazon EBS) direct APIs
-%% to create EBS snapshots, write data directly to your snapshots, read data
-%% on your snapshots, and identify the differences or changes between two
-%% snapshots.
+%% to create Amazon EBS snapshots, write data directly to your snapshots,
+%% read data on your snapshots, and identify the differences or changes
+%% between two snapshots.
 %%
 %% If you’re an independent software vendor (ISV) who offers backup services
 %% for Amazon EBS, the EBS direct APIs make it more efficient and
-%% cost-effective to track incremental changes on your EBS volumes through
-%% snapshots. This can be done without having to create new volumes from
-%% snapshots, and then use Amazon Elastic Compute Cloud (Amazon EC2)
+%% cost-effective to track incremental changes on your Amazon EBS volumes
+%% through snapshots. This can be done without having to create new volumes
+%% from snapshots, and then use Amazon Elastic Compute Cloud (Amazon EC2)
 %% instances to compare the differences.
 %%
 %% You can create incremental snapshots directly from data on-premises into
-%% EBS volumes and the cloud to use for quick disaster recovery. With the
-%% ability to write and read snapshots, you can write your on-premises data
-%% to an EBS snapshot during a disaster. Then after recovery, you can restore
-%% it back to AWS or on-premises from the snapshot. You no longer need to
-%% build and maintain complex mechanisms to copy data to and from Amazon EBS.
+%% volumes and the cloud to use for quick disaster recovery. With the ability
+%% to write and read snapshots, you can write your on-premises data to an
+%% snapshot during a disaster. Then after recovery, you can restore it back
+%% to Amazon Web Services or on-premises from the snapshot. You no longer
+%% need to build and maintain complex mechanisms to copy data to and from
+%% Amazon EBS.
 %%
 %% This API reference provides detailed information about the actions, data
 %% types, parameters, and errors of the EBS direct APIs. For more information
 %% about the elements that make up the EBS direct APIs, and examples of how
-%% to use them effectively, see Accessing the Contents of an EBS Snapshot in
-%% the Amazon Elastic Compute Cloud User Guide. For more information about
-%% the supported AWS Regions, endpoints, and service quotas for the EBS
-%% direct APIs, see Amazon Elastic Block Store Endpoints and Quotas in the
-%% AWS General Reference.
+%% to use them effectively, see Accessing the Contents of an Amazon EBS
+%% Snapshot in the Amazon Elastic Compute Cloud User Guide. For more
+%% information about the supported Amazon Web Services Regions, endpoints,
+%% and service quotas for the EBS direct APIs, see Amazon Elastic Block Store
+%% Endpoints and Quotas in the Amazon Web Services General Reference.
 -module(aws_ebs).
 
 -export([complete_snapshot/3,
@@ -196,7 +197,7 @@ list_snapshot_blocks(Client, SnapshotId, QueryMap, HeadersMap, Options0)
 %% If the specified block contains data, the existing data is overwritten.
 %% The target snapshot must be in the `pending' state.
 %%
-%% Data written to a snapshot must be aligned with 512-byte sectors.
+%% Data written to a snapshot must be aligned with 512-KiB sectors.
 put_snapshot_block(Client, BlockIndex, SnapshotId, Input) ->
     put_snapshot_block(Client, BlockIndex, SnapshotId, Input, []).
 put_snapshot_block(Client, BlockIndex, SnapshotId, Input0, Options0) ->
@@ -304,6 +305,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_ec2_instance_connect.erl
+++ b/src/aws_ec2_instance_connect.erl
@@ -1,13 +1,14 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS EC2 Connect Service is a service that enables system
-%% administrators to publish temporary SSH keys to their EC2 instances in
-%% order to establish connections to their instances without leaving a
-%% permanent authentication option.
+%% @doc Amazon EC2 Instance Connect enables system administrators to publish
+%% one-time use SSH public keys to EC2, providing users a simple and secure
+%% way to connect to their instances.
 -module(aws_ec2_instance_connect).
 
--export([send_ssh_public_key/2,
+-export([send_serial_console_ssh_public_key/2,
+         send_serial_console_ssh_public_key/3,
+         send_ssh_public_key/2,
          send_ssh_public_key/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
@@ -16,8 +17,23 @@
 %% API
 %%====================================================================
 
-%% @doc Pushes an SSH public key to a particular OS user on a given EC2
-%% instance for 60 seconds.
+%% @doc Pushes an SSH public key to the specified EC2 instance.
+%%
+%% The key remains for 60 seconds, which gives you 60 seconds to establish a
+%% serial console connection to the instance using SSH. For more information,
+%% see EC2 Serial Console in the Amazon EC2 User Guide.
+send_serial_console_ssh_public_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_serial_console_ssh_public_key(Client, Input, []).
+send_serial_console_ssh_public_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendSerialConsoleSSHPublicKey">>, Input, Options).
+
+%% @doc Pushes an SSH public key to the specified EC2 instance for use by the
+%% specified user.
+%%
+%% The key remains for 60 seconds. For more information, see Connect to your
+%% Linux instance using EC2 Instance Connect in the Amazon EC2 User Guide.
 send_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     send_ssh_public_key(Client, Input, []).

--- a/src/aws_ecr.erl
+++ b/src/aws_ecr.erl
@@ -12,6 +12,10 @@
 %% images. Amazon ECR supports private repositories with resource-based
 %% permissions using IAM so that specific users or Amazon EC2 instances can
 %% access repositories and images.
+%%
+%% Amazon ECR has service endpoints in each supported Region. For more
+%% information, see Amazon ECR endpoints in the Amazon Web Services General
+%% Reference.
 -module(aws_ecr).
 
 -export([batch_check_layer_availability/2,
@@ -32,6 +36,8 @@
          delete_repository/3,
          delete_repository_policy/2,
          delete_repository_policy/3,
+         describe_image_replication_status/2,
+         describe_image_replication_status/3,
          describe_image_scan_findings/2,
          describe_image_scan_findings/3,
          describe_images/2,
@@ -156,7 +162,7 @@ complete_layer_upload(Client, Input, Options)
 
 %% @doc Creates a repository.
 %%
-%% For more information, see Amazon ECR Repositories in the Amazon Elastic
+%% For more information, see Amazon ECR repositories in the Amazon Elastic
 %% Container Registry User Guide.
 create_repository(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -201,6 +207,14 @@ delete_repository_policy(Client, Input)
 delete_repository_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteRepositoryPolicy">>, Input, Options).
+
+%% @doc Returns the replication status for a specified image.
+describe_image_replication_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_image_replication_status(Client, Input, []).
+describe_image_replication_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeImageReplicationStatus">>, Input, Options).
 
 %% @doc Returns the scan findings for the specified image.
 describe_image_scan_findings(Client, Input)
@@ -251,9 +265,9 @@ describe_repositories(Client, Input, Options)
 %%
 %% The `authorizationToken' returned is a base64 encoded string that can be
 %% decoded and used in a `docker login' command to authenticate to a
-%% registry. The AWS CLI offers an `get-login-password' command that
-%% simplifies the login process. For more information, see Registry
-%% Authentication in the Amazon Elastic Container Registry User Guide.
+%% registry. The CLI offers an `get-login-password' command that simplifies
+%% the login process. For more information, see Registry authentication in
+%% the Amazon Elastic Container Registry User Guide.
 get_authorization_token(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_authorization_token(Client, Input, []).
@@ -381,7 +395,7 @@ put_image_scanning_configuration(Client, Input, Options)
 %% @doc Updates the image tag mutability settings for the specified
 %% repository.
 %%
-%% For more information, see Image Tag Mutability in the Amazon Elastic
+%% For more information, see Image tag mutability in the Amazon Elastic
 %% Container Registry User Guide.
 put_image_tag_mutability(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -392,7 +406,7 @@ put_image_tag_mutability(Client, Input, Options)
 
 %% @doc Creates or updates the lifecycle policy for the specified repository.
 %%
-%% For more information, see Lifecycle Policy Template.
+%% For more information, see Lifecycle policy template.
 put_lifecycle_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_lifecycle_policy(Client, Input, []).
@@ -402,10 +416,10 @@ put_lifecycle_policy(Client, Input, Options)
 
 %% @doc Creates or updates the permissions policy for your registry.
 %%
-%% A registry policy is used to specify permissions for another AWS account
-%% and is used when configuring cross-account replication. For more
-%% information, see Registry permissions in the Amazon Elastic Container
-%% Registry User Guide.
+%% A registry policy is used to specify permissions for another Amazon Web
+%% Services account and is used when configuring cross-account replication.
+%% For more information, see Registry permissions in the Amazon Elastic
+%% Container Registry User Guide.
 put_registry_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_registry_policy(Client, Input, []).
@@ -419,7 +433,7 @@ put_registry_policy(Client, Input, Options)
 %% with the `DescribeRegistry' API action. The first time the
 %% PutReplicationConfiguration API is called, a service-linked IAM role is
 %% created in your account for the replication process. For more information,
-%% see Using Service-Linked Roles for Amazon ECR in the Amazon Elastic
+%% see Using service-linked roles for Amazon ECR in the Amazon Elastic
 %% Container Registry User Guide.
 %%
 %% When configuring cross-account replication, the destination account must
@@ -436,7 +450,7 @@ put_replication_configuration(Client, Input, Options)
 %% @doc Applies a repository policy to the specified repository to control
 %% access permissions.
 %%
-%% For more information, see Amazon ECR Repository Policies in the Amazon
+%% For more information, see Amazon ECR Repository policies in the Amazon
 %% Elastic Container Registry User Guide.
 set_repository_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -447,10 +461,10 @@ set_repository_policy(Client, Input, Options)
 
 %% @doc Starts an image vulnerability scan.
 %%
-%% An image scan can only be started once per day on an individual image.
-%% This limit includes if an image was scanned on initial push. For more
-%% information, see Image Scanning in the Amazon Elastic Container Registry
-%% User Guide.
+%% An image scan can only be started once per 24 hours on an individual
+%% image. This limit includes if an image was scanned on initial push. For
+%% more information, see Image scanning in the Amazon Elastic Container
+%% Registry User Guide.
 start_image_scan(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_image_scan(Client, Input, []).

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -8,14 +8,12 @@
 %% Docker containers on a cluster.
 %%
 %% You can host your cluster on a serverless infrastructure that is managed
-%% by Amazon ECS by launching your services or tasks using the Fargate launch
-%% type. For more control, you can host your tasks on a cluster of Amazon
-%% Elastic Compute Cloud (Amazon EC2) instances that you manage by using the
-%% EC2 launch type. For more information about launch types, see Amazon ECS
-%% Launch Types.
+%% by Amazon ECS by launching your services or tasks on Fargate. For more
+%% control, you can host your tasks on a cluster of Amazon Elastic Compute
+%% Cloud (Amazon EC2) instances that you manage.
 %%
-%% Amazon ECS lets you launch and stop container-based applications with
-%% simple API calls, allows you to get the state of your cluster from a
+%% Amazon ECS makes it easy to launch and stop container-based applications
+%% with simple API calls, allows you to get the state of your cluster from a
 %% centralized service, and gives you access to many familiar Amazon EC2
 %% features.
 %%
@@ -66,6 +64,8 @@
          describe_tasks/3,
          discover_poll_endpoint/2,
          discover_poll_endpoint/3,
+         execute_command/2,
+         execute_command/3,
          list_account_settings/2,
          list_account_settings/3,
          list_attributes/2,
@@ -114,6 +114,8 @@
          untag_resource/3,
          update_capacity_provider/2,
          update_capacity_provider/3,
+         update_cluster/2,
+         update_cluster/3,
          update_cluster_settings/2,
          update_cluster_settings/3,
          update_container_agent/2,
@@ -139,9 +141,9 @@
 %% in capacity provider strategies to facilitate cluster auto scaling.
 %%
 %% Only capacity providers using an Auto Scaling group can be created. Amazon
-%% ECS tasks on AWS Fargate use the `FARGATE' and `FARGATE_SPOT' capacity
+%% ECS tasks on Fargate use the `FARGATE' and `FARGATE_SPOT' capacity
 %% providers which are already created and available to all accounts in
-%% Regions supported by AWS Fargate.
+%% Regions supported by Fargate.
 create_capacity_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_capacity_provider(Client, Input, []).
@@ -157,11 +159,11 @@ create_capacity_provider(Client, Input, Options)
 %%
 %% When you call the `CreateCluster' API operation, Amazon ECS attempts to
 %% create the Amazon ECS service-linked role for your account so that
-%% required resources in other AWS services can be managed on your behalf.
-%% However, if the IAM user that makes the call does not have permissions to
-%% create the service-linked role, it is not created. For more information,
-%% see Using Service-Linked Roles for Amazon ECS in the Amazon Elastic
-%% Container Service Developer Guide.
+%% required resources in other Amazon Web Services services can be managed on
+%% your behalf. However, if the IAM user that makes the call does not have
+%% permissions to create the service-linked role, it is not created. For more
+%% information, see Using Service-Linked Roles for Amazon ECS in the Amazon
+%% Elastic Container Service Developer Guide.
 create_cluster(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_cluster(Client, Input, []).
@@ -463,10 +465,9 @@ describe_clusters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeClusters">>, Input, Options).
 
-%% @doc Describes Amazon Elastic Container Service container instances.
+%% @doc Describes one or more container instances.
 %%
-%% Returns metadata about registered and remaining resources on each
-%% container instance requested.
+%% Returns metadata about each container instance requested.
 describe_container_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_container_instances(Client, Input, []).
@@ -528,6 +529,14 @@ discover_poll_endpoint(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DiscoverPollEndpoint">>, Input, Options).
 
+%% @doc Runs a command remotely on a container within a task.
+execute_command(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    execute_command(Client, Input, []).
+execute_command(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ExecuteCommand">>, Input, Options).
+
 %% @doc Lists the account settings for a specified principal.
 list_account_settings(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -573,7 +582,10 @@ list_container_instances(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListContainerInstances">>, Input, Options).
 
-%% @doc Lists the services that are running in a specified cluster.
+%% @doc Returns a list of services.
+%%
+%% You can filter the results by cluster, launch type, and scheduling
+%% strategy.
 list_services(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_services(Client, Input, []).
@@ -616,11 +628,11 @@ list_task_definitions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListTaskDefinitions">>, Input, Options).
 
-%% @doc Returns a list of tasks for a specified cluster.
+%% @doc Returns a list of tasks.
 %%
-%% You can filter the results by family name, by a particular container
-%% instance, or by the desired status of the task with the `family',
-%% `containerInstance', and `desiredStatus' parameters.
+%% You can filter the results by cluster, task definition family, container
+%% instance, launch type, what IAM principal started the task, or by the
+%% desired status of the task.
 %%
 %% Recently stopped tasks might appear in the returned results. Currently,
 %% stopped tasks appear in the returned results for at least one hour.
@@ -740,10 +752,10 @@ register_container_instance(Client, Input, Options)
 %%
 %% You can specify an IAM role for your task with the `taskRoleArn'
 %% parameter. When you specify an IAM role for a task, its containers can
-%% then use the latest versions of the AWS CLI or SDKs to make API requests
-%% to the AWS services that are specified in the IAM policy associated with
-%% the role. For more information, see IAM Roles for Tasks in the Amazon
-%% Elastic Container Service Developer Guide.
+%% then use the latest versions of the CLI or SDKs to make API requests to
+%% the Amazon Web Services services that are specified in the IAM policy
+%% associated with the role. For more information, see IAM Roles for Tasks in
+%% the Amazon Elastic Container Service Developer Guide.
 %%
 %% You can specify a Docker networking mode for the containers in your task
 %% definition with the `networkMode' parameter. The available network modes
@@ -896,6 +908,14 @@ update_capacity_provider(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateCapacityProvider">>, Input, Options).
 
+%% @doc Updates the cluster.
+update_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_cluster(Client, Input, []).
+update_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateCluster">>, Input, Options).
+
 %% @doc Modifies the settings to use for a cluster.
 update_cluster_settings(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -912,11 +932,17 @@ update_cluster_settings(Client, Input, Options)
 %% differs depending on whether your container instance was launched with the
 %% Amazon ECS-optimized AMI or another operating system.
 %%
-%% `UpdateContainerAgent' requires the Amazon ECS-optimized AMI or Amazon
-%% Linux with the `ecs-init' service installed and running. For help updating
-%% the Amazon ECS container agent on other operating systems, see Manually
-%% Updating the Amazon ECS Container Agent in the Amazon Elastic Container
-%% Service Developer Guide.
+%% The `UpdateContainerAgent' API isn't supported for container instances
+%% using the Amazon ECS-optimized Amazon Linux 2 (arm64) AMI. To update the
+%% container agent, you can update the `ecs-init' package which will update
+%% the agent. For more information, see Updating the Amazon ECS container
+%% agent in the Amazon Elastic Container Service Developer Guide.
+%%
+%% The `UpdateContainerAgent' API requires an Amazon ECS-optimized AMI or
+%% Amazon Linux AMI with the `ecs-init' service installed and running. For
+%% help updating the Amazon ECS container agent on other operating systems,
+%% see Manually updating the Amazon ECS container agent in the Amazon Elastic
+%% Container Service Developer Guide.
 update_container_agent(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_container_agent(Client, Input, []).
@@ -1001,9 +1027,9 @@ update_container_instances_state(Client, Input, Options)
 %% only the desired count, deployment configuration, task placement
 %% constraints and strategies, and health check grace period can be updated
 %% using this API. If the network configuration, platform version, or task
-%% definition need to be updated, a new AWS CodeDeploy deployment should be
-%% created. For more information, see CreateDeployment in the AWS CodeDeploy
-%% API Reference.
+%% definition need to be updated, a new CodeDeploy deployment should be
+%% created. For more information, see CreateDeployment in the CodeDeploy API
+%% Reference.
 %%
 %% For services using an external deployment controller, you can update only
 %% the desired count, task placement constraints and strategies, and health

--- a/src/aws_elastic_inference.erl
+++ b/src/aws_elastic_inference.erl
@@ -202,6 +202,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_elastic_load_balancing_v2.erl
+++ b/src/aws_elastic_load_balancing_v2.erl
@@ -288,7 +288,7 @@ deregister_targets(Client, Input, Options)
     request(Client, <<"DeregisterTargets">>, Input, Options).
 
 %% @doc Describes the current Elastic Load Balancing resource limits for your
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% For more information, see the following:
 %%

--- a/src/aws_elastic_transcoder.erl
+++ b/src/aws_elastic_transcoder.erl
@@ -574,6 +574,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_elasticache.erl
+++ b/src/aws_elasticache.erl
@@ -154,19 +154,23 @@
 %% API
 %%====================================================================
 
-%% @doc Adds up to 50 cost allocation tags to the named resource.
+%% @doc A tag is a key-value pair where the key and value are case-sensitive.
 %%
-%% A cost allocation tag is a key-value pair where the key and value are
-%% case-sensitive. You can use cost allocation tags to categorize and track
-%% your AWS costs.
+%% You can use tags to categorize and track all your ElastiCache resources,
+%% with the exception of global replication group. When you add or remove
+%% tags on replication groups, those actions will be replicated to all nodes
+%% in the replication group. For more information, see Resource-level
+%% permissions.
 %%
-%% When you apply tags to your ElastiCache resources, AWS generates a cost
-%% allocation report as a comma-separated value (CSV) file with your usage
-%% and costs aggregated by your tags. You can apply tags that represent
-%% business categories (such as cost centers, application names, or owners)
-%% to organize your costs across multiple services. For more information, see
-%% Using Cost Allocation Tags in Amazon ElastiCache in the ElastiCache User
-%% Guide.
+%% For example, you can use cost-allocation tags to your ElastiCache
+%% resources, Amazon generates a cost allocation report as a comma-separated
+%% value (CSV) file with your usage and costs aggregated by your tags. You
+%% can apply tags that represent business categories (such as cost centers,
+%% application names, or owners) to organize your costs across multiple
+%% services.
+%%
+%% For more information, see Using Cost Allocation Tags in Amazon ElastiCache
+%% in the ElastiCache User Guide.
 add_tags_to_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_tags_to_resource(Client, Input, []).
@@ -364,7 +368,7 @@ create_cache_subnet_group(Client, Input, Options)
 %% Across Regions Using Global Datastore.
 %%
 %% <ul> <li> The GlobalReplicationGroupIdSuffix is the name of the Global
-%% Datastore.
+%% datastore.
 %%
 %% </li> <li> The PrimaryReplicationGroupId represents the name of the
 %% primary cluster that accepts writes and will replicate updates to the
@@ -382,7 +386,7 @@ create_global_replication_group(Client, Input, Options)
 %% enabled) replication group.
 %%
 %% This API can be used to create a standalone regional replication group or
-%% a secondary replication group associated with a Global Datastore.
+%% a secondary replication group associated with a Global datastore.
 %%
 %% A Redis (cluster mode disabled) replication group is a collection of
 %% clusters, where one of the clusters is a read/write primary and the others
@@ -405,8 +409,8 @@ create_global_replication_group(Client, Input, Options)
 %% heavily used by other clusters. For more information, see Creating a
 %% Subnet Group. For versions below 5.0.6, the limit is 250 per cluster.
 %%
-%% To request a limit increase, see AWS Service Limits and choose the limit
-%% type Nodes per cluster per instance type.
+%% To request a limit increase, see Amazon Service Limits and choose the
+%% limit type Nodes per cluster per instance type.
 %%
 %% When a Redis (cluster mode disabled) replication group has been
 %% successfully created, you can add one or more read replicas to it, up to a
@@ -454,7 +458,7 @@ create_user_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateUserGroup">>, Input, Options).
 
-%% @doc Decreases the number of node groups in a Global Datastore
+%% @doc Decreases the number of node groups in a Global datastore
 decrease_node_groups_in_global_replication_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     decrease_node_groups_in_global_replication_group(Client, Input, []).
@@ -539,18 +543,21 @@ delete_cache_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteCacheSubnetGroup">>, Input, Options).
 
-%% @doc Deleting a Global Datastore is a two-step process:
+%% @doc Deleting a Global datastore is a two-step process:
 %%
 %% <ul> <li> First, you must `DisassociateGlobalReplicationGroup' to remove
-%% the secondary clusters in the Global Datastore.
+%% the secondary clusters in the Global datastore.
 %%
-%% </li> <li> Once the Global Datastore contains only the primary cluster,
-%% you can use DeleteGlobalReplicationGroup API to delete the Global
-%% Datastore while retainining the primary cluster using Retain…= true.
+%% </li> <li> Once the Global datastore contains only the primary cluster,
+%% you can use the `DeleteGlobalReplicationGroup' API to delete the Global
+%% datastore while retainining the primary cluster using
+%% `RetainPrimaryReplicationGroup=true'.
 %%
 %% </li> </ul> Since the Global Datastore has only a primary cluster, you can
 %% delete the Global Datastore while retaining the primary by setting
-%% `RetainPrimaryCluster=true'.
+%% `RetainPrimaryReplicationGroup=true'. The primary cluster is never deleted
+%% when deleting a Global Datastore. It can only be deleted when it no longer
+%% is associated with any Global Datastore.
 %%
 %% When you receive a successful response from this operation, Amazon
 %% ElastiCache immediately begins deleting the selected resources; you cannot
@@ -729,7 +736,7 @@ describe_events(Client, Input, Options)
 %% @doc Returns information about a particular global replication group.
 %%
 %% If no identifier is specified, returns information about all Global
-%% Datastores.
+%% datastores.
 describe_global_replication_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_global_replication_groups(Client, Input, []).
@@ -813,11 +820,11 @@ describe_users(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeUsers">>, Input, Options).
 
-%% @doc Remove a secondary cluster from the Global Datastore using the Global
-%% Datastore name.
+%% @doc Remove a secondary cluster from the Global datastore using the Global
+%% datastore name.
 %%
 %% The secondary cluster will no longer receive updates from the primary
-%% cluster, but will remain as a standalone cluster in that AWS region.
+%% cluster, but will remain as a standalone cluster in that Amazon region.
 disassociate_global_replication_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     disassociate_global_replication_group(Client, Input, []).
@@ -836,7 +843,7 @@ failover_global_replication_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"FailoverGlobalReplicationGroup">>, Input, Options).
 
-%% @doc Increase the number of node groups in the Global Datastore
+%% @doc Increase the number of node groups in the Global datastore
 increase_node_groups_in_global_replication_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     increase_node_groups_in_global_replication_group(Client, Input, []).
@@ -870,17 +877,16 @@ list_allowed_node_type_modifications(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAllowedNodeTypeModifications">>, Input, Options).
 
-%% @doc Lists all cost allocation tags currently on the named resource.
+%% @doc Lists all tags currently on a named resource.
 %%
-%% A `cost allocation tag' is a key-value pair where the key is
-%% case-sensitive and the value is optional. You can use cost allocation tags
-%% to categorize and track your AWS costs.
+%% A tag is a key-value pair where the key and value are case-sensitive. You
+%% can use tags to categorize and track all your ElastiCache resources, with
+%% the exception of global replication group. When you add or remove tags on
+%% replication groups, those actions will be replicated to all nodes in the
+%% replication group. For more information, see Resource-level permissions.
 %%
 %% If the cluster is not in the available state, `ListTagsForResource'
 %% returns an error.
-%%
-%% You can have a maximum of 50 cost allocation tags on an ElastiCache
-%% resource. For more information, see Monitoring Costs with Tags.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -918,7 +924,7 @@ modify_cache_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyCacheSubnetGroup">>, Input, Options).
 
-%% @doc Modifies the settings for a Global Datastore.
+%% @doc Modifies the settings for a Global datastore.
 modify_global_replication_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_global_replication_group(Client, Input, []).
@@ -1018,6 +1024,12 @@ reboot_cache_cluster(Client, Input, Options)
 
 %% @doc Removes the tags identified by the `TagKeys' list from the named
 %% resource.
+%%
+%% A tag is a key-value pair where the key and value are case-sensitive. You
+%% can use tags to categorize and track all your ElastiCache resources, with
+%% the exception of global replication group. When you add or remove tags on
+%% replication groups, those actions will be replicated to all nodes in the
+%% replication group. For more information, see Resource-level permissions.
 remove_tags_from_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     remove_tags_from_resource(Client, Input, []).
@@ -1064,8 +1076,8 @@ start_migration(Client, Input, Options)
 %% == Note the following ==
 %%
 %% <ul> <li> A customer can use this operation to test automatic failover on
-%% up to 5 shards (called node groups in the ElastiCache API and AWS CLI) in
-%% any rolling 24-hour period.
+%% up to 5 shards (called node groups in the ElastiCache API and Amazon CLI)
+%% in any rolling 24-hour period.
 %%
 %% </li> <li> If calling this operation on shards in different clusters
 %% (called replication groups in the API and CLI), the calls can be made
@@ -1076,7 +1088,7 @@ start_migration(Client, Input, Options)
 %% replacement must complete before a subsequent call can be made.
 %%
 %% </li> <li> To determine whether the node replacement is complete you can
-%% check Events using the Amazon ElastiCache console, the AWS CLI, or the
+%% check Events using the Amazon ElastiCache console, the Amazon CLI, or the
 %% ElastiCache API. Look for the following automatic failover related events,
 %% listed here in order of occurrance:
 %%

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -837,7 +837,11 @@ list_domain_names(Client, QueryMap, HeadersMap, Options0)
 
     Headers = [],
 
-    Query_ = [],
+    Query0_ =
+      [
+        {<<"engineType">>, maps:get(<<"engineType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
@@ -1182,6 +1186,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -4,9 +4,10 @@
 %% @doc Amazon EMR is a web service that makes it easier to process large
 %% amounts of data efficiently.
 %%
-%% Amazon EMR uses Hadoop processing combined with several AWS services to do
-%% tasks such as web indexing, data mining, log file analysis, machine
-%% learning, scientific simulation, and data warehouse management.
+%% Amazon EMR uses Hadoop processing combined with several Amazon Web
+%% Services services to do tasks such as web indexing, data mining, log file
+%% analysis, machine learning, scientific simulation, and data warehouse
+%% management.
 -module(aws_emr).
 
 -export([add_instance_fleet/2,
@@ -37,12 +38,16 @@
          describe_job_flows/3,
          describe_notebook_execution/2,
          describe_notebook_execution/3,
+         describe_release_label/2,
+         describe_release_label/3,
          describe_security_configuration/2,
          describe_security_configuration/3,
          describe_step/2,
          describe_step/3,
          describe_studio/2,
          describe_studio/3,
+         get_auto_termination_policy/2,
+         get_auto_termination_policy/3,
          get_block_public_access_configuration/2,
          get_block_public_access_configuration/3,
          get_managed_scaling_policy/2,
@@ -61,6 +66,8 @@
          list_instances/3,
          list_notebook_executions/2,
          list_notebook_executions/3,
+         list_release_labels/2,
+         list_release_labels/3,
          list_security_configurations/2,
          list_security_configurations/3,
          list_steps/2,
@@ -77,12 +84,16 @@
          modify_instance_groups/3,
          put_auto_scaling_policy/2,
          put_auto_scaling_policy/3,
+         put_auto_termination_policy/2,
+         put_auto_termination_policy/3,
          put_block_public_access_configuration/2,
          put_block_public_access_configuration/3,
          put_managed_scaling_policy/2,
          put_managed_scaling_policy/3,
          remove_auto_scaling_policy/2,
          remove_auto_scaling_policy/3,
+         remove_auto_termination_policy/2,
+         remove_auto_termination_policy/3,
          remove_managed_scaling_policy/2,
          remove_managed_scaling_policy/3,
          remove_tags/2,
@@ -161,9 +172,10 @@ add_job_flow_steps(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AddJobFlowSteps">>, Input, Options).
 
-%% @doc Adds tags to an Amazon EMR resource.
+%% @doc Adds tags to an Amazon EMR resource, such as a cluster or an Amazon
+%% EMR Studio.
 %%
-%% Tags make it easier to associate clusters in various ways, such as
+%% Tags make it easier to associate resources in various ways, such as
 %% grouping clusters to track your Amazon EMR resource allocation costs. For
 %% more information, see Tag Clusters.
 add_tags(Client, Input)
@@ -178,8 +190,10 @@ add_tags(Client, Input, Options)
 %% Available only in Amazon EMR versions 4.8.0 and later, excluding version
 %% 5.0.0. A maximum of 256 steps are allowed in each CancelSteps request.
 %% CancelSteps is idempotent but asynchronous; it does not guarantee that a
-%% step will be canceled, even if the request is successfully submitted. You
-%% can only cancel steps that are in a `PENDING' state.
+%% step will be canceled, even if the request is successfully submitted. When
+%% you use Amazon EMR versions 5.28.0 and later, you can cancel steps that
+%% are in a `PENDING' or `RUNNING' state. In earlier versions of Amazon EMR,
+%% you can only cancel steps that are in a `PENDING' state.
 cancel_steps(Client, Input)
   when is_map(Client), is_map(Input) ->
     cancel_steps(Client, Input, []).
@@ -207,6 +221,11 @@ create_studio(Client, Input, Options)
 %% @doc Maps a user or group to the Amazon EMR Studio specified by
 %% `StudioId', and applies a session policy to refine Studio permissions for
 %% that user or group.
+%%
+%% Use `CreateStudioSessionMapping' to assign users to a Studio when you use
+%% Amazon Web Services SSO authentication. For instructions on how to assign
+%% users to a Studio when you use IAM authentication, see Assign a user or
+%% group to your EMR Studio.
 create_studio_session_mapping(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_studio_session_mapping(Client, Input, []).
@@ -283,6 +302,19 @@ describe_notebook_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeNotebookExecution">>, Input, Options).
 
+%% @doc Provides EMR release label details, such as releases available the
+%% region where the API request is run, and the available applications for a
+%% specific EMR release label.
+%%
+%% Can also list EMR release versions that support a specified version of
+%% Spark.
+describe_release_label(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_release_label(Client, Input, []).
+describe_release_label(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeReleaseLabel">>, Input, Options).
+
 %% @doc Provides the details of a security configuration by returning the
 %% configuration JSON.
 describe_security_configuration(Client, Input)
@@ -309,8 +341,16 @@ describe_studio(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeStudio">>, Input, Options).
 
-%% @doc Returns the Amazon EMR block public access configuration for your AWS
-%% account in the current Region.
+%% @doc Returns the auto-termination policy for an Amazon EMR cluster.
+get_auto_termination_policy(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_auto_termination_policy(Client, Input, []).
+get_auto_termination_policy(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetAutoTerminationPolicy">>, Input, Options).
+
+%% @doc Returns the Amazon EMR block public access configuration for your
+%% Amazon Web Services account in the current Region.
 %%
 %% For more information see Configure Block Public Access for Amazon EMR in
 %% the Amazon EMR Management Guide.
@@ -348,12 +388,14 @@ list_bootstrap_actions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListBootstrapActions">>, Input, Options).
 
-%% @doc Provides the status of all clusters visible to this AWS account.
+%% @doc Provides the status of all clusters visible to this Amazon Web
+%% Services account.
 %%
 %% Allows you to filter the list of clusters based on certain criteria; for
 %% example, filtering by cluster creation date and time or by status. This
-%% call returns a maximum of 50 clusters per call, but returns a marker to
-%% track the paging of the cluster list across multiple ListClusters calls.
+%% call returns a maximum of 50 clusters in unsorted order per call, but
+%% returns a marker to track the paging of the cluster list across multiple
+%% ListClusters calls.
 list_clusters(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_clusters(Client, Input, []).
@@ -406,6 +448,15 @@ list_notebook_executions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListNotebookExecutions">>, Input, Options).
 
+%% @doc Retrieves release labels of EMR services in the region where the API
+%% is called.
+list_release_labels(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_release_labels(Client, Input, []).
+list_release_labels(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListReleaseLabels">>, Input, Options).
+
 %% @doc Lists all the security configurations visible to this account,
 %% providing their creation dates and times, and their names.
 %%
@@ -420,9 +471,12 @@ list_security_configurations(Client, Input, Options)
     request(Client, <<"ListSecurityConfigurations">>, Input, Options).
 
 %% @doc Provides a list of steps for the cluster in reverse order unless you
-%% specify `stepIds' with the request of filter by `StepStates'.
+%% specify `stepIds' with the request or filter by `StepStates'.
 %%
-%% You can specify a maximum of 10 `stepIDs'.
+%% You can specify a maximum of 10 `stepIDs'. The CLI automatically paginates
+%% results to return a list greater than 50 steps. To return more than 50
+%% steps using the CLI, specify a `Marker', which is a pagination token that
+%% indicates the next set of steps to retrieve.
 list_steps(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_steps(Client, Input, []).
@@ -439,8 +493,8 @@ list_studio_session_mappings(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListStudioSessionMappings">>, Input, Options).
 
-%% @doc Returns a list of all Amazon EMR Studios associated with the AWS
-%% account.
+%% @doc Returns a list of all Amazon EMR Studios associated with the Amazon
+%% Web Services account.
 %%
 %% The list includes details such as ID, Studio Access URL, and creation time
 %% for each Studio.
@@ -501,8 +555,21 @@ put_auto_scaling_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutAutoScalingPolicy">>, Input, Options).
 
+%% @doc Creates or updates an auto-termination policy for an Amazon EMR
+%% cluster.
+%%
+%% An auto-termination policy defines the amount of idle time in seconds
+%% after which a cluster automatically terminates. For alternative cluster
+%% termination options, see Control cluster termination.
+put_auto_termination_policy(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_auto_termination_policy(Client, Input, []).
+put_auto_termination_policy(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutAutoTerminationPolicy">>, Input, Options).
+
 %% @doc Creates or updates an Amazon EMR block public access configuration
-%% for your AWS account in the current Region.
+%% for your Amazon Web Services account in the current Region.
 %%
 %% For more information see Configure Block Public Access for Amazon EMR in
 %% the Amazon EMR Management Guide.
@@ -536,6 +603,14 @@ remove_auto_scaling_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveAutoScalingPolicy">>, Input, Options).
 
+%% @doc Removes an auto-termination policy from an Amazon EMR cluster.
+remove_auto_termination_policy(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    remove_auto_termination_policy(Client, Input, []).
+remove_auto_termination_policy(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RemoveAutoTerminationPolicy">>, Input, Options).
+
 %% @doc Removes a managed scaling policy from a specified EMR cluster.
 remove_managed_scaling_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -544,9 +619,10 @@ remove_managed_scaling_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveManagedScalingPolicy">>, Input, Options).
 
-%% @doc Removes tags from an Amazon EMR resource.
+%% @doc Removes tags from an Amazon EMR resource, such as a cluster or Amazon
+%% EMR Studio.
 %%
-%% Tags make it easier to associate clusters in various ways, such as
+%% Tags make it easier to associate resources in various ways, such as
 %% grouping clusters to track your Amazon EMR resource allocation costs. For
 %% more information, see Tag Clusters.
 %%
@@ -624,17 +700,19 @@ set_termination_protection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SetTerminationProtection">>, Input, Options).
 
-%% @doc Sets the `Cluster$VisibleToAllUsers' value, which determines whether
-%% the cluster is visible to all IAM users of the AWS account associated with
-%% the cluster.
+%% @doc Sets the `Cluster$VisibleToAllUsers' value for an EMR cluster.
 %%
-%% Only the IAM user who created the cluster or the AWS account root user can
-%% call this action. The default value, `true', indicates that all IAM users
-%% in the AWS account can perform cluster actions if they have the proper IAM
-%% policy permissions. If set to `false', only the IAM user that created the
-%% cluster can perform actions. This action works on running clusters. You
-%% can override the default `true' setting when you create a cluster by using
-%% the `VisibleToAllUsers' parameter with `RunJobFlow'.
+%% When `true', IAM principals in the Amazon Web Services account can perform
+%% EMR cluster actions that their IAM policies allow. When `false', only the
+%% IAM principal that created the cluster and the Amazon Web Services account
+%% root user can perform EMR actions on the cluster, regardless of IAM
+%% permissions policies attached to other IAM principals.
+%%
+%% This action works on running clusters. When you create a cluster, use the
+%% `RunJobFlowInput$VisibleToAllUsers' parameter.
+%%
+%% For more information, see Understanding the EMR Cluster VisibleToAllUsers
+%% Setting in the Amazon EMRManagement Guide.
 set_visible_to_all_users(Client, Input)
   when is_map(Client), is_map(Input) ->
     set_visible_to_all_users(Client, Input, []).

--- a/src/aws_emr_containers.erl
+++ b/src/aws_emr_containers.erl
@@ -543,6 +543,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_eventbridge.erl
+++ b/src/aws_eventbridge.erl
@@ -1,20 +1,20 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Amazon EventBridge helps you to respond to state changes in your AWS
-%% resources.
+%% @doc Amazon EventBridge helps you to respond to state changes in your
+%% Amazon Web Services resources.
 %%
-%% When your resources change state, they automatically send events into an
+%% When your resources change state, they automatically send events to an
 %% event stream. You can create rules that match selected events in the
 %% stream and route them to targets to take action. You can also use rules to
 %% take action on a predetermined schedule. For example, you can configure
 %% rules to:
 %%
-%% <ul> <li> Automatically invoke an AWS Lambda function to update DNS
-%% entries when an event notifies you that Amazon EC2 instance enters the
-%% running state.
+%% <ul> <li> Automatically invoke an Lambda function to update DNS entries
+%% when an event notifies you that Amazon EC2 instance enters the running
+%% state.
 %%
-%% </li> <li> Direct specific API records from AWS CloudTrail to an Amazon
+%% </li> <li> Direct specific API records from CloudTrail to an Amazon
 %% Kinesis data stream for detailed analysis of potential security or
 %% availability risks.
 %%
@@ -201,31 +201,32 @@ create_event_bus(Client, Input, Options)
 
 %% @doc Called by an SaaS partner to create a partner event source.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 %%
-%% Each partner event source can be used by one AWS account to create a
-%% matching partner event bus in that AWS account. A SaaS partner must create
-%% one partner event source for each AWS account that wants to receive those
-%% event types.
+%% Each partner event source can be used by one Amazon Web Services account
+%% to create a matching partner event bus in that Amazon Web Services
+%% account. A SaaS partner must create one partner event source for each
+%% Amazon Web Services account that wants to receive those event types.
 %%
 %% A partner event source creates events based on resources within the SaaS
 %% partner's service or application.
 %%
-%% An AWS account that creates a partner event bus that matches the partner
-%% event source can use that event bus to receive events from the partner,
-%% and then process them using AWS Events rules and targets.
+%% An Amazon Web Services account that creates a partner event bus that
+%% matches the partner event source can use that event bus to receive events
+%% from the partner, and then process them using Amazon Web Services Events
+%% rules and targets.
 %%
 %% Partner event source names follow this format:
 %%
 %% ` partner_name/event_namespace/event_name '
 %%
 %% partner_name is determined during partner registration and identifies the
-%% partner to AWS customers. event_namespace is determined by the partner and
-%% is a way for the partner to categorize their events. event_name is
-%% determined by the partner, and should uniquely identify an
+%% partner to Amazon Web Services customers. event_namespace is determined by
+%% the partner and is a way for the partner to categorize their events.
+%% event_name is determined by the partner, and should uniquely identify an
 %% event-generating resource within the partner system. The combination of
-%% event_namespace and event_name should help AWS customers decide whether to
-%% create an event bus to receive these events.
+%% event_namespace and event_name should help Amazon Web Services customers
+%% decide whether to create an event bus to receive these events.
 create_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_partner_event_source(Client, Input, []).
@@ -242,7 +243,7 @@ create_partner_event_source(Client, Input, Options)
 %% state. If it remains in PENDING state for more than two weeks, it is
 %% deleted.
 %%
-%% To activate a deactivated partner event source, use `ActivateEventSource'.
+%% To activate a deactivated partner event source, use ActivateEventSource.
 deactivate_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     deactivate_event_source(Client, Input, []).
@@ -299,10 +300,10 @@ delete_event_bus(Client, Input, Options)
 %% @doc This operation is used by SaaS partners to delete a partner event
 %% source.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 %%
 %% When you delete an event source, the status of the corresponding partner
-%% event bus in the AWS customer account becomes DELETED.
+%% event bus in the Amazon Web Services customer account becomes DELETED.
 delete_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_partner_event_source(Client, Input, []).
@@ -313,16 +314,20 @@ delete_partner_event_source(Client, Input, Options)
 %% @doc Deletes the specified rule.
 %%
 %% Before you can delete the rule, you must remove all targets, using
-%% `RemoveTargets'.
+%% RemoveTargets.
 %%
 %% When you delete a rule, incoming events might continue to match to the
 %% deleted rule. Allow a short period of time for changes to take effect.
 %%
-%% Managed rules are rules created and managed by another AWS service on your
-%% behalf. These rules are created by those other AWS services to support
-%% functionality in those services. You can delete these rules using the
-%% `Force' option, but you should do so only if you are sure the other
-%% service is not still using that rule.
+%% If you call delete rule multiple times for the same rule, all calls will
+%% succeed. When you call delete rule for a non-existent custom eventbus,
+%% `ResourceNotFoundException' is returned.
+%%
+%% Managed rules are rules created and managed by another Amazon Web Services
+%% service on your behalf. These rules are created by those other Amazon Web
+%% Services services to support functionality in those services. You can
+%% delete these rules using the `Force' option, but you should do so only if
+%% you are sure the other service is not still using that rule.
 delete_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_rule(Client, Input, []).
@@ -356,15 +361,15 @@ describe_connection(Client, Input, Options)
 
 %% @doc Displays details about an event bus in your account.
 %%
-%% This can include the external AWS accounts that are permitted to write
-%% events to your default event bus, and the associated policy. For custom
-%% event buses and partner event buses, it displays the name, ARN, policy,
-%% state, and creation time.
+%% This can include the external Amazon Web Services accounts that are
+%% permitted to write events to your default event bus, and the associated
+%% policy. For custom event buses and partner event buses, it displays the
+%% name, ARN, policy, state, and creation time.
 %%
 %% To enable your account to receive events from other accounts on its
-%% default event bus, use `PutPermission'.
+%% default event bus, use PutPermission.
 %%
-%% For more information about partner event buses, see `CreateEventBus'.
+%% For more information about partner event buses, see CreateEventBus.
 describe_event_bus(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_event_bus(Client, Input, []).
@@ -384,9 +389,9 @@ describe_event_source(Client, Input, Options)
 %% @doc An SaaS partner can use this operation to list details about a
 %% partner event source that they have created.
 %%
-%% AWS customers do not use this operation. Instead, AWS customers can use
-%% `DescribeEventSource' to see details about a partner event source that is
-%% shared with them.
+%% Amazon Web Services customers do not use this operation. Instead, Amazon
+%% Web Services customers can use DescribeEventSource to see details about a
+%% partner event source that is shared with them.
 describe_partner_event_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_partner_event_source(Client, Input, []).
@@ -415,7 +420,7 @@ describe_replay(Client, Input, Options)
 %% @doc Describes the specified rule.
 %%
 %% DescribeRule does not list the targets of a rule. To see the targets
-%% associated with a rule, use `ListTargetsByRule'.
+%% associated with a rule, use ListTargetsByRule.
 describe_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_rule(Client, Input, []).
@@ -489,9 +494,9 @@ list_event_buses(Client, Input, Options)
     request(Client, <<"ListEventBuses">>, Input, Options).
 
 %% @doc You can use this to see all the partner event sources that have been
-%% shared with your AWS account.
+%% shared with your Amazon Web Services account.
 %%
-%% For more information about partner event sources, see `CreateEventBus'.
+%% For more information about partner event sources, see CreateEventBus.
 list_event_sources(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_event_sources(Client, Input, []).
@@ -499,10 +504,11 @@ list_event_sources(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListEventSources">>, Input, Options).
 
-%% @doc An SaaS partner can use this operation to display the AWS account ID
-%% that a particular partner event source name is associated with.
+%% @doc An SaaS partner can use this operation to display the Amazon Web
+%% Services account ID that a particular partner event source name is
+%% associated with.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 list_partner_event_source_accounts(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_partner_event_source_accounts(Client, Input, []).
@@ -513,7 +519,7 @@ list_partner_event_source_accounts(Client, Input, Options)
 %% @doc An SaaS partner can use this operation to list all the partner event
 %% source names that they have created.
 %%
-%% This operation is not used by AWS customers.
+%% This operation is not used by Amazon Web Services customers.
 list_partner_event_sources(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_partner_event_sources(Client, Input, []).
@@ -549,7 +555,7 @@ list_rule_names_by_target(Client, Input, Options)
 %% the rule names.
 %%
 %% ListRules does not list the targets of a rule. To see the targets
-%% associated with a rule, use `ListTargetsByRule'.
+%% associated with a rule, use ListTargetsByRule.
 list_rules(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_rules(Client, Input, []).
@@ -587,7 +593,7 @@ put_events(Client, Input, Options)
 %% @doc This is used by SaaS partners to write events to a customer's partner
 %% event bus.
 %%
-%% AWS customers do not use this operation.
+%% Amazon Web Services customers do not use this operation.
 put_partner_events(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_partner_events(Client, Input, []).
@@ -595,8 +601,9 @@ put_partner_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutPartnerEvents">>, Input, Options).
 
-%% @doc Running `PutPermission' permits the specified AWS account or AWS
-%% organization to put events to the specified event bus.
+%% @doc Running `PutPermission' permits the specified Amazon Web Services
+%% account or Amazon Web Services organization to put events to the specified
+%% event bus.
 %%
 %% Amazon EventBridge (CloudWatch Events) rules in your account are triggered
 %% by these events arriving to an event bus in your account.
@@ -604,20 +611,20 @@ put_partner_events(Client, Input, Options)
 %% For another account to send events to your account, that external account
 %% must have an EventBridge rule with your account's event bus as a target.
 %%
-%% To enable multiple AWS accounts to put events to your event bus, run
-%% `PutPermission' once for each of these accounts. Or, if all the accounts
-%% are members of the same AWS organization, you can run `PutPermission' once
-%% specifying `Principal' as "*" and specifying the AWS organization ID in
-%% `Condition', to grant permissions to all accounts in that organization.
+%% To enable multiple Amazon Web Services accounts to put events to your
+%% event bus, run `PutPermission' once for each of these accounts. Or, if all
+%% the accounts are members of the same Amazon Web Services organization, you
+%% can run `PutPermission' once specifying `Principal' as "*" and specifying
+%% the Amazon Web Services organization ID in `Condition', to grant
+%% permissions to all accounts in that organization.
 %%
 %% If you grant permissions using an organization, then accounts in that
 %% organization must specify a `RoleArn' with proper permissions when they
 %% use `PutTarget' to add your account's event bus as a target. For more
-%% information, see Sending and Receiving Events Between AWS Accounts in the
-%% Amazon EventBridge User Guide.
+%% information, see Sending and Receiving Events Between Amazon Web Services
+%% Accounts in the Amazon EventBridge User Guide.
 %%
-%% The permission policy on the default event bus cannot exceed 10 KB in
-%% size.
+%% The permission policy on the event bus cannot exceed 10 KB in size.
 put_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_permission(Client, Input, []).
@@ -628,14 +635,15 @@ put_permission(Client, Input, Options)
 %% @doc Creates or updates the specified rule.
 %%
 %% Rules are enabled by default, or based on value of the state. You can
-%% disable a rule using `DisableRule'.
+%% disable a rule using DisableRule.
 %%
 %% A single rule watches for events from a single event bus. Events generated
-%% by AWS services go to your account's default event bus. Events generated
-%% by SaaS partner services or applications go to the matching partner event
-%% bus. If you have custom applications or services, you can specify whether
-%% their events go to your default event bus or a custom event bus that you
-%% have created. For more information, see `CreateEventBus'.
+%% by Amazon Web Services services go to your account's default event bus.
+%% Events generated by SaaS partner services or applications go to the
+%% matching partner event bus. If you have custom applications or services,
+%% you can specify whether their events go to your default event bus or a
+%% custom event bus that you have created. For more information, see
+%% CreateEventBus.
 %%
 %% If you are updating an existing rule, the rule is replaced with what you
 %% specify in this `PutRule' command. If you omit arguments in `PutRule', the
@@ -661,12 +669,13 @@ put_permission(Client, Input, Options)
 %%
 %% If you are updating an existing rule, any tags you specify in the
 %% `PutRule' operation are ignored. To update the tags of an existing rule,
-%% use `TagResource' and `UntagResource'.
+%% use TagResource and UntagResource.
 %%
-%% Most services in AWS treat : or / as the same character in Amazon Resource
-%% Names (ARNs). However, EventBridge uses an exact match in event patterns
-%% and rules. Be sure to use the correct ARN characters when creating event
-%% patterns so that they match the ARN syntax in the event you want to match.
+%% Most services in Amazon Web Services treat : or / as the same character in
+%% Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+%% event patterns and rules. Be sure to use the correct ARN characters when
+%% creating event patterns so that they match the ARN syntax in the event you
+%% want to match.
 %%
 %% In EventBridge, it is possible to create rules that lead to infinite
 %% loops, where a rule is fired repeatedly. For example, a rule might detect
@@ -697,46 +706,62 @@ put_rule(Client, Input, Options)
 %%
 %% You can configure the following as targets for Events:
 %%
-%% <ul> <li> EC2 instances
+%% <ul> <li> API destination
 %%
-%% </li> <li> SSM Run Command
+%% </li> <li> Amazon API Gateway REST API endpoints
 %%
-%% </li> <li> SSM Automation
+%% </li> <li> API Gateway
 %%
-%% </li> <li> AWS Lambda functions
+%% </li> <li> Batch job queue
 %%
-%% </li> <li> Data streams in Amazon Kinesis Data Streams
+%% </li> <li> CloudWatch Logs group
 %%
-%% </li> <li> Data delivery streams in Amazon Kinesis Data Firehose
+%% </li> <li> CodeBuild project
+%%
+%% </li> <li> CodePipeline
+%%
+%% </li> <li> Amazon EC2 `CreateSnapshot' API call
+%%
+%% </li> <li> Amazon EC2 `RebootInstances' API call
+%%
+%% </li> <li> Amazon EC2 `StopInstances' API call
+%%
+%% </li> <li> Amazon EC2 `TerminateInstances' API call
 %%
 %% </li> <li> Amazon ECS tasks
 %%
-%% </li> <li> AWS Step Functions state machines
+%% </li> <li> Event bus in a different Amazon Web Services account or Region.
 %%
-%% </li> <li> AWS Batch jobs
+%% You can use an event bus in the US East (N. Virginia) us-east-1, US West
+%% (Oregon) us-west-2, or Europe (Ireland) eu-west-1 Regions as a target for
+%% a rule.
 %%
-%% </li> <li> AWS CodeBuild projects
+%% </li> <li> Firehose delivery stream (Kinesis Data Firehose)
 %%
-%% </li> <li> Pipelines in AWS CodePipeline
+%% </li> <li> Inspector assessment template (Amazon Inspector)
 %%
-%% </li> <li> Amazon Inspector assessment templates
+%% </li> <li> Kinesis stream (Kinesis Data Stream)
 %%
-%% </li> <li> Amazon SNS topics
+%% </li> <li> Lambda function
 %%
-%% </li> <li> Amazon SQS queues, including FIFO queues
+%% </li> <li> Redshift clusters (Data API statement execution)
 %%
-%% </li> <li> The default event bus of another AWS account
+%% </li> <li> Amazon SNS topic
 %%
-%% </li> <li> Amazon API Gateway REST APIs
+%% </li> <li> Amazon SQS queues (includes FIFO queues
 %%
-%% </li> <li> Redshift Clusters to invoke Data API ExecuteStatement on
+%% </li> <li> SSM Automation
 %%
-%% </li> <li> Custom/SaaS HTTPS APIs via EventBridge API Destinations
+%% </li> <li> SSM OpsItem
+%%
+%% </li> <li> SSM Run Command
+%%
+%% </li> <li> Step Functions state machines
 %%
 %% </li> </ul> Creating rules with built-in targets is supported only in the
-%% AWS Management Console. The built-in targets are `EC2 CreateSnapshot API
-%% call', `EC2 RebootInstances API call', `EC2 StopInstances API call', and
-%% `EC2 TerminateInstances API call'.
+%% Amazon Web Services Management Console. The built-in targets are `EC2
+%% CreateSnapshot API call', `EC2 RebootInstances API call', `EC2
+%% StopInstances API call', and `EC2 TerminateInstances API call'.
 %%
 %% For some target types, `PutTargets' provides target-specific parameters.
 %% If the target is a Kinesis data stream, you can optionally specify which
@@ -745,36 +770,36 @@ put_rule(Client, Input, Options)
 %% `RunCommandParameters' field.
 %%
 %% To be able to make API calls against the resources that you own, Amazon
-%% EventBridge (CloudWatch Events) needs the appropriate permissions. For AWS
-%% Lambda and Amazon SNS resources, EventBridge relies on resource-based
-%% policies. For EC2 instances, Kinesis data streams, AWS Step Functions
-%% state machines and API Gateway REST APIs, EventBridge relies on IAM roles
-%% that you specify in the `RoleARN' argument in `PutTargets'. For more
-%% information, see Authentication and Access Control in the Amazon
-%% EventBridge User Guide.
+%% EventBridge needs the appropriate permissions. For Lambda and Amazon SNS
+%% resources, EventBridge relies on resource-based policies. For EC2
+%% instances, Kinesis Data Streams, Step Functions state machines and API
+%% Gateway REST APIs, EventBridge relies on IAM roles that you specify in the
+%% `RoleARN' argument in `PutTargets'. For more information, see
+%% Authentication and Access Control in the Amazon EventBridge User Guide.
 %%
-%% If another AWS account is in the same region and has granted you
-%% permission (using `PutPermission'), you can send events to that account.
-%% Set that account's event bus as a target of the rules in your account. To
-%% send the matched events to the other account, specify that account's event
-%% bus as the `Arn' value when you run `PutTargets'. If your account sends
-%% events to another account, your account is charged for each sent event.
-%% Each event sent to another account is charged as a custom event. The
-%% account receiving the event is not charged. For more information, see
-%% Amazon EventBridge (CloudWatch Events) Pricing.
+%% If another Amazon Web Services account is in the same region and has
+%% granted you permission (using `PutPermission'), you can send events to
+%% that account. Set that account's event bus as a target of the rules in
+%% your account. To send the matched events to the other account, specify
+%% that account's event bus as the `Arn' value when you run `PutTargets'. If
+%% your account sends events to another account, your account is charged for
+%% each sent event. Each event sent to another account is charged as a custom
+%% event. The account receiving the event is not charged. For more
+%% information, see Amazon EventBridge Pricing.
 %%
 %% `Input', `InputPath', and `InputTransformer' are not available with
-%% `PutTarget' if the target is an event bus of a different AWS account.
+%% `PutTarget' if the target is an event bus of a different Amazon Web
+%% Services account.
 %%
 %% If you are setting the event bus of another account as the target, and
 %% that account granted permission to your account through an organization
 %% instead of directly by the account ID, then you must specify a `RoleArn'
 %% with proper permissions in the `Target' structure. For more information,
-%% see Sending and Receiving Events Between AWS Accounts in the Amazon
-%% EventBridge User Guide.
+%% see Sending and Receiving Events Between Amazon Web Services Accounts in
+%% the Amazon EventBridge User Guide.
 %%
 %% For more information about enabling cross-account events, see
-%% `PutPermission'.
+%% PutPermission.
 %%
 %% Input, InputPath, and InputTransformer are mutually exclusive and optional
 %% parameters of a target. When a rule is triggered due to a matched event:
@@ -814,13 +839,12 @@ put_targets(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutTargets">>, Input, Options).
 
-%% @doc Revokes the permission of another AWS account to be able to put
-%% events to the specified event bus.
+%% @doc Revokes the permission of another Amazon Web Services account to be
+%% able to put events to the specified event bus.
 %%
 %% Specify the account to revoke by the `StatementId' value that you
 %% associated with the account when you granted it permission with
-%% `PutPermission'. You can find the `StatementId' by using
-%% `DescribeEventBus'.
+%% `PutPermission'. You can find the `StatementId' by using DescribeEventBus.
 remove_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     remove_permission(Client, Input, []).
@@ -873,8 +897,8 @@ start_replay(Client, Input, Options)
 %% change only resources with certain tag values. In EventBridge, rules and
 %% event buses can be tagged.
 %%
-%% Tags don't have any semantic meaning to AWS and are interpreted strictly
-%% as strings of characters.
+%% Tags don't have any semantic meaning to Amazon Web Services and are
+%% interpreted strictly as strings of characters.
 %%
 %% You can use the `TagResource' action with a resource that already has
 %% tags. If you specify a new tag key, this tag is appended to the list of
@@ -892,10 +916,11 @@ tag_resource(Client, Input, Options)
 
 %% @doc Tests whether the specified event pattern matches the provided event.
 %%
-%% Most services in AWS treat : or / as the same character in Amazon Resource
-%% Names (ARNs). However, EventBridge uses an exact match in event patterns
-%% and rules. Be sure to use the correct ARN characters when creating event
-%% patterns so that they match the ARN syntax in the event you want to match.
+%% Most services in Amazon Web Services treat : or / as the same character in
+%% Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+%% event patterns and rules. Be sure to use the correct ARN characters when
+%% creating event patterns so that they match the ARN syntax in the event you
+%% want to match.
 test_event_pattern(Client, Input)
   when is_map(Client), is_map(Input) ->
     test_event_pattern(Client, Input, []).
@@ -905,7 +930,7 @@ test_event_pattern(Client, Input, Options)
 
 %% @doc Removes one or more tags from the specified EventBridge resource.
 %%
-%% In Amazon EventBridge (CloudWatch Events, rules and event buses can be
+%% In Amazon EventBridge (CloudWatch Events), rules and event buses can be
 %% tagged.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->

--- a/src/aws_finspace.erl
+++ b/src/aws_finspace.erl
@@ -1,0 +1,307 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The FinSpace management service provides the APIs for managing
+%% FinSpace environments.
+-module(aws_finspace).
+
+-export([create_environment/2,
+         create_environment/3,
+         delete_environment/3,
+         delete_environment/4,
+         get_environment/2,
+         get_environment/4,
+         get_environment/5,
+         list_environments/1,
+         list_environments/3,
+         list_environments/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_environment/3,
+         update_environment/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Create a new FinSpace environment.
+create_environment(Client, Input) ->
+    create_environment(Client, Input, []).
+create_environment(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/environment"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete an FinSpace environment.
+delete_environment(Client, EnvironmentId, Input) ->
+    delete_environment(Client, EnvironmentId, Input, []).
+delete_environment(Client, EnvironmentId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/environment/", aws_util:encode_uri(EnvironmentId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns the FinSpace environment object.
+get_environment(Client, EnvironmentId)
+  when is_map(Client) ->
+    get_environment(Client, EnvironmentId, #{}, #{}).
+
+get_environment(Client, EnvironmentId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_environment(Client, EnvironmentId, QueryMap, HeadersMap, []).
+
+get_environment(Client, EnvironmentId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/environment/", aws_util:encode_uri(EnvironmentId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc A list of all of your FinSpace environments.
+list_environments(Client)
+  when is_map(Client) ->
+    list_environments(Client, #{}, #{}).
+
+list_environments(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_environments(Client, QueryMap, HeadersMap, []).
+
+list_environments(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/environment"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc A list of all tags for a resource.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Adds metadata tags to a FinSpace resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes metadata tags from a FinSpace resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update your FinSpace environment.
+update_environment(Client, EnvironmentId, Input) ->
+    update_environment(Client, EnvironmentId, Input, []).
+update_environment(Client, EnvironmentId, Input0, Options0) ->
+    Method = put,
+    Path = ["/environment/", aws_util:encode_uri(EnvironmentId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"finspace">>},
+    Host = build_host(<<"finspace">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_finspace_data.erl
+++ b/src/aws_finspace_data.erl
@@ -1,0 +1,180 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The FinSpace APIs let you take actions inside the FinSpace
+%% environment.
+-module(aws_finspace_data).
+
+-export([create_changeset/3,
+         create_changeset/4,
+         get_programmatic_access_credentials/2,
+         get_programmatic_access_credentials/4,
+         get_programmatic_access_credentials/5,
+         get_working_location/2,
+         get_working_location/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a new changeset in a FinSpace dataset.
+create_changeset(Client, DatasetId, Input) ->
+    create_changeset(Client, DatasetId, Input, []).
+create_changeset(Client, DatasetId, Input0, Options0) ->
+    Method = post,
+    Path = ["/datasets/", aws_util:encode_uri(DatasetId), "/changesets"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Request programmatic credentials to use with Habanero SDK.
+get_programmatic_access_credentials(Client, EnvironmentId)
+  when is_map(Client) ->
+    get_programmatic_access_credentials(Client, EnvironmentId, #{}, #{}).
+
+get_programmatic_access_credentials(Client, EnvironmentId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_programmatic_access_credentials(Client, EnvironmentId, QueryMap, HeadersMap, []).
+
+get_programmatic_access_credentials(Client, EnvironmentId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/credentials/programmatic"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"durationInMinutes">>, maps:get(<<"durationInMinutes">>, QueryMap, undefined)},
+        {<<"environmentId">>, EnvironmentId}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc A temporary Amazon S3 location to copy your files from a source
+%% location to stage or use as a scratch space in Habanero notebook.
+get_working_location(Client, Input) ->
+    get_working_location(Client, Input, []).
+get_working_location(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/workingLocationV1"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"finspace-api">>},
+    Host = build_host(<<"finspace-api">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_firehose.erl
+++ b/src/aws_firehose.erl
@@ -200,7 +200,7 @@ list_tags_for_delivery_stream(Client, Input, Options)
 %%
 %% You must specify the name of the delivery stream and the data record when
 %% using `PutRecord'. The data record consists of a data blob that can be up
-%% to 1,000 KB in size, and any kind of data. For example, it can be a
+%% to 1,000 KiB in size, and any kind of data. For example, it can be a
 %% segment from a log file, geographic location data, website clickstream
 %% data, and so on.
 %%
@@ -245,7 +245,7 @@ put_record(Client, Input, Options)
 %% Quota.
 %%
 %% Each `PutRecordBatch' request supports up to 500 records. Each record in
-%% the request can be as large as 1,000 KB (before 64-bit encoding), up to a
+%% the request can be as large as 1,000 KB (before base64 encoding), up to a
 %% limit of 4 MB for the entire request. These limits cannot be changed.
 %%
 %% You must specify the name of the delivery stream and the data record when

--- a/src/aws_fis.erl
+++ b/src/aws_fis.erl
@@ -1,0 +1,490 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc AWS Fault Injection Simulator is a managed service that enables you
+%% to perform fault injection experiments on your AWS workloads.
+%%
+%% For more information, see the AWS Fault Injection Simulator User Guide.
+-module(aws_fis).
+
+-export([create_experiment_template/2,
+         create_experiment_template/3,
+         delete_experiment_template/3,
+         delete_experiment_template/4,
+         get_action/2,
+         get_action/4,
+         get_action/5,
+         get_experiment/2,
+         get_experiment/4,
+         get_experiment/5,
+         get_experiment_template/2,
+         get_experiment_template/4,
+         get_experiment_template/5,
+         list_actions/1,
+         list_actions/3,
+         list_actions/4,
+         list_experiment_templates/1,
+         list_experiment_templates/3,
+         list_experiment_templates/4,
+         list_experiments/1,
+         list_experiments/3,
+         list_experiments/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         start_experiment/2,
+         start_experiment/3,
+         stop_experiment/3,
+         stop_experiment/4,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_experiment_template/3,
+         update_experiment_template/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates an experiment template.
+%%
+%% To create a template, specify the following information:
+%%
+%% <ul> <li> Targets: A target can be a specific resource in your AWS
+%% environment, or one or more resources that match criteria that you
+%% specify, for example, resources that have specific tags.
+%%
+%% </li> <li> Actions: The actions to carry out on the target. You can
+%% specify multiple actions, the duration of each action, and when to start
+%% each action during an experiment.
+%%
+%% </li> <li> Stop conditions: If a stop condition is triggered while an
+%% experiment is running, the experiment is automatically stopped. You can
+%% define a stop condition as a CloudWatch alarm.
+%%
+%% </li> </ul> For more information, see the AWS Fault Injection Simulator
+%% User Guide.
+create_experiment_template(Client, Input) ->
+    create_experiment_template(Client, Input, []).
+create_experiment_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/experimentTemplates"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified experiment template.
+delete_experiment_template(Client, Id, Input) ->
+    delete_experiment_template(Client, Id, Input, []).
+delete_experiment_template(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/experimentTemplates/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets information about the specified AWS FIS action.
+get_action(Client, Id)
+  when is_map(Client) ->
+    get_action(Client, Id, #{}, #{}).
+
+get_action(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_action(Client, Id, QueryMap, HeadersMap, []).
+
+get_action(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/actions/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about the specified experiment.
+get_experiment(Client, Id)
+  when is_map(Client) ->
+    get_experiment(Client, Id, #{}, #{}).
+
+get_experiment(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_experiment(Client, Id, QueryMap, HeadersMap, []).
+
+get_experiment(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/experiments/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about the specified experiment template.
+get_experiment_template(Client, Id)
+  when is_map(Client) ->
+    get_experiment_template(Client, Id, #{}, #{}).
+
+get_experiment_template(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_experiment_template(Client, Id, QueryMap, HeadersMap, []).
+
+get_experiment_template(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/experimentTemplates/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the available AWS FIS actions.
+list_actions(Client)
+  when is_map(Client) ->
+    list_actions(Client, #{}, #{}).
+
+list_actions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_actions(Client, QueryMap, HeadersMap, []).
+
+list_actions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/actions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists your experiment templates.
+list_experiment_templates(Client)
+  when is_map(Client) ->
+    list_experiment_templates(Client, #{}, #{}).
+
+list_experiment_templates(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_experiment_templates(Client, QueryMap, HeadersMap, []).
+
+list_experiment_templates(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/experimentTemplates"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists your experiments.
+list_experiments(Client)
+  when is_map(Client) ->
+    list_experiments(Client, #{}, #{}).
+
+list_experiments(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_experiments(Client, QueryMap, HeadersMap, []).
+
+list_experiments(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/experiments"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags for the specified resource.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Starts running an experiment from the specified experiment template.
+start_experiment(Client, Input) ->
+    start_experiment(Client, Input, []).
+start_experiment(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/experiments"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Stops the specified experiment.
+stop_experiment(Client, Id, Input) ->
+    stop_experiment(Client, Id, Input, []).
+stop_experiment(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/experiments/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Applies the specified tags to the specified resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the specified tags from the specified resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the specified experiment template.
+update_experiment_template(Client, Id, Input) ->
+    update_experiment_template(Client, Id, Input, []).
+update_experiment_template(Client, Id, Input0, Options0) ->
+    Method = patch,
+    Path = ["/experimentTemplates/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"fis">>},
+    Host = build_host(<<"fis">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_fms.erl
+++ b/src/aws_fms.erl
@@ -1,14 +1,12 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Firewall Manager
+%% @doc This is the Firewall Manager API Reference.
 %%
-%% This is the AWS Firewall Manager API Reference.
-%%
-%% This guide is for developers who need detailed information about the AWS
+%% This guide is for developers who need detailed information about the
 %% Firewall Manager API actions, data types, and errors. For detailed
-%% information about AWS Firewall Manager features, see the AWS Firewall
-%% Manager Developer Guide.
+%% information about Firewall Manager features, see the Firewall Manager
+%% Developer Guide.
 %%
 %% Some API actions require explicit resource permissions. For information,
 %% see the developer guide topic Firewall Manager required permissions for
@@ -74,15 +72,13 @@
 %% API
 %%====================================================================
 
-%% @doc Sets the AWS Firewall Manager administrator account.
+%% @doc Sets the Firewall Manager administrator account.
 %%
-%% AWS Firewall Manager must be associated with the master account of your
-%% AWS organization or associated with a member account that has the
-%% appropriate permissions. If the account ID that you submit is not an AWS
-%% Organizations master account, AWS Firewall Manager will set the
-%% appropriate permissions for the given member account.
+%% The account must be a member of the organization in Organizations whose
+%% resources you want to protect. Firewall Manager sets the permissions that
+%% allow the account to administer your Firewall Manager policies.
 %%
-%% The account that you associate with AWS Firewall Manager is called the AWS
+%% The account that you associate with Firewall Manager is called the
 %% Firewall Manager administrator account.
 associate_admin_account(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -91,7 +87,7 @@ associate_admin_account(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssociateAdminAccount">>, Input, Options).
 
-%% @doc Permanently deletes an AWS Firewall Manager applications list.
+%% @doc Permanently deletes an Firewall Manager applications list.
 delete_apps_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_apps_list(Client, Input, []).
@@ -99,8 +95,8 @@ delete_apps_list(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAppsList">>, Input, Options).
 
-%% @doc Deletes an AWS Firewall Manager association with the IAM role and the
-%% Amazon Simple Notification Service (SNS) topic that is used to record AWS
+%% @doc Deletes an Firewall Manager association with the IAM role and the
+%% Amazon Simple Notification Service (SNS) topic that is used to record
 %% Firewall Manager SNS logs.
 delete_notification_channel(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -109,7 +105,7 @@ delete_notification_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteNotificationChannel">>, Input, Options).
 
-%% @doc Permanently deletes an AWS Firewall Manager policy.
+%% @doc Permanently deletes an Firewall Manager policy.
 delete_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_policy(Client, Input, []).
@@ -117,7 +113,7 @@ delete_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeletePolicy">>, Input, Options).
 
-%% @doc Permanently deletes an AWS Firewall Manager protocols list.
+%% @doc Permanently deletes an Firewall Manager protocols list.
 delete_protocols_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_protocols_list(Client, Input, []).
@@ -125,8 +121,8 @@ delete_protocols_list(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteProtocolsList">>, Input, Options).
 
-%% @doc Disassociates the account that has been set as the AWS Firewall
-%% Manager administrator account.
+%% @doc Disassociates the account that has been set as the Firewall Manager
+%% administrator account.
 %%
 %% To set a different account as the administrator account, you must submit
 %% an `AssociateAdminAccount' request.
@@ -137,8 +133,8 @@ disassociate_admin_account(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisassociateAdminAccount">>, Input, Options).
 
-%% @doc Returns the AWS Organizations master account that is associated with
-%% AWS Firewall Manager as the AWS Firewall Manager administrator.
+%% @doc Returns the Organizations account that is associated with Firewall
+%% Manager as the Firewall Manager administrator.
 get_admin_account(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_admin_account(Client, Input, []).
@@ -146,8 +142,8 @@ get_admin_account(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetAdminAccount">>, Input, Options).
 
-%% @doc Returns information about the specified AWS Firewall Manager
-%% applications list.
+%% @doc Returns information about the specified Firewall Manager applications
+%% list.
 get_apps_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_apps_list(Client, Input, []).
@@ -159,16 +155,27 @@ get_apps_list(Client, Input, Options)
 %% account.
 %%
 %% Details include resources that are in and out of compliance with the
-%% specified policy. Resources are considered noncompliant for AWS WAF and
-%% Shield Advanced policies if the specified policy has not been applied to
-%% them. Resources are considered noncompliant for security group policies if
-%% they are in scope of the policy, they violate one or more of the policy
-%% rules, and remediation is disabled or not possible. Resources are
-%% considered noncompliant for Network Firewall policies if a firewall is
-%% missing in the VPC, if the firewall endpoint isn't set up in an expected
-%% Availability Zone and subnet, if a subnet created by the Firewall Manager
-%% doesn't have the expected route table, and for modifications to a firewall
-%% policy that violate the Firewall Manager policy's rules.
+%% specified policy.
+%%
+%% <ul> <li> Resources are considered noncompliant for WAF and Shield
+%% Advanced policies if the specified policy has not been applied to them.
+%%
+%% </li> <li> Resources are considered noncompliant for security group
+%% policies if they are in scope of the policy, they violate one or more of
+%% the policy rules, and remediation is disabled or not possible.
+%%
+%% </li> <li> Resources are considered noncompliant for Network Firewall
+%% policies if a firewall is missing in the VPC, if the firewall endpoint
+%% isn't set up in an expected Availability Zone and subnet, if a subnet
+%% created by the Firewall Manager doesn't have the expected route table, and
+%% for modifications to a firewall policy that violate the Firewall Manager
+%% policy's rules.
+%%
+%% </li> <li> Resources are considered noncompliant for DNS Firewall policies
+%% if a DNS Firewall rule group is missing from the rule group associations
+%% for the VPC.
+%%
+%% </li> </ul>
 get_compliance_detail(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_compliance_detail(Client, Input, []).
@@ -177,7 +184,7 @@ get_compliance_detail(Client, Input, Options)
     request(Client, <<"GetComplianceDetail">>, Input, Options).
 
 %% @doc Information about the Amazon Simple Notification Service (SNS) topic
-%% that is used to record AWS Firewall Manager SNS logs.
+%% that is used to record Firewall Manager SNS logs.
 get_notification_channel(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_notification_channel(Client, Input, []).
@@ -185,7 +192,7 @@ get_notification_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetNotificationChannel">>, Input, Options).
 
-%% @doc Returns information about the specified AWS Firewall Manager policy.
+%% @doc Returns information about the specified Firewall Manager policy.
 get_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_policy(Client, Input, []).
@@ -204,8 +211,8 @@ get_protection_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetProtectionStatus">>, Input, Options).
 
-%% @doc Returns information about the specified AWS Firewall Manager
-%% protocols list.
+%% @doc Returns information about the specified Firewall Manager protocols
+%% list.
 get_protocols_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_protocols_list(Client, Input, []).
@@ -213,8 +220,8 @@ get_protocols_list(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetProtocolsList">>, Input, Options).
 
-%% @doc Retrieves violations for a resource based on the specified AWS
-%% Firewall Manager policy and AWS account.
+%% @doc Retrieves violations for a resource based on the specified Firewall
+%% Manager policy and Amazon Web Services account.
 get_violation_details(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_violation_details(Client, Input, []).
@@ -242,10 +249,10 @@ list_compliance_status(Client, Input, Options)
     request(Client, <<"ListComplianceStatus">>, Input, Options).
 
 %% @doc Returns a `MemberAccounts' object that lists the member accounts in
-%% the administrator's AWS organization.
+%% the administrator's Amazon Web Services organization.
 %%
 %% The `ListMemberAccounts' must be submitted by the account that is set as
-%% the AWS Firewall Manager administrator.
+%% the Firewall Manager administrator.
 list_member_accounts(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_member_accounts(Client, Input, []).
@@ -269,7 +276,8 @@ list_protocols_lists(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListProtocolsLists">>, Input, Options).
 
-%% @doc Retrieves the list of tags for the specified AWS resource.
+%% @doc Retrieves the list of tags for the specified Amazon Web Services
+%% resource.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -277,7 +285,7 @@ list_tags_for_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListTagsForResource">>, Input, Options).
 
-%% @doc Creates an AWS Firewall Manager applications list.
+%% @doc Creates an Firewall Manager applications list.
 put_apps_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_apps_list(Client, Input, []).
@@ -286,12 +294,12 @@ put_apps_list(Client, Input, Options)
     request(Client, <<"PutAppsList">>, Input, Options).
 
 %% @doc Designates the IAM role and Amazon Simple Notification Service (SNS)
-%% topic that AWS Firewall Manager uses to record SNS logs.
+%% topic that Firewall Manager uses to record SNS logs.
 %%
 %% To perform this action outside of the console, you must configure the SNS
 %% topic to allow the Firewall Manager role `AWSServiceRoleForFMS' to publish
 %% SNS logs. For more information, see Firewall Manager required permissions
-%% for API actions in the AWS Firewall Manager Developer Guide.
+%% for API actions in the Firewall Manager Developer Guide.
 put_notification_channel(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_notification_channel(Client, Input, []).
@@ -299,25 +307,27 @@ put_notification_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutNotificationChannel">>, Input, Options).
 
-%% @doc Creates an AWS Firewall Manager policy.
+%% @doc Creates an Firewall Manager policy.
 %%
 %% Firewall Manager provides the following types of policies:
 %%
-%% <ul> <li> An AWS WAF policy (type WAFV2), which defines rule groups to run
-%% first in the corresponding AWS WAF web ACL and rule groups to run last in
-%% the web ACL.
+%% <ul> <li> An WAF policy (type WAFV2), which defines rule groups to run
+%% first in the corresponding WAF web ACL and rule groups to run last in the
+%% web ACL.
 %%
-%% </li> <li> An AWS WAF Classic policy (type WAF), which defines a rule
-%% group.
+%% </li> <li> An WAF Classic policy (type WAF), which defines a rule group.
 %%
 %% </li> <li> A Shield Advanced policy, which applies Shield Advanced
 %% protection to specified accounts and resources.
 %%
 %% </li> <li> A security group policy, which manages VPC security groups
-%% across your AWS organization.
+%% across your Amazon Web Services organization.
 %%
-%% </li> <li> An AWS Network Firewall policy, which provides firewall rules
-%% to filter network traffic in specified Amazon VPCs.
+%% </li> <li> An Network Firewall policy, which provides firewall rules to
+%% filter network traffic in specified Amazon VPCs.
+%%
+%% </li> <li> A DNS Firewall policy, which provides Route 53 Resolver DNS
+%% Firewall rules to filter DNS queries for specified VPCs.
 %%
 %% </li> </ul> Each policy is specific to one of the types. If you want to
 %% enforce more than one policy type across accounts, create multiple
@@ -333,7 +343,7 @@ put_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutPolicy">>, Input, Options).
 
-%% @doc Creates an AWS Firewall Manager protocols list.
+%% @doc Creates an Firewall Manager protocols list.
 put_protocols_list(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_protocols_list(Client, Input, []).
@@ -341,7 +351,7 @@ put_protocols_list(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutProtocolsList">>, Input, Options).
 
-%% @doc Adds one or more tags to an AWS resource.
+%% @doc Adds one or more tags to an Amazon Web Services resource.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -349,7 +359,7 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Removes one or more tags from an AWS resource.
+%% @doc Removes one or more tags from an Amazon Web Services resource.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).

--- a/src/aws_forecast.erl
+++ b/src/aws_forecast.erl
@@ -32,6 +32,8 @@
          delete_predictor/3,
          delete_predictor_backtest_export_job/2,
          delete_predictor_backtest_export_job/3,
+         delete_resource_tree/2,
+         delete_resource_tree/3,
          describe_dataset/2,
          describe_dataset/3,
          describe_dataset_group/2,
@@ -405,6 +407,37 @@ delete_predictor_backtest_export_job(Client, Input)
 delete_predictor_backtest_export_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeletePredictorBacktestExportJob">>, Input, Options).
+
+%% @doc Deletes an entire resource tree.
+%%
+%% This operation will delete the parent resource and its child resources.
+%%
+%% Child resources are resources that were created from another resource. For
+%% example, when a forecast is generated from a predictor, the forecast is
+%% the child resource and the predictor is the parent resource.
+%%
+%% Amazon Forecast resources possess the following parent-child resource
+%% hierarchies:
+%%
+%% <ul> <li> Dataset: dataset import jobs
+%%
+%% </li> <li> Dataset Group: predictors, predictor backtest export jobs,
+%% forecasts, forecast export jobs
+%%
+%% </li> <li> Predictor: predictor backtest export jobs, forecasts, forecast
+%% export jobs
+%%
+%% </li> <li> Forecast: forecast export jobs
+%%
+%% </li> </ul> `DeleteResourceTree' will only delete Amazon Forecast
+%% resources, and will not delete datasets or exported files stored in Amazon
+%% S3.
+delete_resource_tree(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_resource_tree(Client, Input, []).
+delete_resource_tree(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteResourceTree">>, Input, Options).
 
 %% @doc Describes an Amazon Forecast dataset created using the
 %% `CreateDataset' operation.

--- a/src/aws_frauddetector.erl
+++ b/src/aws_frauddetector.erl
@@ -13,6 +13,14 @@
          batch_create_variable/3,
          batch_get_variable/2,
          batch_get_variable/3,
+         cancel_batch_import_job/2,
+         cancel_batch_import_job/3,
+         cancel_batch_prediction_job/2,
+         cancel_batch_prediction_job/3,
+         create_batch_import_job/2,
+         create_batch_import_job/3,
+         create_batch_prediction_job/2,
+         create_batch_prediction_job/3,
          create_detector_version/2,
          create_detector_version/3,
          create_model/2,
@@ -23,6 +31,10 @@
          create_rule/3,
          create_variable/2,
          create_variable/3,
+         delete_batch_import_job/2,
+         delete_batch_import_job/3,
+         delete_batch_prediction_job/2,
+         delete_batch_prediction_job/3,
          delete_detector/2,
          delete_detector/3,
          delete_detector_version/2,
@@ -33,6 +45,8 @@
          delete_event/3,
          delete_event_type/2,
          delete_event_type/3,
+         delete_events_by_event_type/2,
+         delete_events_by_event_type/3,
          delete_external_model/2,
          delete_external_model/3,
          delete_label/2,
@@ -51,12 +65,20 @@
          describe_detector/3,
          describe_model_versions/2,
          describe_model_versions/3,
+         get_batch_import_jobs/2,
+         get_batch_import_jobs/3,
+         get_batch_prediction_jobs/2,
+         get_batch_prediction_jobs/3,
+         get_delete_events_by_event_type_status/2,
+         get_delete_events_by_event_type_status/3,
          get_detector_version/2,
          get_detector_version/3,
          get_detectors/2,
          get_detectors/3,
          get_entity_types/2,
          get_entity_types/3,
+         get_event/2,
+         get_event/3,
          get_event_prediction/2,
          get_event_prediction/3,
          get_event_types/2,
@@ -93,6 +115,8 @@
          put_label/3,
          put_outcome/2,
          put_outcome/3,
+         send_event/2,
+         send_event/3,
          tag_resource/2,
          tag_resource/3,
          untag_resource/2,
@@ -103,6 +127,8 @@
          update_detector_version_metadata/3,
          update_detector_version_status/2,
          update_detector_version_status/3,
+         update_event_label/2,
+         update_event_label/3,
          update_model/2,
          update_model/3,
          update_model_version/2,
@@ -137,6 +163,38 @@ batch_get_variable(Client, Input)
 batch_get_variable(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchGetVariable">>, Input, Options).
+
+%% @doc Cancels an in-progress batch import job.
+cancel_batch_import_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_batch_import_job(Client, Input, []).
+cancel_batch_import_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelBatchImportJob">>, Input, Options).
+
+%% @doc Cancels the specified batch prediction job.
+cancel_batch_prediction_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_batch_prediction_job(Client, Input, []).
+cancel_batch_prediction_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelBatchPredictionJob">>, Input, Options).
+
+%% @doc Creates a batch import job.
+create_batch_import_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_batch_import_job(Client, Input, []).
+create_batch_import_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBatchImportJob">>, Input, Options).
+
+%% @doc Creates a batch prediction job.
+create_batch_prediction_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_batch_prediction_job(Client, Input, []).
+create_batch_prediction_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBatchPredictionJob">>, Input, Options).
 
 %% @doc Creates a detector version.
 %%
@@ -180,6 +238,22 @@ create_variable(Client, Input)
 create_variable(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateVariable">>, Input, Options).
+
+%% @doc Deletes data that was batch imported to Amazon Fraud Detector.
+delete_batch_import_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_batch_import_job(Client, Input, []).
+delete_batch_import_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBatchImportJob">>, Input, Options).
+
+%% @doc Deletes a batch prediction job.
+delete_batch_prediction_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_batch_prediction_job(Client, Input, []).
+delete_batch_prediction_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBatchPredictionJob">>, Input, Options).
 
 %% @doc Deletes the detector.
 %%
@@ -238,15 +312,22 @@ delete_event(Client, Input, Options)
 %%
 %% You cannot delete an event type that is used in a detector or a model.
 %%
-%% When you delete an entity type, Amazon Fraud Detector permanently deletes
-%% that entity type and the data is no longer stored in Amazon Fraud
-%% Detector.
+%% When you delete an event type, Amazon Fraud Detector permanently deletes
+%% that event type and the data is no longer stored in Amazon Fraud Detector.
 delete_event_type(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_event_type(Client, Input, []).
 delete_event_type(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteEventType">>, Input, Options).
+
+%% @doc Deletes all events of a particular event type.
+delete_events_by_event_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_events_by_event_type(Client, Input, []).
+delete_events_by_event_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEventsByEventType">>, Input, Options).
 
 %% @doc Removes a SageMaker model from Amazon Fraud Detector.
 %%
@@ -370,6 +451,44 @@ describe_model_versions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeModelVersions">>, Input, Options).
 
+%% @doc Gets all batch import jobs or a specific job of the specified ID.
+%%
+%% This is a paginated API. If you provide a null `maxResults', this action
+%% retrieves a maximum of 50 records per page. If you provide a `maxResults',
+%% the value must be between 1 and 50. To get the next page results, provide
+%% the pagination token from the `GetBatchImportJobsResponse' as part of your
+%% request. A null pagination token fetches the records from the beginning.
+get_batch_import_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_batch_import_jobs(Client, Input, []).
+get_batch_import_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBatchImportJobs">>, Input, Options).
+
+%% @doc Gets all batch prediction jobs or a specific job if you specify a job
+%% ID.
+%%
+%% This is a paginated API. If you provide a null maxResults, this action
+%% retrieves a maximum of 50 records per page. If you provide a maxResults,
+%% the value must be between 1 and 50. To get the next page results, provide
+%% the pagination token from the GetBatchPredictionJobsResponse as part of
+%% your request. A null pagination token fetches the records from the
+%% beginning.
+get_batch_prediction_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_batch_prediction_jobs(Client, Input, []).
+get_batch_prediction_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBatchPredictionJobs">>, Input, Options).
+
+%% @doc Retrieves the status of a `DeleteEventsByEventType' action.
+get_delete_events_by_event_type_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_delete_events_by_event_type_status(Client, Input, []).
+get_delete_events_by_event_type_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetDeleteEventsByEventTypeStatus">>, Input, Options).
+
 %% @doc Gets a particular detector version.
 get_detector_version(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -407,6 +526,16 @@ get_entity_types(Client, Input)
 get_entity_types(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetEntityTypes">>, Input, Options).
+
+%% @doc Retrieves details of events stored with Amazon Fraud Detector.
+%%
+%% This action does not retrieve prediction results.
+get_event(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_event(Client, Input, []).
+get_event(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEvent">>, Input, Options).
 
 %% @doc Evaluates an event against a detector version.
 %%
@@ -448,9 +577,8 @@ get_external_models(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetExternalModels">>, Input, Options).
 
-%% @doc Gets the encryption key if a Key Management Service (KMS) customer
-%% master key (CMK) has been specified to be used to encrypt content in
-%% Amazon Fraud Detector.
+%% @doc Gets the encryption key if a KMS key has been specified to be used to
+%% encrypt content in Amazon Fraud Detector.
 get_kms_encryption_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_kms_encryption_key(Client, Input, []).
@@ -482,10 +610,11 @@ get_model_version(Client, Input, Options)
 
 %% @doc Gets one or more models.
 %%
-%% Gets all models for the AWS account if no model type and no model id
-%% provided. Gets all models for the AWS account and model type, if the model
-%% type is specified but model id is not provided. Gets a specific model if
-%% (model type, model id) tuple is specified.
+%% Gets all models for the Amazon Web Services account if no model type and
+%% no model id provided. Gets all models for the Amazon Web Services account
+%% and model type, if the model type is specified but model id is not
+%% provided. Gets a specific model if (model type, model id) tuple is
+%% specified.
 %%
 %% This is a paginated API. If you provide a null `maxResults', this action
 %% retrieves a maximum of 10 records per page. If you provide a `maxResults',
@@ -608,8 +737,8 @@ put_external_model(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutExternalModel">>, Input, Options).
 
-%% @doc Specifies the Key Management Service (KMS) customer master key (CMK)
-%% to be used to encrypt content in Amazon Fraud Detector.
+%% @doc Specifies the KMS key to be used to encrypt content in Amazon Fraud
+%% Detector.
 put_kms_encryption_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_kms_encryption_key(Client, Input, []).
@@ -636,6 +765,18 @@ put_outcome(Client, Input)
 put_outcome(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutOutcome">>, Input, Options).
+
+%% @doc Stores events in Amazon Fraud Detector without generating fraud
+%% predictions for those events.
+%%
+%% For example, you can use `SendEvent' to upload a historical dataset, which
+%% you can then later use to train a model.
+send_event(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_event(Client, Input, []).
+send_event(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendEvent">>, Input, Options).
 
 %% @doc Assigns tags to a resource.
 tag_resource(Client, Input)
@@ -688,9 +829,15 @@ update_detector_version_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateDetectorVersionStatus">>, Input, Options).
 
-%% @doc Updates a model.
-%%
-%% You can update the description attribute using this action.
+%% @doc Updates the specified event with a new label.
+update_event_label(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_event_label(Client, Input, []).
+update_event_label(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEventLabel">>, Input, Options).
+
+%% @doc Updates model description.
 update_model(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_model(Client, Input, []).
@@ -718,7 +865,7 @@ update_model_version(Client, Input, Options)
 %%
 %% <ol> <li> Change the `TRAINING_COMPLETE' status to `ACTIVE'.
 %%
-%% </li> <li> Change `ACTIVE'to `INACTIVE'.
+%% </li> <li> Change `ACTIVE' to `INACTIVE'.
 %%
 %% </li> </ol>
 update_model_version_status(Client, Input)

--- a/src/aws_fsx.erl
+++ b/src/aws_fsx.erl
@@ -9,6 +9,8 @@
          associate_file_system_aliases/3,
          cancel_data_repository_task/2,
          cancel_data_repository_task/3,
+         copy_backup/2,
+         copy_backup/3,
          create_backup/2,
          create_backup/3,
          create_data_repository_task/2,
@@ -17,10 +19,20 @@
          create_file_system/3,
          create_file_system_from_backup/2,
          create_file_system_from_backup/3,
+         create_storage_virtual_machine/2,
+         create_storage_virtual_machine/3,
+         create_volume/2,
+         create_volume/3,
+         create_volume_from_backup/2,
+         create_volume_from_backup/3,
          delete_backup/2,
          delete_backup/3,
          delete_file_system/2,
          delete_file_system/3,
+         delete_storage_virtual_machine/2,
+         delete_storage_virtual_machine/3,
+         delete_volume/2,
+         delete_volume/3,
          describe_backups/2,
          describe_backups/3,
          describe_data_repository_tasks/2,
@@ -29,6 +41,10 @@
          describe_file_system_aliases/3,
          describe_file_systems/2,
          describe_file_systems/3,
+         describe_storage_virtual_machines/2,
+         describe_storage_virtual_machines/3,
+         describe_volumes/2,
+         describe_volumes/3,
          disassociate_file_system_aliases/2,
          disassociate_file_system_aliases/3,
          list_tags_for_resource/2,
@@ -38,7 +54,11 @@
          untag_resource/2,
          untag_resource/3,
          update_file_system/2,
-         update_file_system/3]).
+         update_file_system/3,
+         update_storage_virtual_machine/2,
+         update_storage_virtual_machine/3,
+         update_volume/2,
+         update_volume/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -49,7 +69,7 @@
 %% @doc Use this action to associate one or more Domain Name Server (DNS)
 %% aliases with an existing Amazon FSx for Windows File Server file system.
 %%
-%% A file systen can have a maximum of 50 DNS aliases associated with it at
+%% A file system can have a maximum of 50 DNS aliases associated with it at
 %% any one time. If you try to associate a DNS alias that is already
 %% associated with the file system, FSx takes no action on that alias in the
 %% request. For more information, see Working with DNS Aliases and
@@ -87,29 +107,70 @@ cancel_data_repository_task(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CancelDataRepositoryTask">>, Input, Options).
 
-%% @doc Creates a backup of an existing Amazon FSx file system.
+%% @doc Copies an existing backup within the same Amazon Web Services account
+%% to another Amazon Web Services Region (cross-Region copy) or within the
+%% same Amazon Web Services Region (in-Region copy).
 %%
-%% Creating regular backups for your file system is a best practice, enabling
-%% you to restore a file system from a backup if an issue arises with the
-%% original file system.
+%% You can have up to five backup copy requests in progress to a single
+%% destination Region per account.
+%%
+%% You can use cross-Region backup copies for cross-region disaster recovery.
+%% You periodically take backups and copy them to another Region so that in
+%% the event of a disaster in the primary Region, you can restore from backup
+%% and recover availability quickly in the other Region. You can make
+%% cross-Region copies only within your Amazon Web Services partition.
+%%
+%% You can also use backup copies to clone your file data set to another
+%% Region or within the same Region.
+%%
+%% You can use the `SourceRegion' parameter to specify the Amazon Web
+%% Services Region from which the backup will be copied. For example, if you
+%% make the call from the `us-west-1' Region and want to copy a backup from
+%% the `us-east-2' Region, you specify `us-east-2' in the `SourceRegion'
+%% parameter to make a cross-Region copy. If you don't specify a Region, the
+%% backup copy is created in the same Region where the request is sent from
+%% (in-Region copy).
+%%
+%% For more information on creating backup copies, see Copying backups in the
+%% Amazon FSx for Windows User Guide and Copying backups in the Amazon FSx
+%% for Lustre User Guide.
+copy_backup(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    copy_backup(Client, Input, []).
+copy_backup(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CopyBackup">>, Input, Options).
+
+%% @doc Creates a backup of an existing Amazon FSx for Windows File Server or
+%% Amazon FSx for Lustre file system, or of an Amazon FSx for NetApp ONTAP
+%% volume.
+%%
+%% Creating regular backups is a best practice, enabling you to restore a
+%% file system or volume from a backup if an issue arises with the original
+%% file system or volume.
 %%
 %% For Amazon FSx for Lustre file systems, you can create a backup only for
 %% file systems with the following configuration:
 %%
 %% <ul> <li> a Persistent deployment type
 %%
-%% </li> <li> is not linked to a data respository.
+%% </li> <li> is not linked to a data repository.
 %%
-%% </li> </ul> For more information about backing up Amazon FSx for Lustre
-%% file systems, see Working with FSx for Lustre backups.
+%% </li> </ul> For more information about backups, see the following:
 %%
-%% For more information about backing up Amazon FSx for Windows file systems,
-%% see Working with FSx for Windows backups.
+%% <ul> <li> For Amazon FSx for Lustre, see Working with FSx for Lustre
+%% backups.
 %%
-%% If a backup with the specified client request token exists, and the
-%% parameters match, this operation returns the description of the existing
-%% backup. If a backup specified client request token exists, and the
-%% parameters don't match, this operation returns
+%% </li> <li> For Amazon FSx for Windows, see Working with FSx for Windows
+%% backups.
+%%
+%% </li> <li> For Amazon FSx for NetApp ONTAP, see Working with FSx for
+%% NetApp ONTAP backups.
+%%
+%% </li> </ul> If a backup with the specified client request token exists,
+%% and the parameters match, this operation returns the description of the
+%% existing backup. If a backup specified client request token exists, and
+%% the parameters don't match, this operation returns
 %% `IncompatibleParameterError'. If a backup with the specified client
 %% request token doesn't exist, `CreateBackup' does the following:
 %%
@@ -190,8 +251,8 @@ create_file_system(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateFileSystem">>, Input, Options).
 
-%% @doc Creates a new Amazon FSx file system from an existing Amazon FSx
-%% backup.
+%% @doc Creates a new Amazon FSx for Lustre or Amazon FSx for Windows File
+%% Server file system from an existing Amazon FSx backup.
 %%
 %% If a file system with the specified client request token exists and the
 %% parameters match, this operation returns the description of the file
@@ -230,6 +291,32 @@ create_file_system_from_backup(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateFileSystemFromBackup">>, Input, Options).
 
+%% @doc Creates a storage virtual machine (SVM) for an Amazon FSx for ONTAP
+%% file system.
+create_storage_virtual_machine(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_storage_virtual_machine(Client, Input, []).
+create_storage_virtual_machine(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateStorageVirtualMachine">>, Input, Options).
+
+%% @doc Creates an Amazon FSx for NetApp ONTAP storage volume.
+create_volume(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_volume(Client, Input, []).
+create_volume(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateVolume">>, Input, Options).
+
+%% @doc Creates a new Amazon FSx for NetApp ONTAP volume from an existing
+%% Amazon FSx volume backup.
+create_volume_from_backup(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_volume_from_backup(Client, Input, []).
+create_volume_from_backup(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateVolumeFromBackup">>, Input, Options).
+
 %% @doc Deletes an Amazon FSx backup, deleting its contents.
 %%
 %% After deletion, the backup no longer exists, and its data is gone.
@@ -250,6 +337,10 @@ delete_backup(Client, Input, Options)
 %%
 %% After deletion, the file system no longer exists, and its data is gone.
 %% Any existing automatic backups will also be deleted.
+%%
+%% To delete an Amazon FSx for NetApp ONTAP file system, first delete all the
+%% volumes and SVMs on the file system. Then provide a `FileSystemId' value
+%% to the `DeleFileSystem' operation.
 %%
 %% By default, when you delete an Amazon FSx for Windows File Server file
 %% system, a final backup is created upon deletion. This final backup is not
@@ -275,11 +366,37 @@ delete_file_system(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteFileSystem">>, Input, Options).
 
+%% @doc Deletes an existing Amazon FSx for ONTAP storage virtual machine
+%% (SVM).
+%%
+%% Prior to deleting an SVM, you must delete all non-root volumes in the SVM,
+%% otherwise the operation will fail.
+delete_storage_virtual_machine(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_storage_virtual_machine(Client, Input, []).
+delete_storage_virtual_machine(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteStorageVirtualMachine">>, Input, Options).
+
+%% @doc Deletes an Amazon FSx for NetApp ONTAP volume.
+%%
+%% When deleting a volume, you have the option of creating a final backup. If
+%% you create a final backup, you have the option to apply Tags to the
+%% backup. You need to have `fsx:TagResource' permission in order to apply
+%% tags to the backup.
+delete_volume(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_volume(Client, Input, []).
+delete_volume(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteVolume">>, Input, Options).
+
 %% @doc Returns the description of specific Amazon FSx backups, if a
 %% `BackupIds' value is provided for that backup.
 %%
-%% Otherwise, it returns all backups owned by your AWS account in the AWS
-%% Region of the endpoint that you're calling.
+%% Otherwise, it returns all backups owned by your Amazon Web Services
+%% account in the Amazon Web Services Region of the endpoint that you're
+%% calling.
 %%
 %% When retrieving all backups, you can optionally specify the `MaxResults'
 %% parameter to limit the number of backups in a response. If more backups
@@ -295,8 +412,8 @@ delete_file_system(Client, Input, Options)
 %%
 %% When using this action, keep the following in mind:
 %%
-%% <ul> <li> The implementation might return fewer than `MaxResults' file
-%% system descriptions while still including a `NextToken' value.
+%% <ul> <li> The implementation might return fewer than `MaxResults' backup
+%% descriptions while still including a `NextToken' value.
 %%
 %% </li> <li> The order of backups returned in the response of one
 %% `DescribeBackups' call and the order of backups returned across the
@@ -316,8 +433,9 @@ describe_backups(Client, Input, Options)
 %%
 %% You can use filters to narrow the response to include just tasks for
 %% specific file systems, or tasks in a specific lifecycle state. Otherwise,
-%% it returns all data repository tasks owned by your AWS account in the AWS
-%% Region of the endpoint that you're calling.
+%% it returns all data repository tasks owned by your Amazon Web Services
+%% account in the Amazon Web Services Region of the endpoint that you're
+%% calling.
 %%
 %% When retrieving all tasks, you can paginate the response by using the
 %% optional `MaxResults' parameter to limit the number of tasks returned in a
@@ -348,8 +466,9 @@ describe_file_system_aliases(Client, Input, Options)
 %% @doc Returns the description of specific Amazon FSx file systems, if a
 %% `FileSystemIds' value is provided for that file system.
 %%
-%% Otherwise, it returns descriptions of all file systems owned by your AWS
-%% account in the AWS Region of the endpoint that you're calling.
+%% Otherwise, it returns descriptions of all file systems owned by your
+%% Amazon Web Services account in the Amazon Web Services Region of the
+%% endpoint that you're calling.
 %%
 %% When retrieving all file system descriptions, you can optionally specify
 %% the `MaxResults' parameter to limit the number of descriptions in a
@@ -380,6 +499,23 @@ describe_file_systems(Client, Input)
 describe_file_systems(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeFileSystems">>, Input, Options).
+
+%% @doc Describes one or more Amazon FSx for NetApp ONTAP storage virtual
+%% machines (SVMs).
+describe_storage_virtual_machines(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_storage_virtual_machines(Client, Input, []).
+describe_storage_virtual_machines(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeStorageVirtualMachines">>, Input, Options).
+
+%% @doc Describes one or more Amazon FSx for NetApp ONTAP volumes.
+describe_volumes(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_volumes(Client, Input, []).
+describe_volumes(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeVolumes">>, Input, Options).
 
 %% @doc Use this action to disassociate, or remove, one or more Domain Name
 %% Service (DNS) aliases from an Amazon FSx for Windows File Server file
@@ -456,7 +592,9 @@ untag_resource(Client, Input, Options)
 %% For Amazon FSx for Windows File Server file systems, you can update the
 %% following properties:
 %%
-%% <ul> <li> AutomaticBackupRetentionDays
+%% <ul> <li> AuditLogConfiguration
+%%
+%% </li> <li> AutomaticBackupRetentionDays
 %%
 %% </li> <li> DailyAutomaticBackupStartTime
 %%
@@ -477,7 +615,20 @@ untag_resource(Client, Input, Options)
 %%
 %% </li> <li> DailyAutomaticBackupStartTime
 %%
+%% </li> <li> DataCompressionType
+%%
 %% </li> <li> StorageCapacity
+%%
+%% </li> <li> WeeklyMaintenanceStartTime
+%%
+%% </li> </ul> For Amazon FSx for NetApp ONTAP file systems, you can update
+%% the following properties:
+%%
+%% <ul> <li> AutomaticBackupRetentionDays
+%%
+%% </li> <li> DailyAutomaticBackupStartTime
+%%
+%% </li> <li> FsxAdminPassword
 %%
 %% </li> <li> WeeklyMaintenanceStartTime
 %%
@@ -488,6 +639,22 @@ update_file_system(Client, Input)
 update_file_system(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateFileSystem">>, Input, Options).
+
+%% @doc Updates an Amazon FSx for ONTAP storage virtual machine (SVM).
+update_storage_virtual_machine(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_storage_virtual_machine(Client, Input, []).
+update_storage_virtual_machine(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateStorageVirtualMachine">>, Input, Options).
+
+%% @doc Updates an Amazon FSx for NetApp ONTAP volume's configuration.
+update_volume(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_volume(Client, Input, []).
+update_volume(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateVolume">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_gamelift.erl
+++ b/src/aws_gamelift.erl
@@ -13,31 +13,40 @@
 %%
 %% About GameLift solutions
 %%
-%% Get more information on these GameLift solutions in the Amazon GameLift
-%% Developer Guide.
+%% Get more information on these GameLift solutions in the GameLift Developer
+%% Guide.
 %%
-%% <ul> <li> Managed GameLift -- GameLift offers a fully managed service to
-%% set up and maintain computing machines for hosting, manage game session
-%% and player session life cycle, and handle security, storage, and
+%% <ul> <li> GameLift managed hosting -- GameLift offers a fully managed
+%% service to set up and maintain computing machines for hosting, manage game
+%% session and player session life cycle, and handle security, storage, and
 %% performance tracking. You can use automatic scaling tools to balance
-%% hosting costs against meeting player demand., configure your game session
-%% management to minimize player latency, or add FlexMatch for matchmaking.
+%% player demand and hosting costs, configure your game session management to
+%% minimize player latency, and add FlexMatch for matchmaking.
 %%
-%% </li> <li> Managed GameLift with Realtime Servers – With GameLift Realtime
-%% Servers, you can quickly configure and set up game servers for your game.
-%% Realtime Servers provides a game server framework with core Amazon
-%% GameLift infrastructure already built in.
+%% </li> <li> Managed hosting with Realtime Servers -- With GameLift Realtime
+%% Servers, you can quickly configure and set up ready-to-go game servers for
+%% your game. Realtime Servers provides a game server framework with core
+%% GameLift infrastructure already built in. Then use the full range of
+%% GameLift managed hosting features, including FlexMatch, for your game.
 %%
-%% </li> <li> GameLift FleetIQ – Use GameLift FleetIQ as a standalone feature
-%% while managing your own EC2 instances and Auto Scaling groups for game
-%% hosting. GameLift FleetIQ provides optimizations that make low-cost Spot
-%% Instances viable for game hosting.
+%% </li> <li> GameLift FleetIQ -- Use GameLift FleetIQ as a standalone
+%% service while hosting your games using EC2 instances and Auto Scaling
+%% groups. GameLift FleetIQ provides optimizations for game hosting,
+%% including boosting the viability of low-cost Spot Instances gaming. For a
+%% complete solution, pair the GameLift FleetIQ and FlexMatch standalone
+%% services.
+%%
+%% </li> <li> GameLift FlexMatch -- Add matchmaking to your game hosting
+%% solution. FlexMatch is a customizable matchmaking service for multiplayer
+%% games. Use FlexMatch as integrated with GameLift managed hosting or
+%% incorporate FlexMatch as a standalone service into your own hosting
+%% solution.
 %%
 %% </li> </ul> About this API Reference
 %%
 %% This reference guide describes the low-level service API for Amazon
-%% GameLift. You can find links to language-specific SDK guides and the AWS
-%% CLI reference with each operation and data type topic. Useful links:
+%% GameLift. With each topic in this guide, you can find links to
+%% language-specific SDK guides and the AWS CLI reference. Useful links:
 %%
 %% <ul> <li> GameLift API operations listed by tasks
 %%
@@ -56,6 +65,8 @@
          create_build/3,
          create_fleet/2,
          create_fleet/3,
+         create_fleet_locations/2,
+         create_fleet_locations/3,
          create_game_server_group/2,
          create_game_server_group/3,
          create_game_session/2,
@@ -82,6 +93,8 @@
          delete_build/3,
          delete_fleet/2,
          delete_fleet/3,
+         delete_fleet_locations/2,
+         delete_fleet_locations/3,
          delete_game_server_group/2,
          delete_game_server_group/3,
          delete_game_session_queue/2,
@@ -112,6 +125,12 @@
          describe_fleet_capacity/3,
          describe_fleet_events/2,
          describe_fleet_events/3,
+         describe_fleet_location_attributes/2,
+         describe_fleet_location_attributes/3,
+         describe_fleet_location_capacity/2,
+         describe_fleet_location_capacity/3,
+         describe_fleet_location_utilization/2,
+         describe_fleet_location_utilization/3,
          describe_fleet_port_settings/2,
          describe_fleet_port_settings/3,
          describe_fleet_utilization/2,
@@ -262,23 +281,14 @@
 %%
 %% Learn more
 %%
-%% Add FlexMatch to a Game Client
+%% Add FlexMatch to a game client
 %%
-%% FlexMatch Events Reference
+%% FlexMatch events (reference)
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `StartMatchmaking'
-%%
-%% </li> <li> `DescribeMatchmaking'
-%%
-%% </li> <li> `StopMatchmaking'
-%%
-%% </li> <li> `AcceptMatch'
-%%
-%% </li> <li> `StartMatchBackfill'
-%%
-%% </li> </ul>
+%% `StartMatchmaking' | `DescribeMatchmaking' | `StopMatchmaking' |
+%% `AcceptMatch' | `StartMatchBackfill' | All APIs by task
 accept_match(Client, Input)
   when is_map(Client), is_map(Input) ->
     accept_match(Client, Input, []).
@@ -286,8 +296,8 @@ accept_match(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AcceptMatch">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Locates an available game server and temporarily reserves it to host
 %% gameplay and players. This operation is called from a game client or
@@ -327,21 +337,11 @@ accept_match(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 claim_game_server(Client, Input)
   when is_map(Client), is_map(Input) ->
     claim_game_server(Client, Input, []).
@@ -369,19 +369,10 @@ claim_game_server(Client, Input, Options)
 %% returned, including an alias ID and an ARN. You can reassign an alias to
 %% another fleet by calling `UpdateAlias'.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 create_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_alias(Client, Input, []).
@@ -402,20 +393,21 @@ create_alias(Client, Input, Options)
 %%
 %% The `CreateBuild' operation can used in the following scenarios:
 %%
-%% <ul> <li> To create a new game build with build files that are in an S3
-%% location under an AWS account that you control. To use this option, you
-%% must first give Amazon GameLift access to the S3 bucket. With permissions
-%% in place, call `CreateBuild' and specify a build name, operating system,
-%% and the S3 storage location of your game build.
+%% <ul> <li> To create a new game build with build files that are in an
+%% Amazon S3 location under an AWS account that you control. To use this
+%% option, you must first give Amazon GameLift access to the Amazon S3
+%% bucket. With permissions in place, call `CreateBuild' and specify a build
+%% name, operating system, and the Amazon S3 storage location of your game
+%% build.
 %%
-%% </li> <li> To directly upload your build files to a GameLift S3 location.
-%% To use this option, first call `CreateBuild' and specify a build name and
-%% operating system. This operation creates a new build resource and also
-%% returns an S3 location with temporary access credentials. Use the
-%% credentials to manually upload your build files to the specified S3
-%% location. For more information, see Uploading Objects in the Amazon S3
-%% Developer Guide. Build files can be uploaded to the GameLift S3 location
-%% once only; that can't be updated.
+%% </li> <li> To directly upload your build files to a GameLift Amazon S3
+%% location. To use this option, first call `CreateBuild' and specify a build
+%% name and operating system. This operation creates a new build resource and
+%% also returns an Amazon S3 location with temporary access credentials. Use
+%% the credentials to manually upload your build files to the specified
+%% Amazon S3 location. For more information, see Uploading Objects in the
+%% Amazon S3 Developer Guide. Build files can be uploaded to the GameLift
+%% Amazon S3 location once only; that can't be updated.
 %%
 %% </li> </ul> If successful, this operation creates a new build resource
 %% with a unique build ID and places it in `INITIALIZED' status. A build must
@@ -427,19 +419,10 @@ create_alias(Client, Input, Options)
 %%
 %% Create a Build with Files in Amazon S3
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 create_build(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_build(Client, Input, []).
@@ -447,64 +430,55 @@ create_build(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateBuild">>, Input, Options).
 
-%% @doc Creates a new fleet to run your game servers.
+%% @doc Creates a fleet of Amazon Elastic Compute Cloud (Amazon EC2)
+%% instances to host your custom game server or Realtime Servers.
 %%
-%% whether they are custom game builds or Realtime Servers with game-specific
-%% script. A fleet is a set of Amazon Elastic Compute Cloud (Amazon EC2)
-%% instances, each of which can host multiple game sessions. When creating a
-%% fleet, you choose the hardware specifications, set some configuration
-%% options, and specify the game server to deploy on the new fleet.
+%% Use this operation to configure the computing resources for your fleet and
+%% provide instructions for running game servers on each instance.
 %%
-%% To create a new fleet, provide the following: (1) a fleet name, (2) an EC2
-%% instance type and fleet type (spot or on-demand), (3) the build ID for
-%% your game build or script ID if using Realtime Servers, and (4) a runtime
-%% configuration, which determines how game servers will run on each instance
-%% in the fleet.
+%% Most GameLift fleets can deploy instances to multiple locations, including
+%% the home Region (where the fleet is created) and an optional set of remote
+%% locations. Fleets that are created in the following AWS Regions support
+%% multiple locations: us-east-1 (N. Virginia), us-west-2 (Oregon),
+%% eu-central-1 (Frankfurt), eu-west-1 (Ireland), ap-southeast-2 (Sydney),
+%% ap-northeast-1 (Tokyo), and ap-northeast-2 (Seoul). Fleets that are
+%% created in other GameLift Regions can deploy instances in the fleet's home
+%% Region only. All fleet instances use the same configuration regardless of
+%% location; however, you can adjust capacity settings and turn auto-scaling
+%% on/off for each location.
 %%
-%% If the `CreateFleet' call is successful, Amazon GameLift performs the
-%% following tasks. You can track the process of a fleet by checking the
-%% fleet status or by monitoring fleet creation events:
+%% To create a fleet, choose the hardware for your instances, specify a game
+%% server build or Realtime script to deploy, and provide a runtime
+%% configuration to direct GameLift how to start and run game servers on each
+%% instance in the fleet. Set permissions for inbound traffic to your game
+%% servers, and enable optional features as needed. When creating a
+%% multi-location fleet, provide a list of additional remote locations.
 %%
-%% <ul> <li> Creates a fleet resource. Status: `NEW'.
+%% If successful, this operation creates a new Fleet resource and places it
+%% in `NEW' status, which prompts GameLift to initiate the fleet creation
+%% workflow. You can track fleet creation by checking fleet status using
+%% `DescribeFleetAttributes' and `DescribeFleetLocationAttributes'/, or by
+%% monitoring fleet creation events using `DescribeFleetEvents'. As soon as
+%% the fleet status changes to `ACTIVE', you can enable automatic scaling for
+%% the fleet with `PutScalingPolicy' and set capacity for the home Region
+%% with `UpdateFleetCapacity'. When the status of each remote location
+%% reaches `ACTIVE', you can set capacity by location using
+%% `UpdateFleetCapacity'.
 %%
-%% </li> <li> Begins writing events to the fleet event log, which can be
-%% accessed in the Amazon GameLift console.
+%% Learn more
 %%
-%% </li> <li> Sets the fleet's target capacity to 1 (desired instances),
-%% which triggers Amazon GameLift to start one new EC2 instance.
+%% Setting up fleets
 %%
-%% </li> <li> Downloads the game build or Realtime script to the new instance
-%% and installs it. Statuses: `DOWNLOADING', `VALIDATING', `BUILDING'.
+%% Debug fleet creation issues
 %%
-%% </li> <li> Starts launching server processes on the instance. If the fleet
-%% is configured to run multiple server processes per instance, Amazon
-%% GameLift staggers each process launch by a few seconds. Status:
-%% `ACTIVATING'.
+%% Multi-location fleets
 %%
-%% </li> <li> Sets the fleet's status to `ACTIVE' as soon as one server
-%% process is ready to host a game session.
+%% Related actions
 %%
-%% </li> </ul> Learn more
-%%
-%% Setting Up Fleets
-%%
-%% Debug Fleet Creation Issues
-%%
-%% Related operations
-%%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleet' | `UpdateFleetCapacity' | `PutScalingPolicy' |
+%% `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetLocationAttributes' | `UpdateFleetAttributes' |
+%% `StopFleetActions' | `DeleteFleet' | All APIs by task
 create_fleet(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_fleet(Client, Input, []).
@@ -512,8 +486,51 @@ create_fleet(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateFleet">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc Adds remote locations to a fleet and begins populating the new
+%% locations with EC2 instances.
+%%
+%% The new instances conform to the fleet's instance type, auto-scaling, and
+%% other configuration settings.
+%%
+%% This operation cannot be used with fleets that don't support remote
+%% locations. Fleets can have multiple locations only if they reside in AWS
+%% Regions that support this feature (see `CreateFleet' for the complete
+%% list) and were created after the feature was released in March 2021.
+%%
+%% To add fleet locations, specify the fleet to be updated and provide a list
+%% of one or more locations.
+%%
+%% If successful, this operation returns the list of added locations with
+%% their status set to `NEW'. GameLift initiates the process of starting an
+%% instance in each added location. You can track the status of each new
+%% location by monitoring location creation events using
+%% `DescribeFleetEvents'. Alternatively, you can poll location status by
+%% calling `DescribeFleetLocationAttributes'. After a location status becomes
+%% `ACTIVE', you can adjust the location's capacity as needed with
+%% `UpdateFleetCapacity'.
+%%
+%% Learn more
+%%
+%% Setting up fleets
+%%
+%% Multi-location fleets
+%%
+%% Related actions
+%%
+%% `CreateFleetLocations' | `DescribeFleetLocationAttributes' |
+%% `DescribeFleetLocationCapacity' | `DescribeFleetLocationUtilization' |
+%% `DescribeFleetAttributes' | `DescribeFleetCapacity' |
+%% `DescribeFleetUtilization' | `UpdateFleetCapacity' | `StopFleetActions' |
+%% `DeleteFleetLocations' | All APIs by task
+create_fleet_locations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_fleet_locations(Client, Input, []).
+create_fleet_locations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateFleetLocations">>, Input, Options).
+
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Creates a GameLift FleetIQ game server group for managing game hosting on
 %% a collection of Amazon EC2 instances for game hosting. This operation
@@ -554,25 +571,13 @@ create_fleet(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 create_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_game_server_group(Client, Input, []).
@@ -580,62 +585,55 @@ create_game_server_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateGameServerGroup">>, Input, Options).
 
-%% @doc Creates a multiplayer game session for players.
+%% @doc Creates a multiplayer game session for players in a specific fleet
+%% location.
 %%
-%% This operation creates a game session record and assigns an available
-%% server process in the specified fleet to host the game session. A fleet
-%% must have an `ACTIVE' status before a game session can be created in it.
+%% This operation prompts an available server process to start a game session
+%% and retrieves connection information for the new game session. As an
+%% alternative, consider using the GameLift game session placement feature
+%% with
 %%
-%% To create a game session, specify either fleet ID or alias ID and indicate
-%% a maximum number of players to allow in the game session. You can also
-%% provide a name and game-specific properties for this game session. If
-%% successful, a `GameSession' object is returned containing the game session
-%% properties and other settings you specified.
+%% with `StartGameSessionPlacement', which uses FleetIQ algorithms and queues
+%% to optimize the placement process.
 %%
-%% Idempotency tokens. You can add a token that uniquely identifies game
-%% session requests. This is useful for ensuring that game session requests
-%% are idempotent. Multiple requests with the same idempotency token are
-%% processed only once; subsequent requests return the original result. All
-%% response values are the same with the exception of game session status,
-%% which may change.
+%% When creating a game session, you specify exactly where you want to place
+%% it and provide a set of game session configuration settings. The fleet
+%% must be in `ACTIVE' status before a game session can be created in it.
 %%
-%% Resource creation limits. If you are creating a game session on a fleet
-%% with a resource creation limit policy in force, then you must specify a
-%% creator ID. Without this ID, Amazon GameLift has no way to evaluate the
-%% policy for this new game session request.
+%% This operation can be used in the following ways:
 %%
-%% Player acceptance policy. By default, newly created game sessions are open
-%% to new players. You can restrict new player access by using
-%% `UpdateGameSession' to change the game session's player session creation
-%% policy.
+%% <ul> <li> To create a game session on an instance in a fleet's home
+%% Region, provide a fleet or alias ID along with your game session
+%% configuration.
 %%
-%% Game session logs. Logs are retained for all active game sessions for 14
-%% days. To access the logs, call `GetGameSessionLogUrl' to download the log
-%% files.
+%% </li> <li> To create a game session on an instance in a fleet's remote
+%% location, provide a fleet or alias ID and a location name, along with your
+%% game session configuration.
 %%
-%% Available in Amazon GameLift Local.
+%% </li> </ul> If successful, a workflow is initiated to start a new game
+%% session. A `GameSession' object is returned containing the game session
+%% configuration and status. When the status is `ACTIVE', game session
+%% connection information is provided and player sessions can be created for
+%% the game session. By default, newly created game sessions are open to new
+%% players. You can restrict new player access by using `UpdateGameSession'
+%% to change the game session's player session creation policy.
 %%
-%% <ul> <li> `CreateGameSession'
+%% Game session logs are retained for all active game sessions for 14 days.
+%% To access the logs, call `GetGameSessionLogUrl' to download the log files.
 %%
-%% </li> <li> `DescribeGameSessions'
+%% Available in GameLift Local.
 %%
-%% </li> <li> `DescribeGameSessionDetails'
+%% Learn more
 %%
-%% </li> <li> `SearchGameSessions'
+%% Start a game session
 %%
-%% </li> <li> `UpdateGameSession'
+%% Related actions
 %%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 create_game_session(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_game_session(Client, Input, []).
@@ -643,58 +641,50 @@ create_game_session(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateGameSession">>, Input, Options).
 
-%% @doc Establishes a new queue for processing requests to place new game
+%% @doc Creates a placement queue that processes requests for new game
 %% sessions.
 %%
-%% A queue identifies where new game sessions can be hosted -- by specifying
-%% a list of destinations (fleets or aliases) -- and how long requests can
-%% wait in the queue before timing out. You can set up a queue to try to
-%% place game sessions on fleets in multiple Regions. To add placement
-%% requests to a queue, call `StartGameSessionPlacement' and reference the
-%% queue name.
+%% A queue uses FleetIQ algorithms to determine the best placement locations
+%% and find an available game server there, then prompts the game server
+%% process to start a new game session.
 %%
-%% Destination order. When processing a request for a game session, Amazon
-%% GameLift tries each destination in order until it finds one with available
-%% resources to host the new game session. A queue's default order is
-%% determined by how destinations are listed. The default order is overridden
-%% when a game session placement request provides player latency information.
-%% Player latency information enables Amazon GameLift to prioritize
-%% destinations where players report the lowest average latency, as a result
-%% placing the new game session where the majority of players will have the
-%% best possible gameplay experience.
+%% A game session queue is configured with a set of destinations (GameLift
+%% fleets or aliases), which determine the locations where the queue can
+%% place new game sessions. These destinations can span multiple fleet types
+%% (Spot and On-Demand), instance types, and AWS Regions. If the queue
+%% includes multi-location fleets, the queue is able to place game sessions
+%% in all of a fleet's remote locations. You can opt to filter out individual
+%% locations if needed.
 %%
-%% Player latency policies. For placement requests containing player latency
-%% information, use player latency policies to protect individual players
-%% from very high latencies. With a latency cap, even when a destination can
-%% deliver a low latency for most players, the game is not placed where any
-%% individual player is reporting latency higher than a policy's maximum. A
-%% queue can have multiple latency policies, which are enforced consecutively
-%% starting with the policy with the lowest latency cap. Use multiple
-%% policies to gradually relax latency controls; for example, you might set a
-%% policy with a low latency cap for the first 60 seconds, a second policy
-%% with a higher cap for the next 60 seconds, etc.
+%% The queue configuration also determines how FleetIQ selects the best
+%% available placement for a new game session. Before searching for an
+%% available game server, FleetIQ first prioritizes the queue's destinations
+%% and locations, with the best placement locations on top. You can set up
+%% the queue to use the FleetIQ default prioritization or provide an
+%% alternate set of priorities.
 %%
-%% To create a new queue, provide a name, timeout value, a list of
-%% destinations and, if desired, a set of latency policies. If successful, a
-%% new queue object is returned.
+%% To create a new queue, provide a name, timeout value, and a list of
+%% destinations. Optionally, specify a sort configuration and/or a filter,
+%% and define a set of latency cap policies. You can also include the ARN for
+%% an Amazon Simple Notification Service (SNS) topic to receive notifications
+%% of game session placement activity. Notifications using SNS or CloudWatch
+%% events is the preferred way to track placement activity.
+%%
+%% If successful, a new `GameSessionQueue' object is returned with an
+%% assigned queue ARN. New game session requests, which are submitted to the
+%% queue with `StartGameSessionPlacement' or `StartMatchmaking', reference a
+%% queue's name or ARN.
 %%
 %% Learn more
 %%
-%% Design a Game Session Queue
+%% Design a game session queue
 %%
-%% Create a Game Session Queue
+%% Create a game session queue
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameSessionQueue'
-%%
-%% </li> <li> `DescribeGameSessionQueues'
-%%
-%% </li> <li> `UpdateGameSessionQueue'
-%%
-%% </li> <li> `DeleteGameSessionQueue'
-%%
-%% </li> </ul>
+%% `CreateGameSessionQueue' | `DescribeGameSessionQueues' |
+%% `UpdateGameSessionQueue' | `DeleteGameSessionQueue' | All APIs by task
 create_game_session_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_game_session_queue(Client, Input, []).
@@ -722,38 +712,24 @@ create_game_session_queue(Client, Input, Options)
 %% starting a game session for the match.
 %%
 %% In addition, you must set up an Amazon Simple Notification Service (SNS)
-%% to receive matchmaking notifications, and provide the topic ARN in the
+%% topic to receive matchmaking notifications. Provide the topic ARN in the
 %% matchmaking configuration. An alternative method, continuously polling
 %% ticket status with `DescribeMatchmaking', is only suitable for games in
 %% development with low matchmaking usage.
 %%
 %% Learn more
 %%
-%% FlexMatch Developer Guide
+%% Design a FlexMatch matchmaker
 %%
-%% Design a FlexMatch Matchmaker
+%% Set up FlexMatch event notification
 %%
-%% Set Up FlexMatch Event Notification
+%% Related actions
 %%
-%% Related operations
-%%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 create_matchmaking_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_matchmaking_configuration(Client, Input, []).
@@ -778,31 +754,19 @@ create_matchmaking_configuration(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% <ul> <li> Build a Rule Set
+%% <ul> <li> Build a rule set
 %%
-%% </li> <li> Design a Matchmaker
+%% </li> <li> Design a matchmaker
 %%
 %% </li> <li> Matchmaking with FlexMatch
 %%
-%% </li> </ul> Related operations
+%% </li> </ul> Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 create_matchmaking_rule_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_matchmaking_rule_set(Client, Input, []).
@@ -810,37 +774,29 @@ create_matchmaking_rule_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateMatchmakingRuleSet">>, Input, Options).
 
-%% @doc Reserves an open player slot in an active game session.
+%% @doc Reserves an open player slot in a game session for a player.
 %%
-%% Before a player can be added, a game session must have an `ACTIVE' status,
-%% have a creation policy of `ALLOW_ALL', and have an open player slot. To
-%% add a group of players to a game session, use `CreatePlayerSessions'. When
-%% the player connects to the game server and references a player session ID,
-%% the game server contacts the Amazon GameLift service to validate the
-%% player reservation and accept the player.
+%% New player sessions can be created in any game session with an open slot
+%% that is in `ACTIVE' status and has a player creation policy of
+%% `ACCEPT_ALL'. You can add a group of players to a game session with
+%% `CreatePlayerSessions'.
 %%
 %% To create a player session, specify a game session ID, player ID, and
-%% optionally a string of player data. If successful, a slot is reserved in
-%% the game session for the player and a new `PlayerSession' object is
-%% returned. Player sessions cannot be updated.
+%% optionally a set of player data.
+%%
+%% If successful, a slot is reserved in the game session for the player and a
+%% new `PlayerSession' object is returned with a player session ID. The
+%% player references the player session ID when sending a connection request
+%% to the game session, and the game server can use it to validate the player
+%% reservation with the GameLift service. Player sessions cannot be updated.
 %%
 %% Available in Amazon GameLift Local.
 %%
-%% <ul> <li> `CreatePlayerSession'
+%% Related actions
 %%
-%% </li> <li> `CreatePlayerSessions'
-%%
-%% </li> <li> `DescribePlayerSessions'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreatePlayerSession' | `CreatePlayerSessions' | `DescribePlayerSessions'
+%% | `StartGameSessionPlacement' | `DescribeGameSessionPlacement' | All APIs
+%% by task
 create_player_session(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_player_session(Client, Input, []).
@@ -850,35 +806,28 @@ create_player_session(Client, Input, Options)
 
 %% @doc Reserves open slots in a game session for a group of players.
 %%
-%% Before players can be added, a game session must have an `ACTIVE' status,
-%% have a creation policy of `ALLOW_ALL', and have an open player slot. To
-%% add a single player to a game session, use `CreatePlayerSession'. When a
-%% player connects to the game server and references a player session ID, the
-%% game server contacts the Amazon GameLift service to validate the player
-%% reservation and accept the player.
+%% New player sessions can be created in any game session with an open slot
+%% that is in `ACTIVE' status and has a player creation policy of
+%% `ACCEPT_ALL'. To add a single player to a game session, use
+%% `CreatePlayerSession'.
 %%
-%% To create player sessions, specify a game session ID, a list of player
-%% IDs, and optionally a set of player data strings. If successful, a slot is
-%% reserved in the game session for each player and a set of new
-%% `PlayerSession' objects is returned. Player sessions cannot be updated.
+%% To create player sessions, specify a game session ID and a list of player
+%% IDs. Optionally, provide a set of player data for each player ID.
+%%
+%% If successful, a slot is reserved in the game session for each player, and
+%% new `PlayerSession' objects are returned with player session IDs. Each
+%% player references their player session ID when sending a connection
+%% request to the game session, and the game server can use it to validate
+%% the player reservation with the GameLift service. Player sessions cannot
+%% be updated.
 %%
 %% Available in Amazon GameLift Local.
 %%
-%% <ul> <li> `CreatePlayerSession'
+%% Related actions
 %%
-%% </li> <li> `CreatePlayerSessions'
-%%
-%% </li> <li> `DescribePlayerSessions'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreatePlayerSession' | `CreatePlayerSessions' | `DescribePlayerSessions'
+%% | `StartGameSessionPlacement' | `DescribeGameSessionPlacement' | All APIs
+%% by task
 create_player_sessions(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_player_sessions(Client, Input, []).
@@ -918,19 +867,10 @@ create_player_sessions(Client, Input, Options)
 %%
 %% Set Up a Role for Amazon GameLift Access
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateScript'
-%%
-%% </li> <li> `ListScripts'
-%%
-%% </li> <li> `DescribeScript'
-%%
-%% </li> <li> `UpdateScript'
-%%
-%% </li> <li> `DeleteScript'
-%%
-%% </li> </ul>
+%% `CreateScript' | `ListScripts' | `DescribeScript' | `UpdateScript' |
+%% `DeleteScript' | All APIs by task
 create_script(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_script(Client, Input, []).
@@ -969,19 +909,12 @@ create_script(Client, Input, Options)
 %% call to `DeleteVpcPeeringAuthorization'. You must create or delete the
 %% peering connection while the authorization is valid.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 create_vpc_peering_authorization(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_vpc_peering_authorization(Client, Input, []).
@@ -1016,19 +949,12 @@ create_vpc_peering_authorization(Client, Input, Options)
 %% `DescribeVpcPeeringConnections', or by monitoring fleet events for success
 %% or failure using `DescribeFleetEvents'.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 create_vpc_peering_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_vpc_peering_connection(Client, Input, []).
@@ -1042,19 +968,10 @@ create_vpc_peering_connection(Client, Input, Options)
 %% access a server process using the deleted alias receive an error. To
 %% delete an alias, specify the alias ID to be deleted.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 delete_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_alias(Client, Input, []).
@@ -1075,19 +992,10 @@ delete_alias(Client, Input, Options)
 %%
 %% Upload a Custom Server Build
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 delete_build(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_build(Client, Input, []).
@@ -1095,38 +1003,32 @@ delete_build(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteBuild">>, Input, Options).
 
-%% @doc Deletes everything related to a fleet.
+%% @doc Deletes all resources and information related a fleet.
 %%
-%% Before deleting a fleet, you must set the fleet's desired capacity to
-%% zero. See `UpdateFleetCapacity'.
+%% Any current fleet instances, including those in remote locations, are shut
+%% down. You don't need to call `DeleteFleetLocations' separately.
 %%
 %% If the fleet being deleted has a VPC peering connection, you first need to
 %% get a valid authorization (good for 24 hours) by calling
 %% `CreateVpcPeeringAuthorization'. You do not need to explicitly delete the
 %% VPC peering connection--this is done as part of the delete fleet process.
 %%
-%% This operation removes the fleet and its resources. Once a fleet is
-%% deleted, you can no longer use any of the resource in that fleet.
+%% To delete a fleet, specify the fleet ID to be terminated. During the
+%% deletion process the fleet status is changed to `DELETING'. When
+%% completed, the status switches to `TERMINATED' and the fleet event
+%% `FLEET_DELETED' is sent.
 %%
 %% Learn more
 %%
 %% Setting up GameLift Fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleetLocations' | `UpdateFleetAttributes' | `UpdateFleetCapacity' |
+%% `UpdateFleetPortSettings' | `UpdateRuntimeConfiguration' |
+%% `StopFleetActions' | `StartFleetActions' | `PutScalingPolicy' |
+%% `DeleteFleet' | `DeleteFleetLocations' | `DeleteScalingPolicy' | All APIs
+%% by task
 delete_fleet(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_fleet(Client, Input, []).
@@ -1134,8 +1036,39 @@ delete_fleet(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteFleet">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc Removes locations from a multi-location fleet.
+%%
+%% When deleting a location, all game server process and all instances that
+%% are still active in the location are shut down.
+%%
+%% To delete fleet locations, identify the fleet ID and provide a list of the
+%% locations to be deleted.
+%%
+%% If successful, GameLift sets the location status to `DELETING', and begins
+%% to shut down existing server processes and terminate instances in each
+%% location being deleted. When completed, the location status changes to
+%% `TERMINATED'.
+%%
+%% Learn more
+%%
+%% Setting up GameLift fleets
+%%
+%% Related actions
+%%
+%% `CreateFleetLocations' | `DescribeFleetLocationAttributes' |
+%% `DescribeFleetLocationCapacity' | `DescribeFleetLocationUtilization' |
+%% `DescribeFleetAttributes' | `DescribeFleetCapacity' |
+%% `DescribeFleetUtilization' | `UpdateFleetCapacity' | `StopFleetActions' |
+%% `DeleteFleetLocations' | All APIs by task
+delete_fleet_locations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_fleet_locations(Client, Input, []).
+delete_fleet_locations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteFleetLocations">>, Input, Options).
+
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Terminates a game server group and permanently deletes the game server
 %% group record. You have several options for how these resources are
@@ -1166,25 +1099,13 @@ delete_fleet(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 delete_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_game_server_group(Client, Input, []).
@@ -1202,17 +1123,10 @@ delete_game_server_group(Client, Input, Options)
 %%
 %% Using Multi-Region Queues
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameSessionQueue'
-%%
-%% </li> <li> `DescribeGameSessionQueues'
-%%
-%% </li> <li> `UpdateGameSessionQueue'
-%%
-%% </li> <li> `DeleteGameSessionQueue'
-%%
-%% </li> </ul>
+%% `CreateGameSessionQueue' | `DescribeGameSessionQueues' |
+%% `UpdateGameSessionQueue' | `DeleteGameSessionQueue' | All APIs by task
 delete_game_session_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_game_session_queue(Client, Input, []).
@@ -1225,25 +1139,13 @@ delete_game_session_queue(Client, Input, Options)
 %% To delete, specify the configuration name. A matchmaking configuration
 %% cannot be deleted if it is being used in any active matchmaking tickets.
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 delete_matchmaking_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_matchmaking_configuration(Client, Input, []).
@@ -1258,27 +1160,15 @@ delete_matchmaking_configuration(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% <ul> <li> Build a Rule Set
+%% <ul> <li> Build a rule set
 %%
-%% </li> </ul> Related operations
+%% </li> </ul> Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 delete_matchmaking_rule_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_matchmaking_rule_set(Client, Input, []).
@@ -1295,27 +1185,12 @@ delete_matchmaking_rule_set(Client, Input, Options)
 %% To temporarily suspend scaling policies, call `StopFleetActions'. This
 %% operation suspends all policies for the fleet.
 %%
-%% <ul> <li> `DescribeFleetCapacity'
+%% Related actions
 %%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> Manage scaling policies:
-%%
-%% <ul> <li> `PutScalingPolicy' (auto-scaling)
-%%
-%% </li> <li> `DescribeScalingPolicies' (auto-scaling)
-%%
-%% </li> <li> `DeleteScalingPolicy' (auto-scaling)
-%%
-%% </li> </ul> </li> <li> Manage fleet actions:
-%%
-%% <ul> <li> `StartFleetActions'
-%%
-%% </li> <li> `StopFleetActions'
-%%
-%% </li> </ul> </li> </ul>
+%% `DescribeFleetCapacity' | `UpdateFleetCapacity' |
+%% `DescribeEC2InstanceLimits' | `PutScalingPolicy' |
+%% `DescribeScalingPolicies' | `DeleteScalingPolicy' | `StopFleetActions' |
+%% `StartFleetActions' | All APIs by task
 delete_scaling_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_scaling_policy(Client, Input, []).
@@ -1339,19 +1214,10 @@ delete_scaling_policy(Client, Input, Options)
 %%
 %% Amazon GameLift Realtime Servers
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateScript'
-%%
-%% </li> <li> `ListScripts'
-%%
-%% </li> <li> `DescribeScript'
-%%
-%% </li> <li> `UpdateScript'
-%%
-%% </li> <li> `DeleteScript'
-%%
-%% </li> </ul>
+%% `CreateScript' | `ListScripts' | `DescribeScript' | `UpdateScript' |
+%% `DeleteScript' | All APIs by task
 delete_script(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_script(Client, Input, []).
@@ -1364,19 +1230,12 @@ delete_script(Client, Input, Options)
 %% If you need to delete an existing VPC peering connection, call
 %% `DeleteVpcPeeringConnection'.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 delete_vpc_peering_authorization(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_vpc_peering_authorization(Client, Input, []).
@@ -1396,19 +1255,12 @@ delete_vpc_peering_authorization(Client, Input, Options)
 %% connection to delete by the connection ID and fleet ID. If successful, the
 %% connection is removed.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 delete_vpc_peering_connection(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_vpc_peering_connection(Client, Input, []).
@@ -1416,8 +1268,8 @@ delete_vpc_peering_connection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteVpcPeeringConnection">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Removes the game server from a game server group. As a result of this
 %% operation, the deregistered game server can no longer be claimed and will
@@ -1431,21 +1283,11 @@ delete_vpc_peering_connection(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 deregister_game_server(Client, Input)
   when is_map(Client), is_map(Input) ->
     deregister_game_server(Client, Input, []).
@@ -1461,19 +1303,10 @@ deregister_game_server(Client, Input, Options)
 %% To get alias properties, specify the alias ID. If successful, the
 %% requested alias record is returned.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 describe_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_alias(Client, Input, []).
@@ -1490,19 +1323,10 @@ describe_alias(Client, Input, Options)
 %%
 %% Upload a Custom Server Build
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 describe_build(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_build(Client, Input, []).
@@ -1510,37 +1334,66 @@ describe_build(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeBuild">>, Input, Options).
 
-%% @doc Retrieves the following information for the specified EC2 instance
-%% type:
+%% @doc The GameLift service limits and current utilization for an AWS Region
+%% or location.
 %%
-%% <ul> <li> Maximum number of instances allowed per AWS account (service
-%% limit).
+%% Instance limits control the number of instances, per instance type, per
+%% location, that your AWS account can use. Learn more at Amazon EC2 Instance
+%% Types. The information returned includes the maximum number of instances
+%% allowed and your account's current usage across all fleets. This
+%% information can affect your ability to scale your GameLift fleets. You can
+%% request a limit increase for your account by using the Service limits page
+%% in the GameLift console.
 %%
-%% </li> <li> Current usage for the AWS account.
+%% Instance limits differ based on whether the instances are deployed in a
+%% fleet's home Region or in a remote location. For remote locations, limits
+%% also differ based on the combination of home Region and remote location.
+%% All requests must specify an AWS Region (either explicitly or as your
+%% default settings). To get the limit for a remote location, you must also
+%% specify the location. For example, the following requests all return
+%% different results:
 %%
-%% </li> </ul> To learn more about the capabilities of each instance type,
-%% see Amazon EC2 Instance Types. Note that the instance types offered may
-%% vary depending on the region.
+%% <ul> <li> Request specifies the Region `ap-northeast-1' with no location.
+%% The result is limits and usage data on all instance types that are
+%% deployed in `us-east-2', by all of the fleets that reside in
+%% `ap-northeast-1'.
+%%
+%% </li> <li> Request specifies the Region `us-east-1' with location
+%% `ca-central-1'. The result is limits and usage data on all instance types
+%% that are deployed in `ca-central-1', by all of the fleets that reside in
+%% `us-east-2'. These limits do not affect fleets in any other Regions that
+%% deploy instances to `ca-central-1'.
+%%
+%% </li> <li> Request specifies the Region `eu-west-1' with location
+%% `ca-central-1'. The result is limits and usage data on all instance types
+%% that are deployed in `ca-central-1', by all of the fleets that reside in
+%% `eu-west-1'.
+%%
+%% </li> </ul> This operation can be used in the following ways:
+%%
+%% <ul> <li> To get limit and usage data for all instance types that are
+%% deployed in an AWS Region by fleets that reside in the same Region:
+%% Specify the Region only. Optionally, specify a single instance type to
+%% retrieve information for.
+%%
+%% </li> <li> To get limit and usage data for all instance types that are
+%% deployed to a remote location by fleets that reside in different AWS
+%% Region: Provide both the AWS Region and the remote location. Optionally,
+%% specify a single instance type to retrieve information for.
+%%
+%% </li> </ul> If successful, an `EC2InstanceLimits' object is returned with
+%% limits and usage data for each requested instance type.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleet' | `UpdateFleetCapacity' | `PutScalingPolicy' |
+%% `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetLocationAttributes' | `UpdateFleetAttributes' |
+%% `StopFleetActions' | `DeleteFleet' | All APIs by task
 describe_ec2_instance_limits(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_ec2_instance_limits(Client, Input, []).
@@ -1548,53 +1401,38 @@ describe_ec2_instance_limits(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEC2InstanceLimits">>, Input, Options).
 
-%% @doc Retrieves core properties, including configuration, status, and
-%% metadata, for a fleet.
+%% @doc Retrieves core fleet-wide properties, including the computing
+%% hardware and deployment configuration for all instances in the fleet.
 %%
-%% To get attributes for one or more fleets, provide a list of fleet IDs or
-%% fleet ARNs. To get attributes for all fleets, do not specify a fleet
-%% identifier. When requesting attributes for multiple fleets, use the
-%% pagination parameters to retrieve results as a set of sequential pages. If
-%% successful, a `FleetAttributes' object is returned for each fleet
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To get attributes for one or more specific fleets, provide a
+%% list of fleet IDs or fleet ARNs.
+%%
+%% </li> <li> To get attributes for all fleets, do not provide a fleet
+%% identifier.
+%%
+%% </li> </ul> When requesting attributes for multiple fleets, use the
+%% pagination parameters to retrieve results as a set of sequential pages.
+%%
+%% If successful, a `FleetAttributes' object is returned for each fleet
 %% requested, unless the fleet identifier is not found.
 %%
-%% Some API operations may limit the number of fleet IDs allowed in one
+%% Some API operations limit the number of fleet IDs that allowed in one
 %% request. If a request exceeds this limit, the request fails and the error
-%% message includes the maximum allowed number.
+%% message contains the maximum allowed number.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_fleet_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_fleet_attributes(Client, Input, []).
@@ -1602,58 +1440,47 @@ describe_fleet_attributes(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeFleetAttributes">>, Input, Options).
 
-%% @doc Retrieves the current capacity statistics for one or more fleets.
+%% @doc Retrieves the resource capacity settings for one or more fleets.
 %%
-%% These statistics present a snapshot of the fleet's instances and provide
-%% insight on current or imminent scaling activity. To get statistics on game
-%% hosting activity in the fleet, see `DescribeFleetUtilization'.
+%% The data returned includes the current fleet capacity (number of EC2
+%% instances), and settings that can control how capacity scaling. For fleets
+%% with remote locations, this operation retrieves data for the fleet's home
+%% Region only. See `DescribeFleetLocationCapacity' to get capacity settings
+%% for a fleet's remote locations.
 %%
-%% You can request capacity for all fleets or specify a list of one or more
-%% fleet identifiers. When requesting multiple fleets, use the pagination
-%% parameters to retrieve results as a set of sequential pages. If
-%% successful, a `FleetCapacity' object is returned for each requested fleet
-%% ID. When a list of fleet IDs is provided, attribute objects are returned
-%% only for fleets that currently exist.
+%% This operation can be used in the following ways:
 %%
-%% Some API operations may limit the number of fleet IDs allowed in one
-%% request. If a request exceeds this limit, the request fails and the error
-%% message includes the maximum allowed.
+%% <ul> <li> To get capacity data for one or more specific fleets, provide a
+%% list of fleet IDs or fleet ARNs.
+%%
+%% </li> <li> To get capacity data for all fleets, do not provide a fleet
+%% identifier.
+%%
+%% </li> </ul> When requesting multiple fleets, use the pagination parameters
+%% to retrieve results as a set of sequential pages.
+%%
+%% If successful, a `FleetCapacity' object is returned for each requested
+%% fleet ID. Each FleetCapacity object includes a `Location' property, which
+%% is set to the fleet's home Region. When a list of fleet IDs is provided,
+%% attribute objects are returned only for fleets that currently exist.
+%%
+%% Some API operations may limit the number of fleet IDs that are allowed in
+%% one request. If a request exceeds this limit, the request fails and the
+%% error message includes the maximum allowed.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% GameLift Metrics for Fleets
+%% GameLift metrics for fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_fleet_capacity(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_fleet_capacity(Client, Input, []).
@@ -1661,46 +1488,30 @@ describe_fleet_capacity(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeFleetCapacity">>, Input, Options).
 
-%% @doc Retrieves entries from the specified fleet's event log.
+%% @doc Retrieves entries from a fleet's event log.
+%%
+%% Fleet events are initiated by changes in status, such as during fleet
+%% creation and termination, changes in capacity, etc. If a fleet has
+%% multiple locations, events are also initiated by changes to status and
+%% capacity in remote locations.
 %%
 %% You can specify a time range to limit the result set. Use the pagination
-%% parameters to retrieve results as a set of sequential pages. If
-%% successful, a collection of event log entries matching the request are
+%% parameters to retrieve results as a set of sequential pages.
+%%
+%% If successful, a collection of event log entries matching the request are
 %% returned.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_fleet_events(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_fleet_events(Client, Input, []).
@@ -1708,51 +1519,142 @@ describe_fleet_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeFleetEvents">>, Input, Options).
 
+%% @doc Retrieves information on a fleet's remote locations, including
+%% life-cycle status and any suspended fleet activity.
+%%
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To get data for specific locations, provide a fleet identifier
+%% and a list of locations. Location data is returned in the order that it is
+%% requested.
+%%
+%% </li> <li> To get data for all locations, provide a fleet identifier only.
+%% Location data is returned in no particular order.
+%%
+%% </li> </ul> When requesting attributes for multiple locations, use the
+%% pagination parameters to retrieve results as a set of sequential pages.
+%%
+%% If successful, a `LocationAttributes' object is returned for each
+%% requested location. If the fleet does not have a requested location, no
+%% information is returned. This operation does not return the home Region.
+%% To get information on a fleet's home Region, call
+%% `DescribeFleetAttributes'.
+%%
+%% Learn more
+%%
+%% Setting up GameLift fleets
+%%
+%% Related actions
+%%
+%% `CreateFleetLocations' | `DescribeFleetLocationAttributes' |
+%% `DescribeFleetLocationCapacity' | `DescribeFleetLocationUtilization' |
+%% `DescribeFleetAttributes' | `DescribeFleetCapacity' |
+%% `DescribeFleetUtilization' | `UpdateFleetCapacity' | `StopFleetActions' |
+%% `DeleteFleetLocations' | All APIs by task
+describe_fleet_location_attributes(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_fleet_location_attributes(Client, Input, []).
+describe_fleet_location_attributes(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFleetLocationAttributes">>, Input, Options).
+
+%% @doc Retrieves the resource capacity settings for a fleet location.
+%%
+%% The data returned includes the current capacity (number of EC2 instances)
+%% and some scaling settings for the requested fleet location. Use this
+%% operation to retrieve capacity information for a fleet's remote location
+%% or home Region (you can also retrieve home Region capacity by calling
+%% `DescribeFleetCapacity').
+%%
+%% To retrieve capacity data, identify a fleet and location.
+%%
+%% If successful, a `FleetCapacity' object is returned for the requested
+%% fleet location.
+%%
+%% Learn more
+%%
+%% Setting up GameLift fleets
+%%
+%% GameLift metrics for fleets
+%%
+%% Related actions
+%%
+%% `CreateFleetLocations' | `DescribeFleetLocationAttributes' |
+%% `DescribeFleetLocationCapacity' | `DescribeFleetLocationUtilization' |
+%% `DescribeFleetAttributes' | `DescribeFleetCapacity' |
+%% `DescribeFleetUtilization' | `UpdateFleetCapacity' | `StopFleetActions' |
+%% `DeleteFleetLocations' | All APIs by task
+describe_fleet_location_capacity(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_fleet_location_capacity(Client, Input, []).
+describe_fleet_location_capacity(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFleetLocationCapacity">>, Input, Options).
+
+%% @doc Retrieves current usage data for a fleet location.
+%%
+%% Utilization data provides a snapshot of current game hosting activity at
+%% the requested location. Use this operation to retrieve utilization
+%% information for a fleet's remote location or home Region (you can also
+%% retrieve home Region utilization by calling `DescribeFleetUtilization').
+%%
+%% To retrieve utilization data, identify a fleet and location.
+%%
+%% If successful, a `FleetUtilization' object is returned for the requested
+%% fleet location.
+%%
+%% Learn more
+%%
+%% Setting up GameLift fleets
+%%
+%% GameLift metrics for fleets
+%%
+%% Related actions
+%%
+%% `CreateFleetLocations' | `DescribeFleetLocationAttributes' |
+%% `DescribeFleetLocationCapacity' | `DescribeFleetLocationUtilization' |
+%% `DescribeFleetAttributes' | `DescribeFleetCapacity' |
+%% `DescribeFleetUtilization' | `UpdateFleetCapacity' | `StopFleetActions' |
+%% `DeleteFleetLocations' | All APIs by task
+describe_fleet_location_utilization(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_fleet_location_utilization(Client, Input, []).
+describe_fleet_location_utilization(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFleetLocationUtilization">>, Input, Options).
+
 %% @doc Retrieves a fleet's inbound connection permissions.
 %%
 %% Connection permissions specify the range of IP addresses and port settings
 %% that incoming traffic can use to access server processes in the fleet.
-%% Game sessions that are running on instances in the fleet use connections
-%% that fall in this range.
+%% Game sessions that are running on instances in the fleet must use
+%% connections that fall in this range.
 %%
-%% To get a fleet's inbound connection permissions, specify the fleet's
-%% unique identifier. If successful, a collection of `IpPermission' objects
-%% is returned for the requested fleet ID. If the requested fleet has been
-%% deleted, the result set is empty.
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To retrieve the inbound connection permissions for a fleet,
+%% identify the fleet's unique identifier.
+%%
+%% </li> <li> To check the status of recent updates to a fleet remote
+%% location, specify the fleet ID and a location. Port setting updates can
+%% take time to propagate across all locations.
+%%
+%% </li> </ul> If successful, a set of `IpPermission' objects is returned for
+%% the requested fleet ID. When a location is specified, a pending status is
+%% included. If the requested fleet has been deleted, the result set is
+%% empty.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_fleet_port_settings(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_fleet_port_settings(Client, Input, []).
@@ -1762,15 +1664,27 @@ describe_fleet_port_settings(Client, Input, Options)
 
 %% @doc Retrieves utilization statistics for one or more fleets.
 %%
-%% These statistics provide insight into how available hosting resources are
-%% currently being used. To get statistics on available hosting resources,
-%% see `DescribeFleetCapacity'.
+%% Utilization data provides a snapshot of how the fleet's hosting resources
+%% are currently being used. For fleets with remote locations, this operation
+%% retrieves data for the fleet's home Region only. See
+%% `DescribeFleetLocationUtilization' to get utilization statistics for a
+%% fleet's remote locations.
 %%
-%% You can request utilization data for all fleets, or specify a list of one
-%% or more fleet IDs. When requesting multiple fleets, use the pagination
-%% parameters to retrieve results as a set of sequential pages. If
-%% successful, a `FleetUtilization' object is returned for each requested
-%% fleet ID, unless the fleet identifier is not found.
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To get utilization data for one or more specific fleets, provide
+%% a list of fleet IDs or fleet ARNs.
+%%
+%% </li> <li> To get utilization data for all fleets, do not provide a fleet
+%% identifier.
+%%
+%% </li> </ul> When requesting multiple fleets, use the pagination parameters
+%% to retrieve results as a set of sequential pages.
+%%
+%% If successful, a `FleetUtilization' object is returned for each requested
+%% fleet ID, unless the fleet identifier is not found. Each fleet utilization
+%% object includes a `Location' property, which is set to the fleet's home
+%% Region.
 %%
 %% Some API operations may limit the number of fleet IDs allowed in one
 %% request. If a request exceeds this limit, the request fails and the error
@@ -1782,35 +1696,13 @@ describe_fleet_port_settings(Client, Input, Options)
 %%
 %% GameLift Metrics for Fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_fleet_utilization(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_fleet_utilization(Client, Input, []).
@@ -1818,8 +1710,8 @@ describe_fleet_utilization(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeFleetUtilization">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Retrieves information for a registered game server. Information includes
 %% game server status, health check info, and the instance that the game
@@ -1832,21 +1724,11 @@ describe_fleet_utilization(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 describe_game_server(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_server(Client, Input, []).
@@ -1854,8 +1736,8 @@ describe_game_server(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGameServer">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Retrieves information on a game server group. This operation returns only
 %% properties related to GameLift FleetIQ. To view or update properties for
@@ -1870,25 +1752,13 @@ describe_game_server(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 describe_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_server_group(Client, Input, []).
@@ -1896,8 +1766,8 @@ describe_game_server_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGameServerGroup">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Retrieves status information about the Amazon EC2 instances associated
 %% with a GameLift FleetIQ game server group. Use this operation to detect
@@ -1921,25 +1791,13 @@ describe_game_server_group(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 describe_game_server_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_server_instances(Client, Input, []).
@@ -1947,41 +1805,48 @@ describe_game_server_instances(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGameServerInstances">>, Input, Options).
 
-%% @doc Retrieves properties, including the protection policy in force, for
-%% one or more game sessions.
+%% @doc Retrieves additional game session properties, including the game
+%% session protection policy in force, a set of one or more game sessions in
+%% a specific fleet location.
 %%
-%% This operation can be used in several ways: (1) provide a `GameSessionId'
-%% or `GameSessionArn' to request details for a specific game session; (2)
-%% provide either a `FleetId' or an `AliasId' to request properties for all
-%% game sessions running on a fleet.
+%% You can optionally filter the results by current game session status.
+%% Alternatively, use `SearchGameSessions' to request a set of active game
+%% sessions that are filtered by certain criteria. To retrieve all game
+%% session properties, use `DescribeGameSessions'.
 %%
-%% To get game session record(s), specify just one of the following: game
-%% session ID, fleet ID, or alias ID. You can filter this request by game
-%% session status. Use the pagination parameters to retrieve results as a set
-%% of sequential pages. If successful, a `GameSessionDetail' object is
-%% returned for each session matching the request.
+%% This operation can be used in the following ways:
 %%
-%% <ul> <li> `CreateGameSession'
+%% <ul> <li> To retrieve details for all game sessions that are currently
+%% running on all locations in a fleet, provide a fleet or alias ID, with an
+%% optional status filter. This approach returns details from the fleet's
+%% home Region and all remote locations.
 %%
-%% </li> <li> `DescribeGameSessions'
+%% </li> <li> To retrieve details for all game sessions that are currently
+%% running on a specific fleet location, provide a fleet or alias ID and a
+%% location name, with optional status filter. The location can be the
+%% fleet's home Region or any remote location.
 %%
-%% </li> <li> `DescribeGameSessionDetails'
+%% </li> <li> To retrieve details for a specific game session, provide the
+%% game session ID. This approach looks for the game session ID in all fleets
+%% that reside in the AWS Region defined in the request.
 %%
-%% </li> <li> `SearchGameSessions'
+%% </li> </ul> Use the pagination parameters to retrieve results as a set of
+%% sequential pages.
 %%
-%% </li> <li> `UpdateGameSession'
+%% If successful, a `GameSessionDetail' object is returned for each game
+%% session that matches the request.
 %%
-%% </li> <li> `GetGameSessionLogUrl'
+%% Learn more
 %%
-%% </li> <li> Game session placements
+%% Find a game session
 %%
-%% <ul> <li> `StartGameSessionPlacement'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 describe_game_session_details(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_session_details(Client, Input, []).
@@ -1989,33 +1854,20 @@ describe_game_session_details(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGameSessionDetails">>, Input, Options).
 
-%% @doc Retrieves properties and current status of a game session placement
-%% request.
+%% @doc Retrieves information, including current status, about a game session
+%% placement request.
 %%
-%% To get game session placement details, specify the placement ID. If
-%% successful, a `GameSessionPlacement' object is returned.
+%% To get game session placement details, specify the placement ID.
 %%
-%% <ul> <li> `CreateGameSession'
+%% If successful, a `GameSessionPlacement' object is returned.
 %%
-%% </li> <li> `DescribeGameSessions'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 describe_game_session_placement(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_session_placement(Client, Input, []).
@@ -2035,17 +1887,10 @@ describe_game_session_placement(Client, Input, Options)
 %%
 %% View Your Queues
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameSessionQueue'
-%%
-%% </li> <li> `DescribeGameSessionQueues'
-%%
-%% </li> <li> `UpdateGameSessionQueue'
-%%
-%% </li> <li> `DeleteGameSessionQueue'
-%%
-%% </li> </ul>
+%% `CreateGameSessionQueue' | `DescribeGameSessionQueues' |
+%% `UpdateGameSessionQueue' | `DeleteGameSessionQueue' | All APIs by task
 describe_game_session_queues(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_session_queues(Client, Input, []).
@@ -2053,42 +1898,49 @@ describe_game_session_queues(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGameSessionQueues">>, Input, Options).
 
-%% @doc Retrieves a set of one or more game sessions.
+%% @doc Retrieves a set of one or more game sessions in a specific fleet
+%% location.
 %%
-%% Request a specific game session or request all game sessions on a fleet.
+%% You can optionally filter the results by current game session status.
 %% Alternatively, use `SearchGameSessions' to request a set of active game
-%% sessions that are filtered by certain criteria. To retrieve protection
-%% policy settings for game sessions, use `DescribeGameSessionDetails'.
+%% sessions that are filtered by certain criteria. To retrieve the protection
+%% policy for game sessions, use `DescribeGameSessionDetails'.
 %%
-%% To get game sessions, specify one of the following: game session ID, fleet
-%% ID, or alias ID. You can filter this request by game session status. Use
-%% the pagination parameters to retrieve results as a set of sequential
-%% pages. If successful, a `GameSession' object is returned for each game
-%% session matching the request.
+%% This operation can be used in the following ways:
 %%
-%% Available in Amazon GameLift Local.
+%% <ul> <li> To retrieve all game sessions that are currently running on all
+%% locations in a fleet, provide a fleet or alias ID, with an optional status
+%% filter. This approach returns all game sessions in the fleet's home Region
+%% and all remote locations.
 %%
-%% <ul> <li> `CreateGameSession'
+%% </li> <li> To retrieve all game sessions that are currently running on a
+%% specific fleet location, provide a fleet or alias ID and a location name,
+%% with optional status filter. The location can be the fleet's home Region
+%% or any remote location.
 %%
-%% </li> <li> `DescribeGameSessions'
+%% </li> <li> To retrieve a specific game session, provide the game session
+%% ID. This approach looks for the game session ID in all fleets that reside
+%% in the AWS Region defined in the request.
 %%
-%% </li> <li> `DescribeGameSessionDetails'
+%% </li> </ul> Use the pagination parameters to retrieve results as a set of
+%% sequential pages.
 %%
-%% </li> <li> `SearchGameSessions'
+%% If successful, a `GameSession' object is returned for each game session
+%% that matches the request.
 %%
-%% </li> <li> `UpdateGameSession'
+%% Available in GameLift Local.
 %%
-%% </li> <li> `GetGameSessionLogUrl'
+%% Learn more
 %%
-%% </li> <li> Game session placements
+%% Find a game session
 %%
-%% <ul> <li> `StartGameSessionPlacement'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 describe_game_sessions(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_game_sessions(Client, Input, []).
@@ -2097,15 +1949,24 @@ describe_game_sessions(Client, Input, Options)
     request(Client, <<"DescribeGameSessions">>, Input, Options).
 
 %% @doc Retrieves information about a fleet's instances, including instance
-%% IDs.
+%% IDs, connection data, and status.
 %%
-%% Use this operation to get details on all instances in the fleet or get
-%% details on one specific instance.
+%% This operation can be used in the following ways:
 %%
-%% To get a specific instance, specify fleet ID and instance ID. To get all
-%% instances in a fleet, specify a fleet ID only. Use the pagination
-%% parameters to retrieve results as a set of sequential pages. If
-%% successful, an `Instance' object is returned for each result.
+%% <ul> <li> To get information on all instances that are deployed to a
+%% fleet's home Region, provide the fleet ID.
+%%
+%% </li> <li> To get information on all instances that are deployed to a
+%% fleet's remote location, provide the fleet ID and location name.
+%%
+%% </li> <li> To get information on a specific instance in a fleet, provide
+%% the fleet ID and instance ID.
+%%
+%% </li> </ul> Use the pagination parameters to retrieve results as a set of
+%% sequential pages.
+%%
+%% If successful, an `Instance' object is returned for each requested
+%% instance. Instances are not returned in any particular order.
 %%
 %% Learn more
 %%
@@ -2113,13 +1974,10 @@ describe_game_sessions(Client, Input, Options)
 %%
 %% Debug Fleet Issues
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `DescribeInstances'
-%%
-%% </li> <li> `GetInstanceAccess'
-%%
-%% </li> </ul>
+%% `DescribeInstances' | `GetInstanceAccess' | `DescribeEC2InstanceLimits' |
+%% All APIs by task
 describe_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_instances(Client, Input, []).
@@ -2147,23 +2005,14 @@ describe_instances(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% Add FlexMatch to a Game Client
+%% Add FlexMatch to a game client
 %%
-%% Set Up FlexMatch Event Notification
+%% Set Up FlexMatch event notification
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `StartMatchmaking'
-%%
-%% </li> <li> `DescribeMatchmaking'
-%%
-%% </li> <li> `StopMatchmaking'
-%%
-%% </li> <li> `AcceptMatch'
-%%
-%% </li> <li> `StartMatchBackfill'
-%%
-%% </li> </ul>
+%% `StartMatchmaking' | `DescribeMatchmaking' | `StopMatchmaking' |
+%% `AcceptMatch' | `StartMatchBackfill' | All APIs by task
 describe_matchmaking(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_matchmaking(Client, Input, []).
@@ -2185,27 +2034,15 @@ describe_matchmaking(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% Setting Up FlexMatch Matchmakers
+%% Setting up FlexMatch matchmakers
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 describe_matchmaking_configurations(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_matchmaking_configurations(Client, Input, []).
@@ -2222,27 +2059,15 @@ describe_matchmaking_configurations(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% <ul> <li> Build a Rule Set
+%% <ul> <li> Build a rule set
 %%
-%% </li> </ul> Related operations
+%% </li> </ul> Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 describe_matchmaking_rule_sets(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_matchmaking_rule_sets(Client, Input, []).
@@ -2252,35 +2077,32 @@ describe_matchmaking_rule_sets(Client, Input, Options)
 
 %% @doc Retrieves properties for one or more player sessions.
 %%
-%% This operation can be used in several ways: (1) provide a
-%% `PlayerSessionId' to request properties for a specific player session; (2)
-%% provide a `GameSessionId' to request properties for all player sessions in
-%% the specified game session; (3) provide a `PlayerId' to request properties
-%% for all player sessions of a specified player.
+%% This action can be used in the following ways:
 %%
-%% To get game session record(s), specify only one of the following: a player
-%% session ID, a game session ID, or a player ID. You can filter this request
-%% by player session status. Use the pagination parameters to retrieve
-%% results as a set of sequential pages. If successful, a `PlayerSession'
-%% object is returned for each session matching the request.
+%% <ul> <li> To retrieve a specific player session, provide the player
+%% session ID only.
+%%
+%% </li> <li> To retrieve all player sessions in a game session, provide the
+%% game session ID only.
+%%
+%% </li> <li> To retrieve all player sessions for a specific player, provide
+%% a player ID only.
+%%
+%% </li> </ul> To request player sessions, specify either a player session
+%% ID, game session ID, or player ID. You can filter this request by player
+%% session status. Use the pagination parameters to retrieve results as a set
+%% of sequential pages.
+%%
+%% If successful, a `PlayerSession' object is returned for each session that
+%% matches the request.
 %%
 %% Available in Amazon GameLift Local.
 %%
-%% <ul> <li> `CreatePlayerSession'
+%% Related actions
 %%
-%% </li> <li> `CreatePlayerSessions'
-%%
-%% </li> <li> `DescribePlayerSessions'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreatePlayerSession' | `CreatePlayerSessions' | `DescribePlayerSessions'
+%% | `StartGameSessionPlacement' | `DescribeGameSessionPlacement' | All APIs
+%% by task
 describe_player_sessions(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_player_sessions(Client, Input, []).
@@ -2290,48 +2112,29 @@ describe_player_sessions(Client, Input, Options)
 
 %% @doc Retrieves a fleet's runtime configuration settings.
 %%
-%% The runtime configuration tells Amazon GameLift which server processes to
-%% run (and how) on each instance in the fleet.
+%% The runtime configuration tells GameLift which server processes to run
+%% (and how) on each instance in the fleet.
 %%
-%% To get a runtime configuration, specify the fleet's unique identifier. If
-%% successful, a `RuntimeConfiguration' object is returned for the requested
-%% fleet. If the requested fleet has been deleted, the result set is empty.
+%% To get the runtime configuration that is currently in forces for a fleet,
+%% provide the fleet ID.
+%%
+%% If successful, a `RuntimeConfiguration' object is returned for the
+%% requested fleet. If the requested fleet has been deleted, the result set
+%% is empty.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Running Multiple Processes on a Fleet
+%% Running multiple processes on a fleet
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> Describe fleets:
-%%
-%% <ul> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `DescribeFleetCapacity'
-%%
-%% </li> <li> `DescribeFleetPortSettings'
-%%
-%% </li> <li> `DescribeFleetUtilization'
-%%
-%% </li> <li> `DescribeRuntimeConfiguration'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> `DescribeFleetEvents'
-%%
-%% </li> </ul> </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `ListFleets' | `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetCapacity' | `DescribeFleetEvents' |
+%% `DescribeFleetLocationAttributes' | `DescribeFleetPortSettings' |
+%% `DescribeFleetUtilization' | `DescribeRuntimeConfiguration' |
+%% `DescribeScalingPolicies' | All APIs by task
 describe_runtime_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_runtime_configuration(Client, Input, []).
@@ -2353,27 +2156,12 @@ describe_runtime_configuration(Client, Input, Options)
 %% policies are in force or suspended, call `DescribeFleetAttributes' and
 %% check the stopped actions.
 %%
-%% <ul> <li> `DescribeFleetCapacity'
+%% Related actions
 %%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> Manage scaling policies:
-%%
-%% <ul> <li> `PutScalingPolicy' (auto-scaling)
-%%
-%% </li> <li> `DescribeScalingPolicies' (auto-scaling)
-%%
-%% </li> <li> `DeleteScalingPolicy' (auto-scaling)
-%%
-%% </li> </ul> </li> <li> Manage fleet actions:
-%%
-%% <ul> <li> `StartFleetActions'
-%%
-%% </li> <li> `StopFleetActions'
-%%
-%% </li> </ul> </li> </ul>
+%% `DescribeFleetCapacity' | `UpdateFleetCapacity' |
+%% `DescribeEC2InstanceLimits' | `PutScalingPolicy' |
+%% `DescribeScalingPolicies' | `DeleteScalingPolicy' | `StopFleetActions' |
+%% `StartFleetActions' | All APIs by task
 describe_scaling_policies(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_scaling_policies(Client, Input, []).
@@ -2390,19 +2178,10 @@ describe_scaling_policies(Client, Input, Options)
 %%
 %% Amazon GameLift Realtime Servers
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateScript'
-%%
-%% </li> <li> `ListScripts'
-%%
-%% </li> <li> `DescribeScript'
-%%
-%% </li> <li> `UpdateScript'
-%%
-%% </li> <li> `DeleteScript'
-%%
-%% </li> </ul>
+%% `CreateScript' | `ListScripts' | `DescribeScript' | `UpdateScript' |
+%% `DeleteScript' | All APIs by task
 describe_script(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_script(Client, Input, []).
@@ -2416,19 +2195,12 @@ describe_script(Client, Input, Options)
 %% This operation returns all VPC peering authorizations and requests for
 %% peering. This includes those initiated and received by this account.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 describe_vpc_peering_authorizations(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_vpc_peering_authorizations(Client, Input, []).
@@ -2448,19 +2220,12 @@ describe_vpc_peering_authorizations(Client, Input, Options)
 %% connections. Active connections identify the IpV4 CIDR block that the VPC
 %% uses to connect.
 %%
-%% <ul> <li> `CreateVpcPeeringAuthorization'
+%% Related actions
 %%
-%% </li> <li> `DescribeVpcPeeringAuthorizations'
-%%
-%% </li> <li> `DeleteVpcPeeringAuthorization'
-%%
-%% </li> <li> `CreateVpcPeeringConnection'
-%%
-%% </li> <li> `DescribeVpcPeeringConnections'
-%%
-%% </li> <li> `DeleteVpcPeeringConnection'
-%%
-%% </li> </ul>
+%% `CreateVpcPeeringAuthorization' | `DescribeVpcPeeringAuthorizations' |
+%% `DeleteVpcPeeringAuthorization' | `CreateVpcPeeringConnection' |
+%% `DescribeVpcPeeringConnections' | `DeleteVpcPeeringConnection' | All APIs
+%% by task
 describe_vpc_peering_connections(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_vpc_peering_connections(Client, Input, []).
@@ -2471,34 +2236,20 @@ describe_vpc_peering_connections(Client, Input, Options)
 %% @doc Retrieves the location of stored game session logs for a specified
 %% game session.
 %%
-%% When a game session is terminated, Amazon GameLift automatically stores
-%% the logs in Amazon S3 and retains them for 14 days. Use this URL to
-%% download the logs.
+%% When a game session is terminated, GameLift automatically stores the logs
+%% in Amazon S3 and retains them for 14 days. Use this URL to download the
+%% logs.
 %%
 %% See the AWS Service Limits page for maximum log file sizes. Log files that
 %% exceed this limit are not saved.
 %%
-%% <ul> <li> `CreateGameSession'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessions'
-%%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 get_game_session_log_url(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_game_session_log_url(Client, Input, []).
@@ -2512,14 +2263,14 @@ get_game_session_log_url(Client, Input, Options)
 %% observing activity in real time.
 %%
 %% To remotely access an instance, you need credentials that match the
-%% operating system of the instance. For a Windows instance, Amazon GameLift
-%% returns a user name and password as strings for use with a Windows Remote
-%% Desktop client. For a Linux instance, Amazon GameLift returns a user name
-%% and RSA private key, also as strings, for use with an SSH client. The
-%% private key must be saved in the proper format to a `.pem' file before
-%% using. If you're making this request using the AWS CLI, saving the secret
-%% can be handled as part of the GetInstanceAccess request, as shown in one
-%% of the examples for this operation.
+%% operating system of the instance. For a Windows instance, GameLift returns
+%% a user name and password as strings for use with a Windows Remote Desktop
+%% client. For a Linux instance, GameLift returns a user name and RSA private
+%% key, also as strings, for use with an SSH client. The private key must be
+%% saved in the proper format to a `.pem' file before using. If you're making
+%% this request using the AWS CLI, saving the secret can be handled as part
+%% of the `GetInstanceAccess' request, as shown in one of the examples for
+%% this operation.
 %%
 %% To request access to a specific instance, specify the IDs of both the
 %% instance and the fleet it belongs to. You can retrieve a fleet's instance
@@ -2533,13 +2284,10 @@ get_game_session_log_url(Client, Input, Options)
 %%
 %% Debug Fleet Issues
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `DescribeInstances'
-%%
-%% </li> <li> `GetInstanceAccess'
-%%
-%% </li> </ul>
+%% `DescribeInstances' | `GetInstanceAccess' | `DescribeEC2InstanceLimits' |
+%% All APIs by task
 get_instance_access(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_instance_access(Client, Input, []).
@@ -2554,19 +2302,10 @@ get_instance_access(Client, Input, Options)
 %%
 %% Returned aliases are not listed in any particular order.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 list_aliases(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_aliases(Client, Input, []).
@@ -2587,19 +2326,10 @@ list_aliases(Client, Input, Options)
 %%
 %% Upload a Custom Server Build
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 list_builds(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_builds(Client, Input, []).
@@ -2607,33 +2337,46 @@ list_builds(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListBuilds">>, Input, Options).
 
-%% @doc Retrieves a collection of fleet resources for this AWS account.
+%% @doc Retrieves a collection of fleet resources in an AWS Region.
 %%
-%% You can filter the result set to find only those fleets that are deployed
-%% with a specific build or script. Use the pagination parameters to retrieve
-%% results in sequential pages.
+%% You can call this operation to get fleets in a previously selected default
+%% Region (see
+%% [https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-region.html]or
+%% specify a Region in your request. You can filter the result set to find
+%% only those fleets that are deployed with a specific build or script. For
+%% fleets that have multiple locations, this operation retrieves fleets based
+%% on their home Region only.
+%%
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To get a list of all fleets in a Region, don't provide a build
+%% or script identifier.
+%%
+%% </li> <li> To get a list of all fleets where a specific custom game build
+%% is deployed, provide the build ID.
+%%
+%% </li> <li> To get a list of all Realtime Servers fleets with a specific
+%% configuration script, provide the script ID.
+%%
+%% </li> </ul> Use the pagination parameters to retrieve results as a set of
+%% sequential pages.
+%%
+%% If successful, a list of fleet IDs that match the request parameters is
+%% returned. A NextToken value is also returned if there are more result
+%% pages to retrieve.
 %%
 %% Fleet resources are not listed in a particular order.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleet' | `UpdateFleetCapacity' | `PutScalingPolicy' |
+%% `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetLocationAttributes' | `UpdateFleetAttributes' |
+%% `StopFleetActions' | `DeleteFleet' | All APIs by task
 list_fleets(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_fleets(Client, Input, []).
@@ -2641,8 +2384,8 @@ list_fleets(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListFleets">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Retrieves information on all game servers groups that exist in the current
 %% AWS account for the selected Region. Use the pagination parameters to
@@ -2652,25 +2395,13 @@ list_fleets(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 list_game_server_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_game_server_groups(Client, Input, []).
@@ -2678,8 +2409,8 @@ list_game_server_groups(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListGameServerGroups">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Retrieves information on all game servers that are currently active in a
 %% specified game server group. You can opt to sort the list by game server
@@ -2690,21 +2421,11 @@ list_game_server_groups(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 list_game_servers(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_game_servers(Client, Input, []).
@@ -2719,19 +2440,10 @@ list_game_servers(Client, Input, Options)
 %%
 %% Amazon GameLift Realtime Servers
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateScript'
-%%
-%% </li> <li> `ListScripts'
-%%
-%% </li> <li> `DescribeScript'
-%%
-%% </li> <li> `UpdateScript'
-%%
-%% </li> <li> `DeleteScript'
-%%
-%% </li> </ul>
+%% `CreateScript' | `ListScripts' | `DescribeScript' | `UpdateScript' |
+%% `DeleteScript' | All APIs by task
 list_scripts(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_scripts(Client, Input, []).
@@ -2768,15 +2480,9 @@ list_scripts(Client, Input, Options)
 %%
 %% AWS Tagging Strategies
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `TagResource'
-%%
-%% </li> <li> `UntagResource'
-%%
-%% </li> <li> `ListTagsForResource'
-%%
-%% </li> </ul>
+%% `TagResource' | `UntagResource' | `ListTagsForResource' | All APIs by task
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -2866,27 +2572,12 @@ list_tags_for_resource(Client, Input, Options)
 %% are temporarily suspended, the new policy will be in force once the fleet
 %% actions are restarted.
 %%
-%% <ul> <li> `DescribeFleetCapacity'
+%% Related actions
 %%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `DescribeEC2InstanceLimits'
-%%
-%% </li> <li> Manage scaling policies:
-%%
-%% <ul> <li> `PutScalingPolicy' (auto-scaling)
-%%
-%% </li> <li> `DescribeScalingPolicies' (auto-scaling)
-%%
-%% </li> <li> `DeleteScalingPolicy' (auto-scaling)
-%%
-%% </li> </ul> </li> <li> Manage fleet actions:
-%%
-%% <ul> <li> `StartFleetActions'
-%%
-%% </li> <li> `StopFleetActions'
-%%
-%% </li> </ul> </li> </ul>
+%% `DescribeFleetCapacity' | `UpdateFleetCapacity' |
+%% `DescribeEC2InstanceLimits' | `PutScalingPolicy' |
+%% `DescribeScalingPolicies' | `DeleteScalingPolicy' | `StopFleetActions' |
+%% `StartFleetActions' | All APIs by task
 put_scaling_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_scaling_policy(Client, Input, []).
@@ -2894,8 +2585,8 @@ put_scaling_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutScalingPolicy">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Creates a new game server resource and notifies GameLift FleetIQ that the
 %% game server is ready to host gameplay and players. This operation is
@@ -2919,21 +2610,11 @@ put_scaling_policy(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 register_game_server(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_game_server(Client, Input, []).
@@ -2954,19 +2635,10 @@ register_game_server(Client, Input, Options)
 %%
 %% Create a Build with Files in S3
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 request_upload_credentials(Client, Input)
   when is_map(Client), is_map(Input) ->
     request_upload_credentials(Client, Input, []).
@@ -2976,19 +2648,10 @@ request_upload_credentials(Client, Input, Options)
 
 %% @doc Retrieves the fleet ID that an alias is currently pointing to.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 resolve_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     resolve_alias(Client, Input, []).
@@ -2996,8 +2659,8 @@ resolve_alias(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ResolveAlias">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Reinstates activity on a game server group after it has been suspended. A
 %% game server group might be suspended by the`SuspendGameServerGroup'
@@ -3016,25 +2679,13 @@ resolve_alias(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 resume_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     resume_game_server_group(Client, Input, []).
@@ -3043,7 +2694,32 @@ resume_game_server_group(Client, Input, Options)
     request(Client, <<"ResumeGameServerGroup">>, Input, Options).
 
 %% @doc Retrieves all active game sessions that match a set of search
-%% criteria and sorts them in a specified order.
+%% criteria and sorts them into a specified order.
+%%
+%% When searching for game sessions, you specify exactly where you want to
+%% search and provide a search filter expression, a sort expression, or both.
+%% A search request can search only one fleet, but it can search all of a
+%% fleet's locations.
+%%
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To search all game sessions that are currently running on all
+%% locations in a fleet, provide a fleet or alias ID. This approach returns
+%% game sessions in the fleet's home Region and all remote locations that fit
+%% the search criteria.
+%%
+%% </li> <li> To search all game sessions that are currently running on a
+%% specific fleet location, provide a fleet or alias ID and a location name.
+%% For location, you can specify a fleet's home Region or any remote
+%% location.
+%%
+%% </li> </ul> Use the pagination parameters to retrieve results as a set of
+%% sequential pages.
+%%
+%% If successful, a `GameSession' object is returned for each game session
+%% that matches the request. Search finds game sessions that are in `ACTIVE'
+%% status only. To retrieve information on game sessions in other statuses,
+%% use `DescribeGameSessions'.
 %%
 %% You can search or sort by the following game session attributes:
 %%
@@ -3086,39 +2762,13 @@ resume_game_server_group(Client, Input, Options)
 %% to refresh search results often, and handle sessions that fill up before a
 %% player can join.
 %%
-%% To search or sort, specify either a fleet ID or an alias ID, and provide a
-%% search filter expression, a sort expression, or both. If successful, a
-%% collection of `GameSession' objects matching the request is returned. Use
-%% the pagination parameters to retrieve results as a set of sequential
-%% pages.
+%% Related actions
 %%
-%% You can search for game sessions one fleet at a time only. To find game
-%% sessions across multiple fleets, you must search each fleet separately and
-%% combine the results. This search feature finds only game sessions that are
-%% in `ACTIVE' status. To locate games in statuses other than active, use
-%% `DescribeGameSessionDetails'.
-%%
-%% <ul> <li> `CreateGameSession'
-%%
-%% </li> <li> `DescribeGameSessions'
-%%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 search_game_sessions(Client, Input)
   when is_map(Client), is_map(Input) ->
     search_game_sessions(Client, Input, []).
@@ -3126,38 +2776,38 @@ search_game_sessions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SearchGameSessions">>, Input, Options).
 
-%% @doc Resumes activity on a fleet that was suspended with
-%% `StopFleetActions'.
+%% @doc Resumes certain types of activity on fleet instances that were
+%% suspended with `StopFleetActions'.
 %%
-%% Currently, this operation is used to restart a fleet's auto-scaling
-%% activity.
+%% For multi-location fleets, fleet actions are managed separately for each
+%% location. Currently, this operation is used to restart a fleet's
+%% auto-scaling activity.
 %%
-%% To start fleet actions, specify the fleet ID and the type of actions to
-%% restart. When auto-scaling fleet actions are restarted, Amazon GameLift
-%% once again initiates scaling events as triggered by the fleet's scaling
-%% policies. If actions on the fleet were never stopped, this operation will
-%% have no effect. You can view a fleet's stopped actions using
-%% `DescribeFleetAttributes'.
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To restart actions on instances in the fleet's home Region,
+%% provide a fleet ID and the type of actions to resume.
+%%
+%% </li> <li> To restart actions on instances in one of the fleet's remote
+%% locations, provide a fleet ID, a location name, and the type of actions to
+%% resume.
+%%
+%% </li> </ul> If successful, GameLift once again initiates scaling events as
+%% triggered by the fleet's scaling policies. If actions on the fleet
+%% location were never stopped, this operation will have no effect. You can
+%% view a fleet's stopped actions using `DescribeFleetAttributes' or
+%% `DescribeFleetLocationAttributes'.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleet' | `UpdateFleetCapacity' | `PutScalingPolicy' |
+%% `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetLocationAttributes' | `UpdateFleetAttributes' |
+%% `StopFleetActions' | `DeleteFleet' | All APIs by task
 start_fleet_actions(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_fleet_actions(Client, Input, []).
@@ -3212,27 +2862,13 @@ start_fleet_actions(Client, Input, Options)
 %% session ARN and Region are referenced. If the placement request times out,
 %% you can resubmit the request or retry it with a different queue.
 %%
-%% <ul> <li> `CreateGameSession'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessions'
-%%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 start_game_session_placement(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_game_session_placement(Client, Input, []).
@@ -3240,51 +2876,50 @@ start_game_session_placement(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartGameSessionPlacement">>, Input, Options).
 
-%% @doc Finds new players to fill open slots in an existing game session.
+%% @doc Finds new players to fill open slots in currently running game
+%% sessions.
 %%
-%% This operation can be used to add players to matched games that start with
-%% fewer than the maximum number of players or to replace players when they
-%% drop out. By backfilling with the same matchmaker used to create the
-%% original match, you ensure that new players meet the match criteria and
-%% maintain a consistent experience throughout the game session. You can
-%% backfill a match anytime after a game session has been created.
+%% The backfill match process is essentially identical to the process of
+%% forming new matches. Backfill requests use the same matchmaker that was
+%% used to make the original match, and they provide matchmaking data for all
+%% players currently in the game session. FlexMatch uses this information to
+%% select new players so that backfilled match continues to meet the original
+%% match requirements.
 %%
-%% To request a match backfill, specify a unique ticket ID, the existing game
-%% session's ARN, a matchmaking configuration, and a set of data that
-%% describes all current players in the game session. If successful, a match
-%% backfill ticket is created and returned with status set to QUEUED. The
-%% ticket is placed in the matchmaker's ticket pool and processed. Track the
-%% status of the ticket to respond as needed.
+%% When using FlexMatch with GameLift managed hosting, you can request a
+%% backfill match from a client service by calling this operation with a
+%% `GameSession' identifier. You also have the option of making backfill
+%% requests directly from your game server. In response to a request,
+%% FlexMatch creates player sessions for the new players, updates the
+%% `GameSession' resource, and sends updated matchmaking data to the game
+%% server. You can request a backfill match at any point after a game session
+%% is started. Each game session can have only one active backfill request at
+%% a time; a subsequent request automatically replaces the earlier request.
 %%
-%% The process of finding backfill matches is essentially identical to the
-%% initial matchmaking process. The matchmaker searches the pool and groups
-%% tickets together to form potential matches, allowing only one backfill
-%% ticket per potential match. Once the a match is formed, the matchmaker
-%% creates player sessions for the new players. All tickets in the match are
-%% updated with the game session's connection information, and the
-%% `GameSession' object is updated to include matchmaker data on the new
-%% players. For more detail on how match backfill requests are processed, see
-%% How Amazon GameLift FlexMatch Works.
+%% When using FlexMatch as a standalone component, request a backfill match
+%% by calling this operation without a game session identifier. As with newly
+%% formed matches, matchmaking results are returned in a matchmaking event so
+%% that your game can update the game session that is being backfilled.
+%%
+%% To request a backfill match, specify a unique ticket ID, the original
+%% matchmaking configuration, and matchmaking data for all current players in
+%% the game session being backfilled. Optionally, specify the `GameSession'
+%% ARN. If successful, a match backfill ticket is created and returned with
+%% status set to QUEUED. Track the status of backfill tickets using the same
+%% method for tracking tickets for new matches.
 %%
 %% Learn more
 %%
-%% Backfill Existing Games with FlexMatch
+%% Backfill existing games with FlexMatch
 %%
-%% How GameLift FlexMatch Works
+%% Matchmaking events (reference)
 %%
-%% Related operations
+%% How GameLift FlexMatch works
 %%
-%% <ul> <li> `StartMatchmaking'
+%% Related actions
 %%
-%% </li> <li> `DescribeMatchmaking'
-%%
-%% </li> <li> `StopMatchmaking'
-%%
-%% </li> <li> `AcceptMatch'
-%%
-%% </li> <li> `StartMatchBackfill'
-%%
-%% </li> </ul>
+%% `StartMatchmaking' | `DescribeMatchmaking' | `StopMatchmaking' |
+%% `AcceptMatch' | `StartMatchBackfill' | All APIs by task
 start_match_backfill(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_match_backfill(Client, Input, []).
@@ -3295,50 +2930,38 @@ start_match_backfill(Client, Input, Options)
 %% @doc Uses FlexMatch to create a game match for a group of players based on
 %% custom matchmaking rules.
 %%
-%% If you're also using GameLift hosting, a new game session is started for
-%% the matched players. Each matchmaking request identifies one or more
-%% players to find a match for, and specifies the type of match to build,
-%% including the team configuration and the rules for an acceptable match.
-%% When a matchmaking request identifies a group of players who want to play
-%% together, FlexMatch finds additional players to fill the match. Match
-%% type, rules, and other features are defined in a
-%% `MatchmakingConfiguration'.
+%% With games that use GameLift managed hosting, this operation also triggers
+%% GameLift to find hosting resources and start a new game session for the
+%% new match. Each matchmaking request includes information on one or more
+%% players and specifies the FlexMatch matchmaker to use. When a request is
+%% for multiple players, FlexMatch attempts to build a match that includes
+%% all players in the request, placing them in the same team and finding
+%% additional players as needed to fill the match.
 %%
 %% To start matchmaking, provide a unique ticket ID, specify a matchmaking
-%% configuration, and include the players to be matched. For each player, you
-%% must also include the player attribute values that are required by the
-%% matchmaking configuration (in the rule set). If successful, a matchmaking
-%% ticket is returned with status set to `QUEUED'.
+%% configuration, and include the players to be matched. You must also
+%% include any player attributes that are required by the matchmaking
+%% configuration's rule set. If successful, a matchmaking ticket is returned
+%% with status set to `QUEUED'.
 %%
-%% Track the status of the ticket to respond as needed. If you're also using
-%% GameLift hosting, a successfully completed ticket contains game session
-%% connection information. Ticket status updates are tracked using event
-%% notification through Amazon Simple Notification Service (SNS), which is
-%% defined in the matchmaking configuration.
+%% Track matchmaking events to respond as needed and acquire game session
+%% connection information for successfully completed matches. Ticket status
+%% updates are tracked using event notification through Amazon Simple
+%% Notification Service (SNS), which is defined in the matchmaking
+%% configuration.
 %%
 %% Learn more
 %%
-%% Add FlexMatch to a Game Client
+%% Add FlexMatch to a game client
 %%
-%% Set Up FlexMatch Event Notification
+%% Set Up FlexMatch event notification
 %%
-%% FlexMatch Integration Roadmap
+%% How GameLift FlexMatch works
 %%
-%% How GameLift FlexMatch Works
+%% Related actions
 %%
-%% Related operations
-%%
-%% <ul> <li> `StartMatchmaking'
-%%
-%% </li> <li> `DescribeMatchmaking'
-%%
-%% </li> <li> `StopMatchmaking'
-%%
-%% </li> <li> `AcceptMatch'
-%%
-%% </li> <li> `StartMatchBackfill'
-%%
-%% </li> </ul>
+%% `StartMatchmaking' | `DescribeMatchmaking' | `StopMatchmaking' |
+%% `AcceptMatch' | `StartMatchBackfill' | All APIs by task
 start_matchmaking(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_matchmaking(Client, Input, []).
@@ -3346,38 +2969,42 @@ start_matchmaking(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartMatchmaking">>, Input, Options).
 
-%% @doc Suspends activity on a fleet.
+%% @doc Suspends certain types of activity in a fleet location.
 %%
-%% Currently, this operation is used to stop a fleet's auto-scaling activity.
-%% It is used to temporarily stop triggering scaling events. The policies can
-%% be retained and auto-scaling activity can be restarted using
-%% `StartFleetActions'. You can view a fleet's stopped actions using
-%% `DescribeFleetAttributes'.
+%% Currently, this operation is used to stop auto-scaling activity. For
+%% multi-location fleets, fleet actions are managed separately for each
+%% location.
 %%
-%% To stop fleet actions, specify the fleet ID and the type of actions to
-%% suspend. When auto-scaling fleet actions are stopped, Amazon GameLift no
-%% longer initiates scaling events except in response to manual changes using
-%% `UpdateFleetCapacity'.
+%% Stopping fleet actions has several potential purposes. It allows you to
+%% temporarily stop auto-scaling activity but retain your scaling policies
+%% for use in the future. For multi-location fleets, you can set up
+%% fleet-wide auto-scaling, and then opt out of it for certain locations.
+%%
+%% This operation can be used in the following ways:
+%%
+%% <ul> <li> To stop actions on instances in the fleet's home Region, provide
+%% a fleet ID and the type of actions to suspend.
+%%
+%% </li> <li> To stop actions on instances in one of the fleet's remote
+%% locations, provide a fleet ID, a location name, and the type of actions to
+%% suspend.
+%%
+%% </li> </ul> If successful, GameLift no longer initiates scaling events
+%% except in response to manual changes using `UpdateFleetCapacity'. You can
+%% view a fleet's stopped actions using `DescribeFleetAttributes' or
+%% `DescribeFleetLocationAttributes'. Suspended activity can be restarted
+%% using `StartFleetActions'.
 %%
 %% Learn more
 %%
 %% Setting up GameLift Fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleet' | `UpdateFleetCapacity' | `PutScalingPolicy' |
+%% `DescribeEC2InstanceLimits' | `DescribeFleetAttributes' |
+%% `DescribeFleetLocationAttributes' | `UpdateFleetAttributes' |
+%% `StopFleetActions' | `DeleteFleet' | All APIs by task
 stop_fleet_actions(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_fleet_actions(Client, Input, []).
@@ -3390,27 +3017,13 @@ stop_fleet_actions(Client, Input, Options)
 %% To stop a placement, provide the placement ID values. If successful, the
 %% placement is moved to `CANCELLED' status.
 %%
-%% <ul> <li> `CreateGameSession'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessions'
-%%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 stop_game_session_placement(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_game_session_placement(Client, Input, []).
@@ -3436,21 +3049,12 @@ stop_game_session_placement(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% Add FlexMatch to a Game Client
+%% Add FlexMatch to a game client
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `StartMatchmaking'
-%%
-%% </li> <li> `DescribeMatchmaking'
-%%
-%% </li> <li> `StopMatchmaking'
-%%
-%% </li> <li> `AcceptMatch'
-%%
-%% </li> <li> `StartMatchBackfill'
-%%
-%% </li> </ul>
+%% `StartMatchmaking' | `DescribeMatchmaking' | `StopMatchmaking' |
+%% `AcceptMatch' | `StartMatchBackfill' | All APIs by task
 stop_matchmaking(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_matchmaking(Client, Input, []).
@@ -3458,8 +3062,8 @@ stop_matchmaking(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StopMatchmaking">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Temporarily stops activity on a game server group without terminating
 %% instances or the game server group. You can restart activity by calling
@@ -3484,25 +3088,13 @@ stop_matchmaking(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 suspend_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     suspend_game_server_group(Client, Input, []).
@@ -3543,15 +3135,9 @@ suspend_game_server_group(Client, Input, Options)
 %%
 %% AWS Tagging Strategies
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `TagResource'
-%%
-%% </li> <li> `UntagResource'
-%%
-%% </li> <li> `ListTagsForResource'
-%%
-%% </li> </ul>
+%% `TagResource' | `UntagResource' | `ListTagsForResource' | All APIs by task
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -3590,15 +3176,9 @@ tag_resource(Client, Input, Options)
 %%
 %% AWS Tagging Strategies
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `TagResource'
-%%
-%% </li> <li> `UntagResource'
-%%
-%% </li> <li> `ListTagsForResource'
-%%
-%% </li> </ul>
+%% `TagResource' | `UntagResource' | `ListTagsForResource' | All APIs by task
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
@@ -3613,19 +3193,10 @@ untag_resource(Client, Input, Options)
 %% an updated routing strategy. If successful, the updated alias record is
 %% returned.
 %%
-%% <ul> <li> `CreateAlias'
+%% Related actions
 %%
-%% </li> <li> `ListAliases'
-%%
-%% </li> <li> `DescribeAlias'
-%%
-%% </li> <li> `UpdateAlias'
-%%
-%% </li> <li> `DeleteAlias'
-%%
-%% </li> <li> `ResolveAlias'
-%%
-%% </li> </ul>
+%% `CreateAlias' | `ListAliases' | `DescribeAlias' | `UpdateAlias' |
+%% `DeleteAlias' | `ResolveAlias' | All APIs by task
 update_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_alias(Client, Input, []).
@@ -3644,19 +3215,10 @@ update_alias(Client, Input, Options)
 %%
 %% Upload a Custom Server Build
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateBuild'
-%%
-%% </li> <li> `ListBuilds'
-%%
-%% </li> <li> `DescribeBuild'
-%%
-%% </li> <li> `UpdateBuild'
-%%
-%% </li> <li> `DeleteBuild'
-%%
-%% </li> </ul>
+%% `CreateBuild' | `ListBuilds' | `DescribeBuild' | `UpdateBuild' |
+%% `DeleteBuild' | All APIs by task
 update_build(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_build(Client, Input, []).
@@ -3664,40 +3226,25 @@ update_build(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateBuild">>, Input, Options).
 
-%% @doc Updates fleet properties, including name and description, for a
-%% fleet.
+%% @doc Updates a fleet's mutable attributes, including game session
+%% protection and resource creation limits.
 %%
-%% To update metadata, specify the fleet ID and the property values that you
-%% want to change. If successful, the fleet ID for the updated fleet is
-%% returned.
+%% To update fleet attributes, specify the fleet ID and the property values
+%% that you want to change.
+%%
+%% If successful, an updated `FleetAttributes' object is returned.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> Update fleets:
-%%
-%% <ul> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `UpdateFleetPortSettings'
-%%
-%% </li> <li> `UpdateRuntimeConfiguration'
-%%
-%% </li> </ul> </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleetLocations' | `UpdateFleetAttributes' | `UpdateFleetCapacity' |
+%% `UpdateFleetPortSettings' | `UpdateRuntimeConfiguration' |
+%% `StopFleetActions' | `StartFleetActions' | `PutScalingPolicy' |
+%% `DeleteFleet' | `DeleteFleetLocations' | `DeleteScalingPolicy' | All APIs
+%% by task
 update_fleet_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_fleet_attributes(Client, Input, []).
@@ -3707,52 +3254,53 @@ update_fleet_attributes(Client, Input, Options)
 
 %% @doc Updates capacity settings for a fleet.
 %%
-%% Use this operation to specify the number of EC2 instances (hosts) that you
-%% want this fleet to contain. Before calling this operation, you may want to
-%% call `DescribeEC2InstanceLimits' to get the maximum capacity based on the
-%% fleet's EC2 instance type.
+%% For fleets with multiple locations, use this operation to manage capacity
+%% settings in each location individually. Fleet capacity determines the
+%% number of game sessions and players that can be hosted based on the fleet
+%% configuration. Use this operation to set the following fleet capacity
+%% properties:
 %%
-%% Specify minimum and maximum number of instances. Amazon GameLift will not
-%% change fleet capacity to values fall outside of this range. This is
-%% particularly important when using auto-scaling (see `PutScalingPolicy') to
-%% allow capacity to adjust based on player demand while imposing limits on
-%% automatic adjustments.
+%% <ul> <li> Minimum/maximum size: Set hard limits on fleet capacity.
+%% GameLift cannot set the fleet's capacity to a value outside of this range,
+%% whether the capacity is changed manually or through automatic scaling.
 %%
-%% To update fleet capacity, specify the fleet ID and the number of instances
-%% you want the fleet to host. If successful, Amazon GameLift starts or
-%% terminates instances so that the fleet's active instance count matches the
-%% desired instance count. You can view a fleet's current capacity
-%% information by calling `DescribeFleetCapacity'. If the desired instance
-%% count is higher than the instance type's limit, the "Limit Exceeded"
-%% exception occurs.
+%% </li> <li> Desired capacity: Manually set the number of EC2 instances to
+%% be maintained in a fleet location. Before changing a fleet's desired
+%% capacity, you may want to call `DescribeEC2InstanceLimits' to get the
+%% maximum capacity of the fleet's EC2 instance type. Alternatively, consider
+%% using automatic scaling to adjust capacity based on player demand.
+%%
+%% </li> </ul> This operation can be used in the following ways:
+%%
+%% <ul> <li> To update capacity for a fleet's home Region, or if the fleet
+%% has no remote locations, omit the `Location' parameter. The fleet must be
+%% in `ACTIVE' status.
+%%
+%% </li> <li> To update capacity for a fleet's remote location, include the
+%% `Location' parameter set to the location to be updated. The location must
+%% be in `ACTIVE' status.
+%%
+%% </li> </ul> If successful, capacity settings are updated immediately. In
+%% response a change in desired capacity, GameLift initiates steps to start
+%% new instances or terminate existing instances in the requested fleet
+%% location. This continues until the location's active instance count
+%% matches the new desired instance count. You can track a fleet's current
+%% capacity by calling `DescribeFleetCapacity' or
+%% `DescribeFleetLocationCapacity'. If the requested desired instance count
+%% is higher than the instance type's limit, the `LimitExceeded' exception
+%% occurs.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Scaling fleet capacity
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> Update fleets:
-%%
-%% <ul> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `UpdateFleetPortSettings'
-%%
-%% </li> <li> `UpdateRuntimeConfiguration'
-%%
-%% </li> </ul> </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleetLocations' | `UpdateFleetAttributes' | `UpdateFleetCapacity' |
+%% `UpdateFleetPortSettings' | `UpdateRuntimeConfiguration' |
+%% `StopFleetActions' | `StartFleetActions' | `PutScalingPolicy' |
+%% `DeleteFleet' | `DeleteFleetLocations' | `DeleteScalingPolicy' | All APIs
+%% by task
 update_fleet_capacity(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_fleet_capacity(Client, Input, []).
@@ -3760,42 +3308,31 @@ update_fleet_capacity(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateFleetCapacity">>, Input, Options).
 
-%% @doc Updates port settings for a fleet.
+%% @doc Updates permissions that allow inbound traffic to connect to game
+%% sessions that are being hosted on instances in the fleet.
 %%
-%% To update settings, specify the fleet ID to be updated and list the
-%% permissions you want to update. List the permissions you want to add in
+%% To update settings, specify the fleet ID to be updated and specify the
+%% changes to be made. List the permissions you want to add in
 %% `InboundPermissionAuthorizations', and permissions you want to remove in
 %% `InboundPermissionRevocations'. Permissions to be removed must match
-%% existing fleet permissions. If successful, the fleet ID for the updated
-%% fleet is returned.
+%% existing fleet permissions.
+%%
+%% If successful, the fleet ID for the updated fleet is returned. For fleets
+%% with remote locations, port setting updates can take time to propagate
+%% across all locations. You can check the status of updates in each location
+%% by calling `DescribeFleetPortSettings' with a location name.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> Update fleets:
-%%
-%% <ul> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `UpdateFleetPortSettings'
-%%
-%% </li> <li> `UpdateRuntimeConfiguration'
-%%
-%% </li> </ul> </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleetLocations' | `UpdateFleetAttributes' | `UpdateFleetCapacity' |
+%% `UpdateFleetPortSettings' | `UpdateRuntimeConfiguration' |
+%% `StopFleetActions' | `StartFleetActions' | `PutScalingPolicy' |
+%% `DeleteFleet' | `DeleteFleetLocations' | `DeleteScalingPolicy' | All APIs
+%% by task
 update_fleet_port_settings(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_fleet_port_settings(Client, Input, []).
@@ -3803,8 +3340,8 @@ update_fleet_port_settings(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateFleetPortSettings">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Updates information about a registered game server to help GameLift
 %% FleetIQ to track game server availability. This operation is called by a
@@ -3835,21 +3372,11 @@ update_fleet_port_settings(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `RegisterGameServer'
-%%
-%% </li> <li> `ListGameServers'
-%%
-%% </li> <li> `ClaimGameServer'
-%%
-%% </li> <li> `DescribeGameServer'
-%%
-%% </li> <li> `UpdateGameServer'
-%%
-%% </li> <li> `DeregisterGameServer'
-%%
-%% </li> </ul>
+%% `RegisterGameServer' | `ListGameServers' | `ClaimGameServer' |
+%% `DescribeGameServer' | `UpdateGameServer' | `DeregisterGameServer' | All
+%% APIs by task
 update_game_server(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_game_server(Client, Input, []).
@@ -3857,8 +3384,8 @@ update_game_server(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateGameServer">>, Input, Options).
 
-%% @doc This operation is used with the Amazon GameLift FleetIQ solution and
-%% game server groups.
+%% @doc This operation is used with the GameLift FleetIQ solution and game
+%% server groups.
 %%
 %% Updates GameLift FleetIQ-specific properties for a game server group. Many
 %% Auto Scaling group properties are updated on the Auto Scaling group
@@ -3875,25 +3402,13 @@ update_game_server(Client, Input, Options)
 %%
 %% GameLift FleetIQ Guide
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameServerGroup'
-%%
-%% </li> <li> `ListGameServerGroups'
-%%
-%% </li> <li> `DescribeGameServerGroup'
-%%
-%% </li> <li> `UpdateGameServerGroup'
-%%
-%% </li> <li> `DeleteGameServerGroup'
-%%
-%% </li> <li> `ResumeGameServerGroup'
-%%
-%% </li> <li> `SuspendGameServerGroup'
-%%
-%% </li> <li> `DescribeGameServerInstances'
-%%
-%% </li> </ul>
+%% `CreateGameServerGroup' | `ListGameServerGroups' |
+%% `DescribeGameServerGroup' | `UpdateGameServerGroup' |
+%% `DeleteGameServerGroup' | `ResumeGameServerGroup' |
+%% `SuspendGameServerGroup' | `DescribeGameServerInstances' | All APIs by
+%% task
 update_game_server_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_game_server_group(Client, Input, []).
@@ -3901,36 +3416,20 @@ update_game_server_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateGameServerGroup">>, Input, Options).
 
-%% @doc Updates game session properties.
+%% @doc Updates the mutable properties of a game session.
 %%
-%% This includes the session name, maximum player count, protection policy,
-%% which controls whether or not an active game session can be terminated
-%% during a scale-down event, and the player session creation policy, which
-%% controls whether or not new players can join the session. To update a game
-%% session, specify the game session ID and the values you want to change. If
-%% successful, an updated `GameSession' object is returned.
+%% To update a game session, specify the game session ID and the values you
+%% want to change.
 %%
-%% <ul> <li> `CreateGameSession'
+%% If successful, the updated `GameSession' object is returned.
 %%
-%% </li> <li> `DescribeGameSessions'
+%% Related actions
 %%
-%% </li> <li> `DescribeGameSessionDetails'
-%%
-%% </li> <li> `SearchGameSessions'
-%%
-%% </li> <li> `UpdateGameSession'
-%%
-%% </li> <li> `GetGameSessionLogUrl'
-%%
-%% </li> <li> Game session placements
-%%
-%% <ul> <li> `StartGameSessionPlacement'
-%%
-%% </li> <li> `DescribeGameSessionPlacement'
-%%
-%% </li> <li> `StopGameSessionPlacement'
-%%
-%% </li> </ul> </li> </ul>
+%% `CreateGameSession' | `DescribeGameSessions' |
+%% `DescribeGameSessionDetails' | `SearchGameSessions' | `UpdateGameSession'
+%% | `GetGameSessionLogUrl' | `StartGameSessionPlacement' |
+%% `DescribeGameSessionPlacement' | `StopGameSessionPlacement' | All APIs by
+%% task
 update_game_session(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_game_session(Client, Input, []).
@@ -3938,8 +3437,8 @@ update_game_session(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateGameSession">>, Input, Options).
 
-%% @doc Updates settings for a game session queue, which determines how new
-%% game session requests in the queue are processed.
+%% @doc Updates the configuration of a game session queue, which determines
+%% how the queue processes new game session requests.
 %%
 %% To update settings, specify the queue name to be updated and provide the
 %% new settings. When updating destinations, provide a complete list of
@@ -3949,17 +3448,10 @@ update_game_session(Client, Input, Options)
 %%
 %% Using Multi-Region Queues
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateGameSessionQueue'
-%%
-%% </li> <li> `DescribeGameSessionQueues'
-%%
-%% </li> <li> `UpdateGameSessionQueue'
-%%
-%% </li> <li> `DeleteGameSessionQueue'
-%%
-%% </li> </ul>
+%% `CreateGameSessionQueue' | `DescribeGameSessionQueues' |
+%% `UpdateGameSessionQueue' | `DeleteGameSessionQueue' | All APIs by task
 update_game_session_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_game_session_queue(Client, Input, []).
@@ -3975,27 +3467,15 @@ update_game_session_queue(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% Design a FlexMatch Matchmaker
+%% Design a FlexMatch matchmaker
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 update_matchmaking_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_matchmaking_configuration(Client, Input, []).
@@ -4004,50 +3484,34 @@ update_matchmaking_configuration(Client, Input, Options)
     request(Client, <<"UpdateMatchmakingConfiguration">>, Input, Options).
 
 %% @doc Updates the current runtime configuration for the specified fleet,
-%% which tells Amazon GameLift how to launch server processes on instances in
+%% which tells GameLift how to launch server processes on all instances in
 %% the fleet.
 %%
 %% You can update a fleet's runtime configuration at any time after the fleet
-%% is created; it does not need to be in an `ACTIVE' status.
+%% is created; it does not need to be in `ACTIVE' status.
 %%
 %% To update runtime configuration, specify the fleet ID and provide a
-%% `RuntimeConfiguration' object with an updated set of server process
+%% `RuntimeConfiguration' with an updated set of server process
 %% configurations.
 %%
-%% Each instance in a Amazon GameLift fleet checks regularly for an updated
-%% runtime configuration and changes how it launches server processes to
-%% comply with the latest version. Existing server processes are not affected
-%% by the update; runtime configuration changes are applied gradually as
-%% existing processes shut down and new processes are launched during Amazon
-%% GameLift's normal process recycling activity.
+%% If successful, the fleet's runtime configuration settings are updated.
+%% Each instance in the fleet regularly checks for and retrieves updated
+%% runtime configurations. Instances immediately begin complying with the new
+%% configuration by launching new server processes or not replacing existing
+%% processes when they shut down. Updating a fleet's runtime configuration
+%% never affects existing server processes.
 %%
 %% Learn more
 %%
-%% Setting up GameLift Fleets
+%% Setting up GameLift fleets
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateFleet'
-%%
-%% </li> <li> `ListFleets'
-%%
-%% </li> <li> `DeleteFleet'
-%%
-%% </li> <li> `DescribeFleetAttributes'
-%%
-%% </li> <li> Update fleets:
-%%
-%% <ul> <li> `UpdateFleetAttributes'
-%%
-%% </li> <li> `UpdateFleetCapacity'
-%%
-%% </li> <li> `UpdateFleetPortSettings'
-%%
-%% </li> <li> `UpdateRuntimeConfiguration'
-%%
-%% </li> </ul> </li> <li> `StartFleetActions' or `StopFleetActions'
-%%
-%% </li> </ul>
+%% `CreateFleetLocations' | `UpdateFleetAttributes' | `UpdateFleetCapacity' |
+%% `UpdateFleetPortSettings' | `UpdateRuntimeConfiguration' |
+%% `StopFleetActions' | `StartFleetActions' | `PutScalingPolicy' |
+%% `DeleteFleet' | `DeleteFleetLocations' | `DeleteScalingPolicy' | All APIs
+%% by task
 update_runtime_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_runtime_configuration(Client, Input, []).
@@ -4074,19 +3538,10 @@ update_runtime_configuration(Client, Input, Options)
 %%
 %% Amazon GameLift Realtime Servers
 %%
-%% Related operations
+%% Related actions
 %%
-%% <ul> <li> `CreateScript'
-%%
-%% </li> <li> `ListScripts'
-%%
-%% </li> <li> `DescribeScript'
-%%
-%% </li> <li> `UpdateScript'
-%%
-%% </li> <li> `DeleteScript'
-%%
-%% </li> </ul>
+%% `CreateScript' | `ListScripts' | `DescribeScript' | `UpdateScript' |
+%% `DeleteScript' | All APIs by task
 update_script(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_script(Client, Input, []).
@@ -4102,27 +3557,15 @@ update_script(Client, Input, Options)
 %%
 %% Learn more
 %%
-%% <ul> <li> Build a Rule Set
+%% <ul> <li> Build a rule set
 %%
-%% </li> </ul> Related operations
+%% </li> </ul> Related actions
 %%
-%% <ul> <li> `CreateMatchmakingConfiguration'
-%%
-%% </li> <li> `DescribeMatchmakingConfigurations'
-%%
-%% </li> <li> `UpdateMatchmakingConfiguration'
-%%
-%% </li> <li> `DeleteMatchmakingConfiguration'
-%%
-%% </li> <li> `CreateMatchmakingRuleSet'
-%%
-%% </li> <li> `DescribeMatchmakingRuleSets'
-%%
-%% </li> <li> `ValidateMatchmakingRuleSet'
-%%
-%% </li> <li> `DeleteMatchmakingRuleSet'
-%%
-%% </li> </ul>
+%% `CreateMatchmakingConfiguration' | `DescribeMatchmakingConfigurations' |
+%% `UpdateMatchmakingConfiguration' | `DeleteMatchmakingConfiguration' |
+%% `CreateMatchmakingRuleSet' | `DescribeMatchmakingRuleSets' |
+%% `ValidateMatchmakingRuleSet' | `DeleteMatchmakingRuleSet' | All APIs by
+%% task
 validate_matchmaking_rule_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     validate_matchmaking_rule_set(Client, Input, []).

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -1772,6 +1772,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_glue.erl
+++ b/src/aws_glue.erl
@@ -1,9 +1,9 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Glue
+%% @doc Glue
 %%
-%% Defines the public endpoint for the AWS Glue service.
+%% Defines the public endpoint for the Glue service.
 -module(aws_glue).
 
 -export([batch_create_partition/2,
@@ -16,6 +16,8 @@
          batch_delete_table/3,
          batch_delete_table_version/2,
          batch_delete_table_version/3,
+         batch_get_blueprints/2,
+         batch_get_blueprints/3,
          batch_get_crawlers/2,
          batch_get_crawlers/3,
          batch_get_dev_endpoints/2,
@@ -36,6 +38,8 @@
          cancel_ml_task_run/3,
          check_schema_version_validity/2,
          check_schema_version_validity/3,
+         create_blueprint/2,
+         create_blueprint/3,
          create_classifier/2,
          create_classifier/3,
          create_connection/2,
@@ -70,6 +74,8 @@
          create_user_defined_function/3,
          create_workflow/2,
          create_workflow/3,
+         delete_blueprint/2,
+         delete_blueprint/3,
          delete_classifier/2,
          delete_classifier/3,
          delete_column_statistics_for_partition/2,
@@ -112,6 +118,12 @@
          delete_user_defined_function/3,
          delete_workflow/2,
          delete_workflow/3,
+         get_blueprint/2,
+         get_blueprint/3,
+         get_blueprint_run/2,
+         get_blueprint_run/3,
+         get_blueprint_runs/2,
+         get_blueprint_runs/3,
          get_catalog_import_status/2,
          get_catalog_import_status/3,
          get_classifier/2,
@@ -218,6 +230,8 @@
          get_workflow_runs/3,
          import_catalog_to_glue/2,
          import_catalog_to_glue/3,
+         list_blueprints/2,
+         list_blueprints/3,
          list_crawlers/2,
          list_crawlers/3,
          list_dev_endpoints/2,
@@ -256,6 +270,8 @@
          resume_workflow_run/3,
          search_tables/2,
          search_tables/3,
+         start_blueprint_run/2,
+         start_blueprint_run/3,
          start_crawler/2,
          start_crawler/3,
          start_crawler_schedule/2,
@@ -286,6 +302,8 @@
          tag_resource/3,
          untag_resource/2,
          untag_resource/3,
+         update_blueprint/2,
+         update_blueprint/3,
          update_classifier/2,
          update_classifier/3,
          update_column_statistics_for_partition/2,
@@ -354,7 +372,7 @@ batch_delete_partition(Client, Input, Options)
 %% @doc Deletes multiple tables at once.
 %%
 %% After completing this operation, you no longer have access to the table
-%% versions and partitions that belong to the deleted table. AWS Glue deletes
+%% versions and partitions that belong to the deleted table. Glue deletes
 %% these "orphaned" resources asynchronously in a timely manner, at the
 %% discretion of the service.
 %%
@@ -376,6 +394,14 @@ batch_delete_table_version(Client, Input)
 batch_delete_table_version(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchDeleteTableVersion">>, Input, Options).
+
+%% @doc Retrieves information about a list of blueprints.
+batch_get_blueprints(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_get_blueprints(Client, Input, []).
+batch_get_blueprints(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchGetBlueprints">>, Input, Options).
 
 %% @doc Returns a list of resource metadata for a given list of crawler
 %% names.
@@ -472,10 +498,10 @@ batch_update_partition(Client, Input, Options)
 
 %% @doc Cancels (stops) a task run.
 %%
-%% Machine learning task runs are asynchronous tasks that AWS Glue runs on
-%% your behalf as part of various machine learning workflows. You can cancel
-%% a machine learning task run at any time by calling `CancelMLTaskRun' with
-%% a task run's parent transform's `TransformID' and the task run's
+%% Machine learning task runs are asynchronous tasks that Glue runs on your
+%% behalf as part of various machine learning workflows. You can cancel a
+%% machine learning task run at any time by calling `CancelMLTaskRun' with a
+%% task run's parent transform's `TransformID' and the task run's
 %% `TaskRunId'.
 cancel_ml_task_run(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -495,6 +521,14 @@ check_schema_version_validity(Client, Input)
 check_schema_version_validity(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CheckSchemaVersionValidity">>, Input, Options).
+
+%% @doc Registers a blueprint with Glue.
+create_blueprint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_blueprint(Client, Input, []).
+create_blueprint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBlueprint">>, Input, Options).
 
 %% @doc Creates a classifier in the user's account.
 %%
@@ -551,7 +585,7 @@ create_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateJob">>, Input, Options).
 
-%% @doc Creates an AWS Glue machine learning transform.
+%% @doc Creates an Glue machine learning transform.
 %%
 %% This operation creates the transform and all the necessary parameters to
 %% train it.
@@ -561,10 +595,10 @@ create_job(Client, Input, Options)
 %% data. You can provide an optional `Description', in addition to the
 %% parameters that you want to use for your algorithm.
 %%
-%% You must also specify certain parameters for the tasks that AWS Glue runs
-%% on your behalf as part of learning from your data and creating a
-%% high-quality machine learning transform. These parameters include `Role',
-%% and optionally, `AllocatedCapacity', `Timeout', and `MaxRetries'. For more
+%% You must also specify certain parameters for the tasks that Glue runs on
+%% your behalf as part of learning from your data and creating a high-quality
+%% machine learning transform. These parameters include `Role', and
+%% optionally, `AllocatedCapacity', `Timeout', and `MaxRetries'. For more
 %% information, see Jobs.
 create_ml_transform(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -631,9 +665,9 @@ create_script(Client, Input, Options)
 %% @doc Creates a new security configuration.
 %%
 %% A security configuration is a set of security properties that can be used
-%% by AWS Glue. You can use a security configuration to encrypt data at rest.
-%% For information about using security configurations in AWS Glue, see
-%% Encrypting Data Written by Crawlers, Jobs, and Development Endpoints.
+%% by Glue. You can use a security configuration to encrypt data at rest. For
+%% information about using security configurations in Glue, see Encrypting
+%% Data Written by Crawlers, Jobs, and Development Endpoints.
 create_security_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_security_configuration(Client, Input, []).
@@ -673,6 +707,14 @@ create_workflow(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateWorkflow">>, Input, Options).
 
+%% @doc Deletes an existing blueprint.
+delete_blueprint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_blueprint(Client, Input, []).
+delete_blueprint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBlueprint">>, Input, Options).
+
 %% @doc Removes a classifier from the Data Catalog.
 delete_classifier(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -711,8 +753,8 @@ delete_connection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteConnection">>, Input, Options).
 
-%% @doc Removes a specified crawler from the AWS Glue Data Catalog, unless
-%% the crawler state is `RUNNING'.
+%% @doc Removes a specified crawler from the Glue Data Catalog, unless the
+%% crawler state is `RUNNING'.
 delete_crawler(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_crawler(Client, Input, []).
@@ -724,9 +766,9 @@ delete_crawler(Client, Input, Options)
 %%
 %% After completing this operation, you no longer have access to the tables
 %% (and all table versions and partitions that might belong to the tables)
-%% and the user-defined functions in the deleted database. AWS Glue deletes
-%% these "orphaned" resources asynchronously in a timely manner, at the
-%% discretion of the service.
+%% and the user-defined functions in the deleted database. Glue deletes these
+%% "orphaned" resources asynchronously in a timely manner, at the discretion
+%% of the service.
 %%
 %% To ensure the immediate deletion of all related resources, before calling
 %% `DeleteDatabase', use `DeleteTableVersion' or `BatchDeleteTableVersion',
@@ -758,15 +800,14 @@ delete_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteJob">>, Input, Options).
 
-%% @doc Deletes an AWS Glue machine learning transform.
+%% @doc Deletes an Glue machine learning transform.
 %%
 %% Machine learning transforms are a special type of transform that use
 %% machine learning to learn the details of the transformation to be
 %% performed by learning from examples provided by humans. These
-%% transformations are then saved by AWS Glue. If you no longer need a
-%% transform, you can delete it by calling `DeleteMLTransforms'. However, any
-%% AWS Glue jobs that still reference the deleted transform will no longer
-%% succeed.
+%% transformations are then saved by Glue. If you no longer need a transform,
+%% you can delete it by calling `DeleteMLTransforms'. However, any Glue jobs
+%% that still reference the deleted transform will no longer succeed.
 delete_ml_transform(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_ml_transform(Client, Input, []).
@@ -793,7 +834,7 @@ delete_partition_index(Client, Input, Options)
 %% @doc Delete the entire registry including schema and all of its versions.
 %%
 %% To get the status of the delete operation, you can call the `GetRegistry'
-%% API after the asynchronous call. Deleting a registry will disable all
+%% API after the asynchronous call. Deleting a registry will deactivate all
 %% online operations for the registry such as the `UpdateRegistry',
 %% `CreateSchema', `UpdateSchema', and `RegisterSchemaVersion' APIs.
 delete_registry(Client, Input)
@@ -815,8 +856,8 @@ delete_resource_policy(Client, Input, Options)
 %% its versions.
 %%
 %% To get the status of the delete operation, you can call `GetSchema' API
-%% after the asynchronous call. Deleting a registry will disable all online
-%% operations for the schema, such as the `GetSchemaByDefinition', and
+%% after the asynchronous call. Deleting a registry will deactivate all
+%% online operations for the schema, such as the `GetSchemaByDefinition', and
 %% `RegisterSchemaVersion' APIs.
 delete_schema(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -863,7 +904,7 @@ delete_security_configuration(Client, Input, Options)
 %% @doc Removes a table definition from the Data Catalog.
 %%
 %% After completing this operation, you no longer have access to the table
-%% versions and partitions that belong to the deleted table. AWS Glue deletes
+%% versions and partitions that belong to the deleted table. Glue deletes
 %% these "orphaned" resources asynchronously in a timely manner, at the
 %% discretion of the service.
 %%
@@ -911,6 +952,30 @@ delete_workflow(Client, Input)
 delete_workflow(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteWorkflow">>, Input, Options).
+
+%% @doc Retrieves the details of a blueprint.
+get_blueprint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_blueprint(Client, Input, []).
+get_blueprint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBlueprint">>, Input, Options).
+
+%% @doc Retrieves the details of a blueprint run.
+get_blueprint_run(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_blueprint_run(Client, Input, []).
+get_blueprint_run(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBlueprintRun">>, Input, Options).
+
+%% @doc Retrieves the details of blueprint runs for a specified blueprint.
+get_blueprint_runs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_blueprint_runs(Client, Input, []).
+get_blueprint_runs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBlueprintRuns">>, Input, Options).
 
 %% @doc Retrieves the status of a migration operation.
 get_catalog_import_status(Client, Input)
@@ -1033,9 +1098,9 @@ get_dataflow_graph(Client, Input, Options)
 %% @doc Retrieves information about a specified development endpoint.
 %%
 %% When you create a development endpoint in a virtual private cloud (VPC),
-%% AWS Glue returns only a private IP address, and the public IP address
-%% field is not populated. When you create a non-VPC development endpoint,
-%% AWS Glue returns only a public IP address.
+%% Glue returns only a private IP address, and the public IP address field is
+%% not populated. When you create a non-VPC development endpoint, Glue
+%% returns only a public IP address.
 get_dev_endpoint(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_dev_endpoint(Client, Input, []).
@@ -1046,8 +1111,8 @@ get_dev_endpoint(Client, Input, Options)
 %% @doc Retrieves all the development endpoints in this AWS account.
 %%
 %% When you create a development endpoint in a virtual private cloud (VPC),
-%% AWS Glue returns only a private IP address and the public IP address field
-%% is not populated. When you create a non-VPC development endpoint, AWS Glue
+%% Glue returns only a private IP address and the public IP address field is
+%% not populated. When you create a non-VPC development endpoint, Glue
 %% returns only a public IP address.
 get_dev_endpoints(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1106,10 +1171,10 @@ get_mapping(Client, Input, Options)
 
 %% @doc Gets details for a specific task run on a machine learning transform.
 %%
-%% Machine learning task runs are asynchronous tasks that AWS Glue runs on
-%% your behalf as part of various machine learning workflows. You can check
-%% the stats of any task run by calling `GetMLTaskRun' with the `TaskRunID'
-%% and its parent transform's `TransformID'.
+%% Machine learning task runs are asynchronous tasks that Glue runs on your
+%% behalf as part of various machine learning workflows. You can check the
+%% stats of any task run by calling `GetMLTaskRun' with the `TaskRunID' and
+%% its parent transform's `TransformID'.
 get_ml_task_run(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ml_task_run(Client, Input, []).
@@ -1119,8 +1184,8 @@ get_ml_task_run(Client, Input, Options)
 
 %% @doc Gets a list of runs for a machine learning transform.
 %%
-%% Machine learning task runs are asynchronous tasks that AWS Glue runs on
-%% your behalf as part of various machine learning workflows. You can get a
+%% Machine learning task runs are asynchronous tasks that Glue runs on your
+%% behalf as part of various machine learning workflows. You can get a
 %% sortable, filterable list of machine learning task runs by calling
 %% `GetMLTaskRuns' with their parent transform's `TransformID' and other
 %% optional parameters as documented in this section.
@@ -1133,14 +1198,14 @@ get_ml_task_runs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetMLTaskRuns">>, Input, Options).
 
-%% @doc Gets an AWS Glue machine learning transform artifact and all its
+%% @doc Gets an Glue machine learning transform artifact and all its
 %% corresponding metadata.
 %%
 %% Machine learning transforms are a special type of transform that use
 %% machine learning to learn the details of the transformation to be
 %% performed by learning from examples provided by humans. These
-%% transformations are then saved by AWS Glue. You can retrieve their
-%% metadata by calling `GetMLTransform'.
+%% transformations are then saved by Glue. You can retrieve their metadata by
+%% calling `GetMLTransform'.
 get_ml_transform(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ml_transform(Client, Input, []).
@@ -1148,13 +1213,13 @@ get_ml_transform(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetMLTransform">>, Input, Options).
 
-%% @doc Gets a sortable, filterable list of existing AWS Glue machine
-%% learning transforms.
+%% @doc Gets a sortable, filterable list of existing Glue machine learning
+%% transforms.
 %%
 %% Machine learning transforms are a special type of transform that use
 %% machine learning to learn the details of the transformation to be
 %% performed by learning from examples provided by humans. These
-%% transformations are then saved by AWS Glue, and you can retrieve their
+%% transformations are then saved by Glue, and you can retrieve their
 %% metadata by calling `GetMLTransforms'.
 get_ml_transforms(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1203,12 +1268,13 @@ get_registry(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetRegistry">>, Input, Options).
 
-%% @doc Retrieves the security configurations for the resource policies set
-%% on individual resources, and also the account-level policy.
+%% @doc Retrieves the resource policies set on individual resources by
+%% Resource Access Manager during cross-account permission grants.
 %%
-%% This operation also returns the Data Catalog resource policy. However, if
-%% you enabled metadata encryption in Data Catalog settings, and you do not
-%% have permission on the AWS KMS key, the operation can't return the Data
+%% Also retrieves the Data Catalog resource policy.
+%%
+%% If you enabled metadata encryption in Data Catalog settings, and you do
+%% not have permission on the KMS key, the operation can't return the Data
 %% Catalog resource policy.
 get_resource_policies(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1393,7 +1459,7 @@ get_workflow_runs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetWorkflowRuns">>, Input, Options).
 
-%% @doc Imports an existing Amazon Athena Data Catalog to AWS Glue
+%% @doc Imports an existing Amazon Athena Data Catalog to Glue.
 import_catalog_to_glue(Client, Input)
   when is_map(Client), is_map(Input) ->
     import_catalog_to_glue(Client, Input, []).
@@ -1401,8 +1467,16 @@ import_catalog_to_glue(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ImportCatalogToGlue">>, Input, Options).
 
-%% @doc Retrieves the names of all crawler resources in this AWS account, or
-%% the resources with the specified tag.
+%% @doc Lists all the blueprint names in an account.
+list_blueprints(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_blueprints(Client, Input, []).
+list_blueprints(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListBlueprints">>, Input, Options).
+
+%% @doc Retrieves the names of all crawler resources in this Amazon Web
+%% Services account, or the resources with the specified tag.
 %%
 %% This operation allows you to see which resources are available in your
 %% account, and their names.
@@ -1418,8 +1492,8 @@ list_crawlers(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListCrawlers">>, Input, Options).
 
-%% @doc Retrieves the names of all `DevEndpoint' resources in this AWS
-%% account, or the resources with the specified tag.
+%% @doc Retrieves the names of all `DevEndpoint' resources in this Amazon Web
+%% Services account, or the resources with the specified tag.
 %%
 %% This operation allows you to see which resources are available in your
 %% account, and their names.
@@ -1435,8 +1509,8 @@ list_dev_endpoints(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListDevEndpoints">>, Input, Options).
 
-%% @doc Retrieves the names of all job resources in this AWS account, or the
-%% resources with the specified tag.
+%% @doc Retrieves the names of all job resources in this Amazon Web Services
+%% account, or the resources with the specified tag.
 %%
 %% This operation allows you to see which resources are available in your
 %% account, and their names.
@@ -1452,9 +1526,9 @@ list_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListJobs">>, Input, Options).
 
-%% @doc Retrieves a sortable, filterable list of existing AWS Glue machine
-%% learning transforms in this AWS account, or the resources with the
-%% specified tag.
+%% @doc Retrieves a sortable, filterable list of existing Glue machine
+%% learning transforms in this Amazon Web Services account, or the resources
+%% with the specified tag.
 %%
 %% This operation takes the optional `Tags' field, which you can use as a
 %% filter of the responses so that tagged resources can be retrieved as a
@@ -1505,8 +1579,8 @@ list_schemas(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListSchemas">>, Input, Options).
 
-%% @doc Retrieves the names of all trigger resources in this AWS account, or
-%% the resources with the specified tag.
+%% @doc Retrieves the names of all trigger resources in this Amazon Web
+%% Services account, or the resources with the specified tag.
 %%
 %% This operation allows you to see which resources are available in your
 %% account, and their names.
@@ -1650,6 +1724,14 @@ search_tables(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SearchTables">>, Input, Options).
 
+%% @doc Starts a new run of the specified blueprint.
+start_blueprint_run(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_blueprint_run(Client, Input, []).
+start_blueprint_run(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartBlueprintRun">>, Input, Options).
+
 %% @doc Starts a crawl using the specified crawler, regardless of what is
 %% scheduled.
 %%
@@ -1698,7 +1780,7 @@ start_export_labels_task_run(Client, Input, Options)
 %% and that ultimately results in improving the quality of your machine
 %% learning transform.
 %%
-%% After the `StartMLLabelingSetGenerationTaskRun' finishes, AWS Glue machine
+%% After the `StartMLLabelingSetGenerationTaskRun' finishes, Glue machine
 %% learning will have generated a series of questions for humans to answer.
 %% (Answering these questions is often called 'labeling' in the machine
 %% learning workflows). In the case of the `FindMatches' transform, these
@@ -1736,9 +1818,9 @@ start_job_run(Client, Input, Options)
 
 %% @doc Starts a task to estimate the quality of the transform.
 %%
-%% When you provide label sets as examples of truth, AWS Glue machine
-%% learning uses some of those examples to learn from them. The rest of the
-%% labels are used as a test to estimate quality.
+%% When you provide label sets as examples of truth, Glue machine learning
+%% uses some of those examples to learn from them. The rest of the labels are
+%% used as a test to estimate quality.
 %%
 %% Returns a unique identifier for the run. You can call `GetMLTaskRun' to
 %% get more information about the stats of the `EvaluationTaskRun'.
@@ -1753,9 +1835,8 @@ start_ml_evaluation_task_run(Client, Input, Options)
 %% transform to improve the transform's quality by generating label sets and
 %% adding labels.
 %%
-%% When the `StartMLLabelingSetGenerationTaskRun' finishes, AWS Glue will
-%% have generated a "labeling set" or a set of questions for humans to
-%% answer.
+%% When the `StartMLLabelingSetGenerationTaskRun' finishes, Glue will have
+%% generated a "labeling set" or a set of questions for humans to answer.
 %%
 %% In the case of the `FindMatches' transform, these questions are of the
 %% form, “What is the correct way to group these rows together into groups
@@ -1826,9 +1907,9 @@ stop_workflow_run(Client, Input, Options)
 
 %% @doc Adds tags to a resource.
 %%
-%% A tag is a label you can assign to an AWS resource. In AWS Glue, you can
-%% tag only certain resources. For information about what resources you can
-%% tag, see AWS Tags in AWS Glue.
+%% A tag is a label you can assign to an Amazon Web Services resource. In
+%% Glue, you can tag only certain resources. For information about what
+%% resources you can tag, see Amazon Web Services Tags in Glue.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -1843,6 +1924,14 @@ untag_resource(Client, Input)
 untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates a registered blueprint.
+update_blueprint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_blueprint(Client, Input, []).
+update_blueprint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateBlueprint">>, Input, Options).
 
 %% @doc Modifies an existing classifier (a `GrokClassifier', an
 %% `XMLClassifier', a `JsonClassifier', or a `CsvClassifier', depending on

--- a/src/aws_grafana.erl
+++ b/src/aws_grafana.erl
@@ -1,0 +1,436 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Managed Grafana is a fully managed and secure data
+%% visualization service that you can use to instantly query, correlate, and
+%% visualize operational metrics, logs, and traces from multiple sources.
+%%
+%% Amazon Managed Grafana makes it easy to deploy, operate, and scale
+%% Grafana, a widely deployed data visualization tool that is popular for its
+%% extensible data support.
+%%
+%% With Amazon Managed Grafana, you create logically isolated Grafana servers
+%% called workspaces. In a workspace, you can create Grafana dashboards and
+%% visualizations to analyze your metrics, logs, and traces without having to
+%% build, package, or deploy any hardware to run Grafana servers.
+-module(aws_grafana).
+
+-export([associate_license/4,
+         associate_license/5,
+         create_workspace/2,
+         create_workspace/3,
+         delete_workspace/3,
+         delete_workspace/4,
+         describe_workspace/2,
+         describe_workspace/4,
+         describe_workspace/5,
+         describe_workspace_authentication/2,
+         describe_workspace_authentication/4,
+         describe_workspace_authentication/5,
+         disassociate_license/4,
+         disassociate_license/5,
+         list_permissions/2,
+         list_permissions/4,
+         list_permissions/5,
+         list_workspaces/1,
+         list_workspaces/3,
+         list_workspaces/4,
+         update_permissions/3,
+         update_permissions/4,
+         update_workspace/3,
+         update_workspace/4,
+         update_workspace_authentication/3,
+         update_workspace_authentication/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Assigns a Grafana Enterprise license to a workspace.
+%%
+%% Upgrading to Grafana Enterprise incurs additional fees. For more
+%% information, see Upgrade a workspace to Grafana Enterprise.
+associate_license(Client, LicenseType, WorkspaceId, Input) ->
+    associate_license(Client, LicenseType, WorkspaceId, Input, []).
+associate_license(Client, LicenseType, WorkspaceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/licenses/", aws_util:encode_uri(LicenseType), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a workspace.
+%%
+%% In a workspace, you can create Grafana dashboards and visualizations to
+%% analyze your metrics, logs, and traces. You don't have to build, package,
+%% or deploy any hardware to run the Grafana server.
+%%
+%% Don't use `CreateWorkspace' to modify an existing workspace. Instead, use
+%% UpdateWorkspace.
+create_workspace(Client, Input) ->
+    create_workspace(Client, Input, []).
+create_workspace(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/workspaces"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an Amazon Managed Grafana workspace.
+delete_workspace(Client, WorkspaceId, Input) ->
+    delete_workspace(Client, WorkspaceId, Input, []).
+delete_workspace(Client, WorkspaceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Displays information about one Amazon Managed Grafana workspace.
+describe_workspace(Client, WorkspaceId)
+  when is_map(Client) ->
+    describe_workspace(Client, WorkspaceId, #{}, #{}).
+
+describe_workspace(Client, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_workspace(Client, WorkspaceId, QueryMap, HeadersMap, []).
+
+describe_workspace(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Displays information about the authentication methods used in one
+%% Amazon Managed Grafana workspace.
+describe_workspace_authentication(Client, WorkspaceId)
+  when is_map(Client) ->
+    describe_workspace_authentication(Client, WorkspaceId, #{}, #{}).
+
+describe_workspace_authentication(Client, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_workspace_authentication(Client, WorkspaceId, QueryMap, HeadersMap, []).
+
+describe_workspace_authentication(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/authentication"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Removes the Grafana Enterprise license from a workspace.
+disassociate_license(Client, LicenseType, WorkspaceId, Input) ->
+    disassociate_license(Client, LicenseType, WorkspaceId, Input, []).
+disassociate_license(Client, LicenseType, WorkspaceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/licenses/", aws_util:encode_uri(LicenseType), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the users and groups who have the Grafana `Admin' and `Editor'
+%% roles in this workspace.
+%%
+%% If you use this operation without specifying `userId' or `groupId', the
+%% operation returns the roles of all users and groups. If you specify a
+%% `userId' or a `groupId', only the roles for that user or group are
+%% returned. If you do this, you can specify only one `userId' or one
+%% `groupId'.
+list_permissions(Client, WorkspaceId)
+  when is_map(Client) ->
+    list_permissions(Client, WorkspaceId, #{}, #{}).
+
+list_permissions(Client, WorkspaceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_permissions(Client, WorkspaceId, QueryMap, HeadersMap, []).
+
+list_permissions(Client, WorkspaceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/permissions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"groupId">>, maps:get(<<"groupId">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"userId">>, maps:get(<<"userId">>, QueryMap, undefined)},
+        {<<"userType">>, maps:get(<<"userType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of Amazon Managed Grafana workspaces in the account,
+%% with some information about each workspace.
+%%
+%% For more complete information about one workspace, use DescribeWorkspace.
+list_workspaces(Client)
+  when is_map(Client) ->
+    list_workspaces(Client, #{}, #{}).
+
+list_workspaces(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_workspaces(Client, QueryMap, HeadersMap, []).
+
+list_workspaces(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/workspaces"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Updates which users in a workspace have the Grafana `Admin' or
+%% `Editor' roles.
+update_permissions(Client, WorkspaceId, Input) ->
+    update_permissions(Client, WorkspaceId, Input, []).
+update_permissions(Client, WorkspaceId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/permissions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Modifies an existing Amazon Managed Grafana workspace.
+%%
+%% If you use this operation and omit any optional parameters, the existing
+%% values of those parameters are not changed.
+%%
+%% To modify the user authentication methods that the workspace uses, such as
+%% SAML or Amazon Web Services SSO, use UpdateWorkspaceAuthentication.
+%%
+%% To modify which users in the workspace have the `Admin' and `Editor'
+%% Grafana roles, use UpdatePermissions.
+update_workspace(Client, WorkspaceId, Input) ->
+    update_workspace(Client, WorkspaceId, Input, []).
+update_workspace(Client, WorkspaceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Use this operation to define the identity provider (IdP) that this
+%% workspace authenticates users from, using SAML.
+%%
+%% You can also map SAML assertion attributes to workspace user information
+%% and define which groups in the assertion attribute are to have the `Admin'
+%% and `Editor' roles in the workspace.
+update_workspace_authentication(Client, WorkspaceId, Input) ->
+    update_workspace_authentication(Client, WorkspaceId, Input, []).
+update_workspace_authentication(Client, WorkspaceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/workspaces/", aws_util:encode_uri(WorkspaceId), "/authentication"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"grafana">>},
+    Host = build_host(<<"grafana">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -2652,6 +2652,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_greengrassv2.erl
+++ b/src/aws_greengrassv2.erl
@@ -1,27 +1,31 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS IoT Greengrass brings local compute, messaging, data management,
+%% @doc IoT Greengrass brings local compute, messaging, data management,
 %% sync, and ML inference capabilities to edge devices.
 %%
 %% This enables devices to collect and analyze data closer to the source of
 %% information, react autonomously to local events, and communicate securely
 %% with each other on local networks. Local devices can also communicate
-%% securely with AWS IoT Core and export IoT data to the AWS Cloud. AWS IoT
-%% Greengrass developers can use AWS Lambda functions and components to
-%% create and deploy applications to fleets of edge devices for local
-%% operation.
+%% securely with Amazon Web Services IoT Core and export IoT data to the
+%% Amazon Web Services Cloud. IoT Greengrass developers can use Lambda
+%% functions and components to create and deploy applications to fleets of
+%% edge devices for local operation.
 %%
-%% AWS IoT Greengrass Version 2 provides a new major version of the AWS IoT
+%% IoT Greengrass Version 2 provides a new major version of the IoT
 %% Greengrass Core software, new APIs, and a new console. Use this API
-%% reference to learn how to use the AWS IoT Greengrass V2 API operations to
+%% reference to learn how to use the IoT Greengrass V2 API operations to
 %% manage components, manage deployments, and core devices.
 %%
-%% For more information, see What is AWS IoT Greengrass? in the AWS IoT
-%% Greengrass V2 Developer Guide.
+%% For more information, see What is IoT Greengrass? in the IoT Greengrass V2
+%% Developer Guide.
 -module(aws_greengrassv2).
 
--export([cancel_deployment/3,
+-export([batch_associate_client_device_with_core_device/3,
+         batch_associate_client_device_with_core_device/4,
+         batch_disassociate_client_device_from_core_device/3,
+         batch_disassociate_client_device_from_core_device/4,
+         cancel_deployment/3,
          cancel_deployment/4,
          create_component_version/2,
          create_component_version/3,
@@ -46,6 +50,9 @@
          get_deployment/2,
          get_deployment/4,
          get_deployment/5,
+         list_client_devices_associated_with_core_device/2,
+         list_client_devices_associated_with_core_device/4,
+         list_client_devices_associated_with_core_device/5,
          list_component_versions/2,
          list_component_versions/4,
          list_component_versions/5,
@@ -80,6 +87,69 @@
 %% API
 %%====================================================================
 
+%% @doc Associate a list of client devices with a core device.
+%%
+%% Use this API operation to specify which client devices can discover a core
+%% device through cloud discovery. With cloud discovery, client devices
+%% connect to IoT Greengrass to retrieve associated core devices'
+%% connectivity information and certificates. For more information, see
+%% Configure cloud discovery in the IoT Greengrass V2 Developer Guide.
+%%
+%% Client devices are local IoT devices that connect to and communicate with
+%% an IoT Greengrass core device over MQTT. You can connect client devices to
+%% a core device to sync MQTT messages and data to Amazon Web Services IoT
+%% Core and interact with client devices in Greengrass components. For more
+%% information, see Interact with local IoT devices in the IoT Greengrass V2
+%% Developer Guide.
+batch_associate_client_device_with_core_device(Client, CoreDeviceThingName, Input) ->
+    batch_associate_client_device_with_core_device(Client, CoreDeviceThingName, Input, []).
+batch_associate_client_device_with_core_device(Client, CoreDeviceThingName, Input0, Options0) ->
+    Method = post,
+    Path = ["/greengrass/v2/coreDevices/", aws_util:encode_uri(CoreDeviceThingName), "/associateClientDevices"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Disassociate a list of client devices from a core device.
+%%
+%% After you disassociate a client device from a core device, the client
+%% device won't be able to use cloud discovery to retrieve the core device's
+%% connectivity information and certificates.
+batch_disassociate_client_device_from_core_device(Client, CoreDeviceThingName, Input) ->
+    batch_disassociate_client_device_from_core_device(Client, CoreDeviceThingName, Input, []).
+batch_disassociate_client_device_from_core_device(Client, CoreDeviceThingName, Input0, Options0) ->
+    Method = post,
+    Path = ["/greengrass/v2/coreDevices/", aws_util:encode_uri(CoreDeviceThingName), "/disassociateClientDevices"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Cancels a deployment.
 %%
 %% This operation cancels the deployment for devices that haven't yet
@@ -109,10 +179,10 @@ cancel_deployment(Client, DeploymentId, Input0, Options0) ->
 
 %% @doc Creates a component.
 %%
-%% Components are software that run on AWS IoT Greengrass core devices. After
-%% you develop and test a component on your core device, you can use this
-%% operation to upload your component to AWS IoT Greengrass. Then, you can
-%% deploy the component to other core devices.
+%% Components are software that run on Greengrass core devices. After you
+%% develop and test a component on your core device, you can use this
+%% operation to upload your component to IoT Greengrass. Then, you can deploy
+%% the component to other core devices.
 %%
 %% You can use this operation to do the following:
 %%
@@ -120,18 +190,18 @@ cancel_deployment(Client, DeploymentId, Input0, Options0) ->
 %%
 %% Create a component from a recipe, which is a file that defines the
 %% component's metadata, parameters, dependencies, lifecycle, artifacts, and
-%% platform capability. For more information, see AWS IoT Greengrass
-%% component recipe reference in the AWS IoT Greengrass V2 Developer Guide.
+%% platform capability. For more information, see IoT Greengrass component
+%% recipe reference in the IoT Greengrass V2 Developer Guide.
 %%
 %% To create a component from a recipe, specify `inlineRecipe' when you call
 %% this operation.
 %%
 %% </li> <li> Create components from Lambda functions
 %%
-%% Create a component from an AWS Lambda function that runs on AWS IoT
-%% Greengrass. This creates a recipe and artifacts from the Lambda function's
-%% deployment package. You can use this operation to migrate Lambda functions
-%% from AWS IoT Greengrass V1 to AWS IoT Greengrass V2.
+%% Create a component from an Lambda function that runs on IoT Greengrass.
+%% This creates a recipe and artifacts from the Lambda function's deployment
+%% package. You can use this operation to migrate Lambda functions from IoT
+%% Greengrass V1 to IoT Greengrass V2.
 %%
 %% This function only accepts Lambda functions that use the following
 %% runtimes:
@@ -174,16 +244,16 @@ create_component_version(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a continuous deployment for a target, which is a AWS IoT
-%% Greengrass core device or group of core devices.
+%% @doc Creates a continuous deployment for a target, which is a Greengrass
+%% core device or group of core devices.
 %%
 %% When you add a new core device to a group of core devices that has a
-%% deployment, AWS IoT Greengrass deploys that group's deployment to the new
+%% deployment, IoT Greengrass deploys that group's deployment to the new
 %% device.
 %%
 %% You can define one deployment for each target. When you create a new
 %% deployment for a target that has an existing deployment, you replace the
-%% previous deployment. AWS IoT Greengrass applies the new deployment to the
+%% previous deployment. IoT Greengrass applies the new deployment to the
 %% target devices.
 %%
 %% Every deployment has a revision number that indicates how many deployment
@@ -191,8 +261,8 @@ create_component_version(Client, Input0, Options0) ->
 %% revision of an existing deployment. This operation returns the revision
 %% number of the new deployment when you create it.
 %%
-%% For more information, see the Create deployments in the AWS IoT Greengrass
-%% V2 Developer Guide.
+%% For more information, see the Create deployments in the IoT Greengrass V2
+%% Developer Guide.
 create_deployment(Client, Input) ->
     create_deployment(Client, Input, []).
 create_deployment(Client, Input0, Options0) ->
@@ -215,7 +285,7 @@ create_deployment(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a version of a component from AWS IoT Greengrass.
+%% @doc Deletes a version of a component from IoT Greengrass.
 %%
 %% This operation deletes the component's recipe and artifacts. As a result,
 %% deployments that refer to this component version will fail. If you have
@@ -243,11 +313,11 @@ delete_component(Client, Arn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a AWS IoT Greengrass core device, which is an AWS IoT thing.
+%% @doc Deletes a Greengrass core device, which is an IoT thing.
 %%
 %% This operation removes the core device from the list of core devices. This
-%% operation doesn't delete the AWS IoT thing. For more information about how
-%% to delete the AWS IoT thing, see DeleteThing in the AWS IoT API Reference.
+%% operation doesn't delete the IoT thing. For more information about how to
+%% delete the IoT thing, see DeleteThing in the IoT API Reference.
 delete_core_device(Client, CoreDeviceThingName, Input) ->
     delete_core_device(Client, CoreDeviceThingName, Input, []).
 delete_core_device(Client, CoreDeviceThingName, Input0, Options0) ->
@@ -349,7 +419,7 @@ get_component_version_artifact(Client, Arn, ArtifactName, QueryMap, HeadersMap, 
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves metadata for a AWS IoT Greengrass core device.
+%% @doc Retrieves metadata for a Greengrass core device.
 get_core_device(Client, CoreDeviceThingName)
   when is_map(Client) ->
     get_core_device(Client, CoreDeviceThingName, #{}, #{}).
@@ -374,8 +444,7 @@ get_core_device(Client, CoreDeviceThingName, QueryMap, HeadersMap, Options0)
 
 %% @doc Gets a deployment.
 %%
-%% Deployments define the components that run on AWS IoT Greengrass core
-%% devices.
+%% Deployments define the components that run on Greengrass core devices.
 get_deployment(Client, DeploymentId)
   when is_map(Client) ->
     get_deployment(Client, DeploymentId, #{}, #{}).
@@ -398,7 +467,38 @@ get_deployment(Client, DeploymentId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Retrieves a paginated list of client devices that are associated with
+%% a core device.
+list_client_devices_associated_with_core_device(Client, CoreDeviceThingName)
+  when is_map(Client) ->
+    list_client_devices_associated_with_core_device(Client, CoreDeviceThingName, #{}, #{}).
+
+list_client_devices_associated_with_core_device(Client, CoreDeviceThingName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_client_devices_associated_with_core_device(Client, CoreDeviceThingName, QueryMap, HeadersMap, []).
+
+list_client_devices_associated_with_core_device(Client, CoreDeviceThingName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/greengrass/v2/coreDevices/", aws_util:encode_uri(CoreDeviceThingName), "/associatedClientDevices"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Retrieves a paginated list of all versions for a component.
+%%
+%% Greater versions are listed first.
 list_component_versions(Client, Arn)
   when is_map(Client) ->
     list_component_versions(Client, Arn, #{}, #{}).
@@ -457,7 +557,7 @@ list_components(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of AWS IoT Greengrass core devices.
+%% @doc Retrieves a paginated list of Greengrass core devices.
 list_core_devices(Client)
   when is_map(Client) ->
     list_core_devices(Client, #{}, #{}).
@@ -517,8 +617,8 @@ list_deployments(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of deployment jobs that AWS IoT Greengrass
-%% sends to AWS IoT Greengrass core devices.
+%% @doc Retrieves a paginated list of deployment jobs that IoT Greengrass
+%% sends to Greengrass core devices.
 list_effective_deployments(Client, CoreDeviceThingName)
   when is_map(Client) ->
     list_effective_deployments(Client, CoreDeviceThingName, #{}, #{}).
@@ -546,8 +646,8 @@ list_effective_deployments(Client, CoreDeviceThingName, QueryMap, HeadersMap, Op
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of the components that a AWS IoT
-%% Greengrass core device runs.
+%% @doc Retrieves a paginated list of the components that a Greengrass core
+%% device runs.
 list_installed_components(Client, CoreDeviceThingName)
   when is_map(Client) ->
     list_installed_components(Client, CoreDeviceThingName, #{}, #{}).
@@ -575,7 +675,7 @@ list_installed_components(Client, CoreDeviceThingName, QueryMap, HeadersMap, Opt
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the list of tags for an AWS IoT Greengrass resource.
+%% @doc Retrieves the list of tags for an IoT Greengrass resource.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -601,8 +701,8 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 %% @doc Retrieves a list of components that meet the component, version, and
 %% platform requirements of a deployment.
 %%
-%% AWS IoT Greengrass core devices call this operation when they receive a
-%% deployment to identify the components to install.
+%% Greengrass core devices call this operation when they receive a deployment
+%% to identify the components to install.
 %%
 %% This operation identifies components that meet all dependency requirements
 %% for a deployment. If the requirements conflict, then this operation
@@ -610,14 +710,15 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 %% component `A' requires version `>2.0.0' and component `B' requires version
 %% `<2.0.0' of a component dependency.
 %%
-%% When you specify the component candidates to resolve, AWS IoT Greengrass
+%% When you specify the component candidates to resolve, IoT Greengrass
 %% compares each component's digest from the core device with the component's
-%% digest in the AWS Cloud. If the digests don't match, then AWS IoT
-%% Greengrass specifies to use the version from the AWS Cloud.
+%% digest in the Amazon Web Services Cloud. If the digests don't match, then
+%% IoT Greengrass specifies to use the version from the Amazon Web Services
+%% Cloud.
 %%
 %% To use this operation, you must use the data plane API endpoint and
-%% authenticate with an AWS IoT device certificate. For more information, see
-%% AWS IoT Greengrass endpoints and quotas.
+%% authenticate with an IoT device certificate. For more information, see IoT
+%% Greengrass endpoints and quotas.
 resolve_component_candidates(Client, Input) ->
     resolve_component_candidates(Client, Input, []).
 resolve_component_candidates(Client, Input0, Options0) ->
@@ -640,7 +741,7 @@ resolve_component_candidates(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Adds tags to an AWS IoT Greengrass resource.
+%% @doc Adds tags to an IoT Greengrass resource.
 %%
 %% If a tag already exists for the resource, this operation updates the tag's
 %% value.
@@ -666,7 +767,7 @@ tag_resource(Client, ResourceArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes a tag from an AWS IoT Greengrass resource.
+%% @doc Removes a tag from an IoT Greengrass resource.
 untag_resource(Client, ResourceArn, Input) ->
     untag_resource(Client, ResourceArn, Input, []).
 untag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -725,6 +826,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -738,6 +738,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -1668,6 +1668,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_health.erl
+++ b/src/aws_health.erl
@@ -9,13 +9,18 @@
 %% You can use the API operations to get information about AWS Health events
 %% that affect your AWS services and resources.
 %%
-%% You must have a Business or Enterprise support plan from AWS Support to
+%% You must have a Business or Enterprise Support plan from AWS Support to
 %% use the AWS Health API. If you call the AWS Health API from an AWS account
-%% that doesn't have a Business or Enterprise support plan, you receive a
+%% that doesn't have a Business or Enterprise Support plan, you receive a
 %% `SubscriptionRequiredException' error.
 %%
-%% AWS Health has a single endpoint: health.us-east-1.amazonaws.com (HTTPS).
-%% Use this endpoint to call the AWS Health API operations.
+%% You can use the AWS Health endpoint health.us-east-1.amazonaws.com (HTTPS)
+%% to call the AWS Health API operations. AWS Health supports a multi-Region
+%% application architecture and has two regional endpoints in an
+%% active-passive configuration. You can use the high availability endpoint
+%% example to determine which AWS Region is active, so that you can get the
+%% latest information from the API. For more information, see Accessing the
+%% AWS Health API in the AWS Health User Guide.
 %%
 %% For authentication of requests, AWS Health uses the Signature Version 4
 %% Signing Process.
@@ -181,10 +186,10 @@ describe_event_aggregates(Client, Input, Options)
 %% Information includes standard event data (AWS Region, service, and so on,
 %% as returned by DescribeEvents), a detailed event description, and possible
 %% additional metadata that depends upon the nature of the event. Affected
-%% entities are not included. To retrieve those, use the
+%% entities are not included. To retrieve the entities, use the
 %% DescribeAffectedEntities operation.
 %%
-%% If a specified event cannot be retrieved, an error message is returned for
+%% If a specified event can't be retrieved, an error message is returned for
 %% that event.
 %%
 %% This operation supports resource-level permissions. You can use this
@@ -199,32 +204,33 @@ describe_event_details(Client, Input, Options)
     request(Client, <<"DescribeEventDetails">>, Input, Options).
 
 %% @doc Returns detailed information about one or more specified events for
-%% one or more accounts in your organization.
+%% one or more AWS accounts in your organization.
 %%
-%% Information includes standard event data (AWS Region, service, and so on,
-%% as returned by DescribeEventsForOrganization), a detailed event
-%% description, and possible additional metadata that depends upon the nature
-%% of the event. Affected entities are not included; to retrieve those, use
-%% the DescribeAffectedEntitiesForOrganization operation.
+%% This information includes standard event data (such as the AWS Region and
+%% service), an event description, and (depending on the event) possible
+%% metadata. This operation doesn't return affected entities, such as the
+%% resources related to the event. To return affected entities, use the
+%% DescribeAffectedEntitiesForOrganization operation.
 %%
 %% Before you can call this operation, you must first enable AWS Health to
 %% work with AWS Organizations. To do this, call the
 %% EnableHealthServiceAccessForOrganization operation from your
 %% organization's management account.
 %%
-%% When you call the `DescribeEventDetailsForOrganization' operation, you
-%% specify the `organizationEventDetailFilters' object in the request.
-%% Depending on the AWS Health event type, note the following differences:
+%% When you call the `DescribeEventDetailsForOrganization' operation, specify
+%% the `organizationEventDetailFilters' object in the request. Depending on
+%% the AWS Health event type, note the following differences:
 %%
-%% <ul> <li> If the event is public, the `awsAccountId' parameter must be
-%% empty. If you specify an account ID for a public event, then an error
-%% message is returned. That's because the event might apply to all AWS
-%% accounts and isn't specific to an account in your organization.
+%% <ul> <li> To return event details for a public event, you must specify a
+%% null value for the `awsAccountId' parameter. If you specify an account ID
+%% for a public event, AWS Health returns an error message because public
+%% events aren't specific to an account.
 %%
-%% </li> <li> If the event is specific to an account, then you must specify
-%% the `awsAccountId' parameter in the request. If you don't specify an
-%% account ID, an error message returns because the event is specific to an
-%% AWS account in your organization.
+%% </li> <li> To return event details for an event that is specific to an
+%% account in your organization, you must specify the `awsAccountId'
+%% parameter in the request. If you don't specify an account ID, AWS Health
+%% returns an error message because the event is specific to an account in
+%% your organization.
 %%
 %% </li> </ul> For more information, see Event.
 %%
@@ -373,9 +379,9 @@ disable_health_service_access_for_organization(Client, Input, Options)
 %%
 %% To call this operation, you must meet the following requirements:
 %%
-%% You must have a Business or Enterprise support plan from AWS Support to
+%% You must have a Business or Enterprise Support plan from AWS Support to
 %% use the AWS Health API. If you call the AWS Health API from an AWS account
-%% that doesn't have a Business or Enterprise support plan, you receive a
+%% that doesn't have a Business or Enterprise Support plan, you receive a
 %% `SubscriptionRequiredException' error.
 %%
 %% You must have permission to call this operation from the organization's

--- a/src/aws_healthlake.erl
+++ b/src/aws_healthlake.erl
@@ -18,10 +18,20 @@
          describe_fhir_import_job/3,
          list_fhir_datastores/2,
          list_fhir_datastores/3,
+         list_fhir_export_jobs/2,
+         list_fhir_export_jobs/3,
+         list_fhir_import_jobs/2,
+         list_fhir_import_jobs/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
          start_fhir_export_job/2,
          start_fhir_export_job/3,
          start_fhir_import_job/2,
-         start_fhir_import_job/3]).
+         start_fhir_import_job/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -82,6 +92,32 @@ list_fhir_datastores(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListFHIRDatastores">>, Input, Options).
 
+%% @doc Lists all FHIR export jobs associated with an account and their
+%% statuses.
+list_fhir_export_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_fhir_export_jobs(Client, Input, []).
+list_fhir_export_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListFHIRExportJobs">>, Input, Options).
+
+%% @doc Lists all FHIR import jobs associated with an account and their
+%% statuses.
+list_fhir_import_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_fhir_import_jobs(Client, Input, []).
+list_fhir_import_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListFHIRImportJobs">>, Input, Options).
+
+%% @doc Returns a list of all existing tags associated with a Data Store.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
 %% @doc Begins a FHIR export job.
 start_fhir_export_job(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -97,6 +133,22 @@ start_fhir_import_job(Client, Input)
 start_fhir_import_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartFHIRImportJob">>, Input, Options).
+
+%% @doc Adds a user specifed key and value tag to a Data Store.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes tags from a Data Store.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_honeycode.erl
+++ b/src/aws_honeycode.erl
@@ -417,6 +417,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -1,16 +1,16 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Identity and Access Management
+%% @doc Identity and Access Management
 %%
-%% AWS Identity and Access Management (IAM) is a web service for securely
-%% controlling access to AWS services.
+%% Identity and Access Management (IAM) is a web service for securely
+%% controlling access to Amazon Web Services services.
 %%
 %% With IAM, you can centrally manage users, security credentials such as
-%% access keys, and permissions that control which AWS resources users and
-%% applications can access. For more information about IAM, see AWS Identity
-%% and Access Management (IAM) and the AWS Identity and Access Management
-%% User Guide.
+%% access keys, and permissions that control which Amazon Web Services
+%% resources users and applications can access. For more information about
+%% IAM, see Identity and Access Management (IAM) and the Identity and Access
+%% Management User Guide.
 -module(aws_iam).
 
 -export([add_client_id_to_open_id_connect_provider/2,
@@ -354,9 +354,9 @@ add_client_id_to_open_id_connect_provider(Client, Input, Options)
 %% An instance profile can contain only one role, and this quota cannot be
 %% increased. You can remove the existing role and then add a different role
 %% to an instance profile. You must then wait for the change to appear across
-%% all of AWS because of eventual consistency. To force the change, you must
-%% disassociate the instance profile and then associate the instance profile,
-%% or you can stop your instance and then restart it.
+%% all of Amazon Web Services because of eventual consistency. To force the
+%% change, you must disassociate the instance profile and then associate the
+%% instance profile, or you can stop your instance and then restart it.
 %%
 %% The caller of this operation must be granted the `PassRole' permission on
 %% the IAM role by a permissions policy.
@@ -383,6 +383,9 @@ add_user_to_group(Client, Input, Options)
 %% You use this operation to attach a managed policy to a group. To embed an
 %% inline policy in a group, use `PutGroupPolicy'.
 %%
+%% As a best practice, you can validate your IAM policies. To learn more, see
+%% Validating IAM policies in the IAM User Guide.
+%%
 %% For more information about policies, see Managed policies and inline
 %% policies in the IAM User Guide.
 attach_group_policy(Client, Input)
@@ -404,6 +407,9 @@ attach_group_policy(Client, Input, Options)
 %% Use this operation to attach a managed policy to a role. To embed an
 %% inline policy in a role, use `PutRolePolicy'. For more information about
 %% policies, see Managed policies and inline policies in the IAM User Guide.
+%%
+%% As a best practice, you can validate your IAM policies. To learn more, see
+%% Validating IAM policies in the IAM User Guide.
 attach_role_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     attach_role_policy(Client, Input, []).
@@ -416,6 +422,9 @@ attach_role_policy(Client, Input, Options)
 %% You use this operation to attach a managed policy to a user. To embed an
 %% inline policy in a user, use `PutUserPolicy'.
 %%
+%% As a best practice, you can validate your IAM policies. To learn more, see
+%% Validating IAM policies in the IAM User Guide.
+%%
 %% For more information about policies, see Managed policies and inline
 %% policies in the IAM User Guide.
 attach_user_policy(Client, Input)
@@ -427,14 +436,15 @@ attach_user_policy(Client, Input, Options)
 
 %% @doc Changes the password of the IAM user who is calling this operation.
 %%
-%% This operation can be performed using the AWS CLI, the AWS API, or the My
-%% Security Credentials page in the AWS Management Console. The AWS account
-%% root user password is not affected by this operation.
+%% This operation can be performed using the CLI, the Amazon Web Services
+%% API, or the My Security Credentials page in the Amazon Web Services
+%% Management Console. The Amazon Web Services account root user password is
+%% not affected by this operation.
 %%
-%% Use `UpdateLoginProfile' to use the AWS CLI, the AWS API, or the Users
-%% page in the IAM console to change the password for any IAM user. For more
-%% information about modifying passwords, see Managing passwords in the IAM
-%% User Guide.
+%% Use `UpdateLoginProfile' to use the CLI, the Amazon Web Services API, or
+%% the Users page in the IAM console to change the password for any IAM user.
+%% For more information about modifying passwords, see Managing passwords in
+%% the IAM User Guide.
 change_password(Client, Input)
   when is_map(Client), is_map(Input) ->
     change_password(Client, Input, []).
@@ -442,25 +452,26 @@ change_password(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ChangePassword">>, Input, Options).
 
-%% @doc Creates a new AWS secret access key and corresponding AWS access key
-%% ID for the specified user.
+%% @doc Creates a new Amazon Web Services secret access key and corresponding
+%% Amazon Web Services access key ID for the specified user.
 %%
 %% The default status for new keys is `Active'.
 %%
 %% If you do not specify a user name, IAM determines the user name implicitly
-%% based on the AWS access key ID signing the request. This operation works
-%% for access keys under the AWS account. Consequently, you can use this
-%% operation to manage AWS account root user credentials. This is true even
-%% if the AWS account has no associated users.
+%% based on the Amazon Web Services access key ID signing the request. This
+%% operation works for access keys under the Amazon Web Services account.
+%% Consequently, you can use this operation to manage Amazon Web Services
+%% account root user credentials. This is true even if the Amazon Web
+%% Services account has no associated users.
 %%
 %% For information about quotas on the number of keys you can create, see IAM
 %% and STS quotas in the IAM User Guide.
 %%
-%% To ensure the security of your AWS account, the secret access key is
-%% accessible only during key and user creation. You must save the key (for
-%% example, in a text file) if you want to be able to access it again. If a
-%% secret key is lost, you can delete the access keys for the associated user
-%% and then create new keys.
+%% To ensure the security of your Amazon Web Services account, the secret
+%% access key is accessible only during key and user creation. You must save
+%% the key (for example, in a text file) if you want to be able to access it
+%% again. If a secret key is lost, you can delete the access keys for the
+%% associated user and then create new keys.
 create_access_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_access_key(Client, Input, []).
@@ -468,10 +479,11 @@ create_access_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateAccessKey">>, Input, Options).
 
-%% @doc Creates an alias for your AWS account.
+%% @doc Creates an alias for your Amazon Web Services account.
 %%
-%% For information about using an AWS account alias, see Using an alias for
-%% your AWS account ID in the IAM User Guide.
+%% For information about using an Amazon Web Services account alias, see
+%% Using an alias for your Amazon Web Services account ID in the IAM User
+%% Guide.
 create_account_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_account_alias(Client, Input, []).
@@ -492,7 +504,9 @@ create_group(Client, Input, Options)
 
 %% @doc Creates a new instance profile.
 %%
-%% For information about instance profiles, see About instance profiles.
+%% For information about instance profiles, see Using roles for applications
+%% on Amazon EC2 in the IAM User Guide, and Instance profiles in the Amazon
+%% EC2 User Guide.
 %%
 %% For information about the number of instance profiles you can create, see
 %% IAM object quotas in the IAM User Guide.
@@ -505,13 +519,13 @@ create_instance_profile(Client, Input, Options)
 
 %% @doc Creates a password for the specified IAM user.
 %%
-%% A password allows an IAM user to access AWS services through the AWS
-%% Management Console.
+%% A password allows an IAM user to access Amazon Web Services services
+%% through the Amazon Web Services Management Console.
 %%
-%% You can use the AWS CLI, the AWS API, or the Users page in the IAM console
-%% to create a password for any IAM user. Use `ChangePassword' to update your
-%% own existing password in the My Security Credentials page in the AWS
-%% Management Console.
+%% You can use the CLI, the Amazon Web Services API, or the Users page in the
+%% IAM console to create a password for any IAM user. Use `ChangePassword' to
+%% update your own existing password in the My Security Credentials page in
+%% the Amazon Web Services Management Console.
 %%
 %% For more information about managing passwords, see Managing passwords in
 %% the IAM User Guide.
@@ -527,21 +541,36 @@ create_login_profile(Client, Input, Options)
 %%
 %% The OIDC provider that you create with this operation can be used as a
 %% principal in a role's trust policy. Such a policy establishes a trust
-%% relationship between AWS and the OIDC provider.
+%% relationship between Amazon Web Services and the OIDC provider.
+%%
+%% If you are using an OIDC identity provider from Google, Facebook, or
+%% Amazon Cognito, you don't need to create a separate IAM identity provider.
+%% These OIDC identity providers are already built-in to Amazon Web Services
+%% and are available for your use. Instead, you can move directly to creating
+%% new roles using your identity provider. To learn more, see Creating a role
+%% for web identity or OpenID connect federation in the IAM User Guide.
 %%
 %% When you create the IAM OIDC provider, you specify the following:
 %%
 %% <ul> <li> The URL of the OIDC identity provider (IdP) to trust
 %%
 %% </li> <li> A list of client IDs (also known as audiences) that identify
-%% the application or applications that are allowed to authenticate using the
-%% OIDC provider
+%% the application or applications allowed to authenticate using the OIDC
+%% provider
 %%
 %% </li> <li> A list of thumbprints of one or more server certificates that
 %% the IdP uses
 %%
-%% </li> </ul> You get all of this information from the OIDC IdP that you
-%% want to use to access AWS.
+%% </li> </ul> You get all of this information from the OIDC IdP you want to
+%% use to access Amazon Web Services.
+%%
+%% Amazon Web Services secures communication with some OIDC identity
+%% providers (IdPs) through our library of trusted certificate authorities
+%% (CAs) instead of using a certificate thumbprint to verify your IdP server
+%% certificate. These OIDC IdPs include Google, and those that use an Amazon
+%% S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these cases, your
+%% legacy thumbprint remains in your configuration, but is no longer used for
+%% validation.
 %%
 %% The trust for the OIDC provider is derived from the IAM provider that this
 %% operation creates. Therefore, it is best to limit access to the
@@ -553,12 +582,15 @@ create_open_id_connect_provider(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateOpenIDConnectProvider">>, Input, Options).
 
-%% @doc Creates a new managed policy for your AWS account.
+%% @doc Creates a new managed policy for your Amazon Web Services account.
 %%
 %% This operation creates a policy version with a version identifier of `v1'
 %% and sets v1 as the policy's default version. For more information about
 %% policy versions, see Versioning for managed policies in the IAM User
 %% Guide.
+%%
+%% As a best practice, you can validate your IAM policies. To learn more, see
+%% Validating IAM policies in the IAM User Guide.
 %%
 %% For more information about managed policies in general, see Managed
 %% policies and inline policies in the IAM User Guide.
@@ -589,7 +621,7 @@ create_policy_version(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreatePolicyVersion">>, Input, Options).
 
-%% @doc Creates a new role for your AWS account.
+%% @doc Creates a new role for your Amazon Web Services account.
 %%
 %% For more information about roles, see IAM roles. For information about
 %% quotas for role names and the number of roles you can create, see IAM and
@@ -607,8 +639,9 @@ create_role(Client, Input, Options)
 %% The SAML provider resource that you create with this operation can be used
 %% as a principal in an IAM role's trust policy. Such a policy can enable
 %% federated users who sign in using the SAML IdP to assume the role. You can
-%% create an IAM role that supports Web-based single sign-on (SSO) to the AWS
-%% Management Console or one that supports API access to AWS.
+%% create an IAM role that supports Web-based single sign-on (SSO) to the
+%% Amazon Web Services Management Console or one that supports API access to
+%% Amazon Web Services.
 %%
 %% When you create the SAML provider resource, you upload a SAML metadata
 %% document that you get from your IdP. That document includes the issuer's
@@ -620,8 +653,8 @@ create_role(Client, Input, Options)
 %% This operation requires Signature Version 4.
 %%
 %% For more information, see Enabling SAML 2.0 federated users to access the
-%% AWS Management Console and About SAML 2.0-based federation in the IAM User
-%% Guide.
+%% Amazon Web Services Management Console and About SAML 2.0-based federation
+%% in the IAM User Guide.
 create_saml_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_saml_provider(Client, Input, []).
@@ -629,18 +662,19 @@ create_saml_provider(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateSAMLProvider">>, Input, Options).
 
-%% @doc Creates an IAM role that is linked to a specific AWS service.
+%% @doc Creates an IAM role that is linked to a specific Amazon Web Services
+%% service.
 %%
 %% The service controls the attached policies and when the role can be
 %% deleted. This helps ensure that the service is not broken by an
-%% unexpectedly changed or deleted role, which could put your AWS resources
-%% into an unknown state. Allowing the service to control the role helps
-%% improve service stability and proper cleanup when a service and its role
-%% are no longer needed. For more information, see Using service-linked roles
-%% in the IAM User Guide.
+%% unexpectedly changed or deleted role, which could put your Amazon Web
+%% Services resources into an unknown state. Allowing the service to control
+%% the role helps improve service stability and proper cleanup when a service
+%% and its role are no longer needed. For more information, see Using
+%% service-linked roles in the IAM User Guide.
 %%
 %% To attach a policy to this service-linked role, you must make the request
-%% using the AWS service that depends on this role.
+%% using the Amazon Web Services service that depends on this role.
 create_service_linked_role(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_service_linked_role(Client, Input, []).
@@ -657,15 +691,15 @@ create_service_linked_role(Client, Input, Options)
 %% You can have a maximum of two sets of service-specific credentials for
 %% each supported service per user.
 %%
-%% You can create service-specific credentials for AWS CodeCommit and Amazon
+%% You can create service-specific credentials for CodeCommit and Amazon
 %% Keyspaces (for Apache Cassandra).
 %%
 %% You can reset the password to a new service-generated value by calling
 %% `ResetServiceSpecificCredential'.
 %%
 %% For more information about service-specific credentials, see Using IAM
-%% with AWS CodeCommit: Git credentials, SSH keys, and AWS access keys in the
-%% IAM User Guide.
+%% with CodeCommit: Git credentials, SSH keys, and Amazon Web Services access
+%% keys in the IAM User Guide.
 create_service_specific_credential(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_service_specific_credential(Client, Input, []).
@@ -673,7 +707,7 @@ create_service_specific_credential(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateServiceSpecificCredential">>, Input, Options).
 
-%% @doc Creates a new IAM user for your AWS account.
+%% @doc Creates a new IAM user for your Amazon Web Services account.
 %%
 %% For information about quotas for the number of IAM users you can create,
 %% see IAM and STS quotas in the IAM User Guide.
@@ -684,7 +718,7 @@ create_user(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateUser">>, Input, Options).
 
-%% @doc Creates a new virtual MFA device for the AWS account.
+%% @doc Creates a new virtual MFA device for the Amazon Web Services account.
 %%
 %% After creating the virtual MFA, use `EnableMFADevice' to attach the MFA
 %% device to an IAM user. For more information about creating and working
@@ -696,9 +730,10 @@ create_user(Client, Input, Options)
 %%
 %% The seed information contained in the QR code and the Base32 string should
 %% be treated like any other secret access information. In other words,
-%% protect the seed information as you would your AWS access keys or your
-%% passwords. After you provision your virtual device, you should ensure that
-%% the information is destroyed following secure procedures.
+%% protect the seed information as you would your Amazon Web Services access
+%% keys or your passwords. After you provision your virtual device, you
+%% should ensure that the information is destroyed following secure
+%% procedures.
 create_virtual_mfa_device(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_virtual_mfa_device(Client, Input, []).
@@ -722,10 +757,11 @@ deactivate_mfa_device(Client, Input, Options)
 %% @doc Deletes the access key pair associated with the specified IAM user.
 %%
 %% If you do not specify a user name, IAM determines the user name implicitly
-%% based on the AWS access key ID signing the request. This operation works
-%% for access keys under the AWS account. Consequently, you can use this
-%% operation to manage AWS account root user credentials even if the AWS
-%% account has no associated users.
+%% based on the Amazon Web Services access key ID signing the request. This
+%% operation works for access keys under the Amazon Web Services account.
+%% Consequently, you can use this operation to manage Amazon Web Services
+%% account root user credentials even if the Amazon Web Services account has
+%% no associated users.
 delete_access_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_access_key(Client, Input, []).
@@ -733,10 +769,11 @@ delete_access_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAccessKey">>, Input, Options).
 
-%% @doc Deletes the specified AWS account alias.
+%% @doc Deletes the specified Amazon Web Services account alias.
 %%
-%% For information about using an AWS account alias, see Using an alias for
-%% your AWS account ID in the IAM User Guide.
+%% For information about using an Amazon Web Services account alias, see
+%% Using an alias for your Amazon Web Services account ID in the IAM User
+%% Guide.
 delete_account_alias(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_account_alias(Client, Input, []).
@@ -744,7 +781,7 @@ delete_account_alias(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAccountAlias">>, Input, Options).
 
-%% @doc Deletes the password policy for the AWS account.
+%% @doc Deletes the password policy for the Amazon Web Services account.
 %%
 %% There are no parameters.
 delete_account_password_policy(Client, Input)
@@ -796,18 +833,19 @@ delete_instance_profile(Client, Input, Options)
     request(Client, <<"DeleteInstanceProfile">>, Input, Options).
 
 %% @doc Deletes the password for the specified IAM user, which terminates the
-%% user's ability to access AWS services through the AWS Management Console.
+%% user's ability to access Amazon Web Services services through the Amazon
+%% Web Services Management Console.
 %%
-%% You can use the AWS CLI, the AWS API, or the Users page in the IAM console
-%% to delete a password for any IAM user. You can use `ChangePassword' to
-%% update, but not delete, your own password in the My Security Credentials
-%% page in the AWS Management Console.
+%% You can use the CLI, the Amazon Web Services API, or the Users page in the
+%% IAM console to delete a password for any IAM user. You can use
+%% `ChangePassword' to update, but not delete, your own password in the My
+%% Security Credentials page in the Amazon Web Services Management Console.
 %%
-%% Deleting a user's password does not prevent a user from accessing AWS
-%% through the command line interface or the API. To prevent all user access,
-%% you must also either make any access keys inactive or delete them. For
-%% more information about making keys inactive or deleting them, see
-%% `UpdateAccessKey' and `DeleteAccessKey'.
+%% Deleting a user's password does not prevent a user from accessing Amazon
+%% Web Services through the command line interface or the API. To prevent all
+%% user access, you must also either make any access keys inactive or delete
+%% them. For more information about making keys inactive or deleting them,
+%% see `UpdateAccessKey' and `DeleteAccessKey'.
 delete_login_profile(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_login_profile(Client, Input, []).
@@ -938,8 +976,8 @@ delete_saml_provider(Client, Input, Options)
 %%
 %% For more information about working with server certificates, see Working
 %% with server certificates in the IAM User Guide. This topic also includes a
-%% list of AWS services that can use the server certificates that you manage
-%% with IAM.
+%% list of Amazon Web Services services that can use the server certificates
+%% that you manage with IAM.
 %%
 %% If you are using a server certificate with Elastic Load Balancing,
 %% deleting the certificate could have implications for your application. If
@@ -972,11 +1010,11 @@ delete_server_certificate(Client, Input, Options)
 %% deleted. To delete the service-linked role, you must first remove those
 %% resources from the linked service and then submit the deletion request
 %% again. Resources are specific to the service that is linked to the role.
-%% For more information about removing resources from a service, see the AWS
-%% documentation for your service.
+%% For more information about removing resources from a service, see the
+%% Amazon Web Services documentation for your service.
 %%
 %% For more information about service-linked roles, see Roles terms and
-%% concepts: AWS service-linked role in the IAM User Guide.
+%% concepts: Amazon Web Services service-linked role in the IAM User Guide.
 delete_service_linked_role(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_service_linked_role(Client, Input, []).
@@ -995,10 +1033,11 @@ delete_service_specific_credential(Client, Input, Options)
 %% @doc Deletes a signing certificate associated with the specified IAM user.
 %%
 %% If you do not specify a user name, IAM determines the user name implicitly
-%% based on the AWS access key ID signing the request. This operation works
-%% for access keys under the AWS account. Consequently, you can use this
-%% operation to manage AWS account root user credentials even if the AWS
-%% account has no associated IAM users.
+%% based on the Amazon Web Services access key ID signing the request. This
+%% operation works for access keys under the Amazon Web Services account.
+%% Consequently, you can use this operation to manage Amazon Web Services
+%% account root user credentials even if the Amazon Web Services account has
+%% no associated IAM users.
 delete_signing_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_signing_certificate(Client, Input, []).
@@ -1009,10 +1048,10 @@ delete_signing_certificate(Client, Input, Options)
 %% @doc Deletes the specified SSH public key.
 %%
 %% The SSH public key deleted by this operation is used only for
-%% authenticating the associated IAM user to an AWS CodeCommit repository.
-%% For more information about using SSH keys to authenticate to an AWS
-%% CodeCommit repository, see Set up AWS CodeCommit for SSH connections in
-%% the AWS CodeCommit User Guide.
+%% authenticating the associated IAM user to an CodeCommit repository. For
+%% more information about using SSH keys to authenticate to an CodeCommit
+%% repository, see Set up CodeCommit for SSH connections in the CodeCommit
+%% User Guide.
 delete_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_ssh_public_key(Client, Input, []).
@@ -1022,7 +1061,7 @@ delete_ssh_public_key(Client, Input, Options)
 
 %% @doc Deletes the specified IAM user.
 %%
-%% Unlike the AWS Management Console, when you delete a user
+%% Unlike the Amazon Web Services Management Console, when you delete a user
 %% programmatically, you must delete the items attached to the user manually,
 %% or the deletion fails. For more information, see Deleting an IAM user.
 %% Before attempting to delete a user, remove the following items:
@@ -1139,7 +1178,7 @@ enable_mfa_device(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"EnableMFADevice">>, Input, Options).
 
-%% @doc Generates a credential report for the AWS account.
+%% @doc Generates a credential report for the Amazon Web Services account.
 %%
 %% For more information about the credential report, see Getting credential
 %% reports in the IAM User Guide.
@@ -1150,17 +1189,16 @@ generate_credential_report(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GenerateCredentialReport">>, Input, Options).
 
-%% @doc Generates a report for service last accessed data for AWS
-%% Organizations.
+%% @doc Generates a report for service last accessed data for Organizations.
 %%
 %% You can generate a report for any entities (organization root,
 %% organizational unit, or account) or policies in your organization.
 %%
-%% To call this operation, you must be signed in using your AWS Organizations
+%% To call this operation, you must be signed in using your Organizations
 %% management account credentials. You can use your long-term IAM user or
 %% root user credentials, or temporary credentials from assuming an IAM role.
 %% SCPs must be enabled for your organization root. You must have the
-%% required IAM and AWS Organizations permissions. For more information, see
+%% required IAM and Organizations permissions. For more information, see
 %% Refining permissions using service last accessed data in the IAM User
 %% Guide.
 %%
@@ -1170,9 +1208,8 @@ generate_credential_report(Client, Input, Options)
 %% entity.
 %%
 %% You can generate a service last accessed data report for a policy by
-%% specifying an entity's path and an optional AWS Organizations policy ID.
-%% This data includes a list of services that are allowed by the specified
-%% SCP.
+%% specifying an entity's path and an optional Organizations policy ID. This
+%% data includes a list of services that are allowed by the specified SCP.
 %%
 %% For each service in both report types, the data includes the most recent
 %% account activity that the policy allows to account principals in the
@@ -1181,15 +1218,15 @@ generate_credential_report(Client, Input, Options)
 %% Regions see Reducing permissions using service last accessed data in the
 %% IAM User Guide.
 %%
-%% The data includes all attempts to access AWS, not just the successful
-%% ones. This includes all attempts that were made using the AWS Management
-%% Console, the AWS API through any of the SDKs, or any of the command line
-%% tools. An unexpected entry in the service last accessed data does not mean
-%% that an account has been compromised, because the request might have been
-%% denied. Refer to your CloudTrail logs as the authoritative source for
-%% information about all API calls and whether they were successful or denied
-%% access. For more information, see Logging IAM events with CloudTrail in
-%% the IAM User Guide.
+%% The data includes all attempts to access Amazon Web Services, not just the
+%% successful ones. This includes all attempts that were made using the
+%% Amazon Web Services Management Console, the Amazon Web Services API
+%% through any of the SDKs, or any of the command line tools. An unexpected
+%% entry in the service last accessed data does not mean that an account has
+%% been compromised, because the request might have been denied. Refer to
+%% your CloudTrail logs as the authoritative source for information about all
+%% API calls and whether they were successful or denied access. For more
+%% information, see Logging IAM events with CloudTrail in the IAM User Guide.
 %%
 %% This operation returns a `JobId'. Use this parameter in the `
 %% `GetOrganizationsAccessReport' ' operation to check the status of the
@@ -1199,8 +1236,8 @@ generate_credential_report(Client, Input, Options)
 %% the report.
 %%
 %% To generate a service last accessed data report for entities, specify an
-%% entity path without specifying the optional AWS Organizations policy ID.
-%% The type of entity that you specify determines the data returned in the
+%% entity path without specifying the optional Organizations policy ID. The
+%% type of entity that you specify determines the data returned in the
 %% report.
 %%
 %% <ul> <li> Root – When you specify the organizations root as the entity,
@@ -1217,9 +1254,9 @@ generate_credential_report(Client, Input, Options)
 %% limited by SCPs.
 %%
 %% </li> <li> management account – When you specify the management account,
-%% the resulting report lists all AWS services, because the management
-%% account is not limited by SCPs. For each service, the report includes data
-%% for only the management account.
+%% the resulting report lists all Amazon Web Services services, because the
+%% management account is not limited by SCPs. For each service, the report
+%% includes data for only the management account.
 %%
 %% </li> <li> Account – When you specify another account as the entity, the
 %% resulting report lists all of the services allowed by SCPs that are
@@ -1227,9 +1264,8 @@ generate_credential_report(Client, Input, Options)
 %% includes data for only the specified account.
 %%
 %% </li> </ul> To generate a service last accessed data report for policies,
-%% specify an entity path and the optional AWS Organizations policy ID. The
-%% type of entity that you specify determines the data returned for each
-%% service.
+%% specify an entity path and the optional Organizations policy ID. The type
+%% of entity that you specify determines the data returned for each service.
 %%
 %% <ul> <li> Root – When you specify the root entity and a policy ID, the
 %% resulting report lists all of the services that are allowed by the
@@ -1250,10 +1286,10 @@ generate_credential_report(Client, Input, Options)
 %% with no data.
 %%
 %% </li> <li> management account – When you specify the management account,
-%% the resulting report lists all AWS services, because the management
-%% account is not limited by SCPs. If you specify a policy ID in the CLI or
-%% API, the policy is ignored. For each service, the report includes data for
-%% only the management account.
+%% the resulting report lists all Amazon Web Services services, because the
+%% management account is not limited by SCPs. If you specify a policy ID in
+%% the CLI or API, the policy is ignored. For each service, the report
+%% includes data for only the management account.
 %%
 %% </li> <li> Account – When you specify another account entity and a policy
 %% ID, the resulting report lists all of the services that are allowed by the
@@ -1280,32 +1316,33 @@ generate_organizations_access_report(Client, Input, Options)
     request(Client, <<"GenerateOrganizationsAccessReport">>, Input, Options).
 
 %% @doc Generates a report that includes details about when an IAM resource
-%% (user, group, role, or policy) was last used in an attempt to access AWS
-%% services.
+%% (user, group, role, or policy) was last used in an attempt to access
+%% Amazon Web Services services.
 %%
 %% Recent activity usually appears within four hours. IAM reports activity
 %% for the last 365 days, or less if your Region began supporting this
 %% feature within the last year. For more information, see Regions where data
 %% is tracked.
 %%
-%% The service last accessed data includes all attempts to access an AWS API,
-%% not just the successful ones. This includes all attempts that were made
-%% using the AWS Management Console, the AWS API through any of the SDKs, or
-%% any of the command line tools. An unexpected entry in the service last
-%% accessed data does not mean that your account has been compromised,
-%% because the request might have been denied. Refer to your CloudTrail logs
-%% as the authoritative source for information about all API calls and
-%% whether they were successful or denied access. For more information,
-%% see Logging IAM events with CloudTrail in the IAM User Guide.
+%% The service last accessed data includes all attempts to access an Amazon
+%% Web Services API, not just the successful ones. This includes all attempts
+%% that were made using the Amazon Web Services Management Console, the
+%% Amazon Web Services API through any of the SDKs, or any of the command
+%% line tools. An unexpected entry in the service last accessed data does not
+%% mean that your account has been compromised, because the request might
+%% have been denied. Refer to your CloudTrail logs as the authoritative
+%% source for information about all API calls and whether they were
+%% successful or denied access. For more information, see Logging IAM events
+%% with CloudTrail in the IAM User Guide.
 %%
 %% The `GenerateServiceLastAccessedDetails' operation returns a `JobId'. Use
 %% this parameter in the following operations to retrieve the following
 %% details from your report:
 %%
 %% <ul> <li> `GetServiceLastAccessedDetails' – Use this operation for users,
-%% groups, roles, or policies to list every AWS service that the resource
-%% could access using permissions policies. For each service, the response
-%% includes information about the most recent access attempt.
+%% groups, roles, or policies to list every Amazon Web Services service that
+%% the resource could access using permissions policies. For each service,
+%% the response includes information about the most recent access attempt.
 %%
 %% The `JobId' returned by `GenerateServiceLastAccessedDetail' must be used
 %% by the same role within a session, or by the same user when used to call
@@ -1313,7 +1350,8 @@ generate_organizations_access_report(Client, Input, Options)
 %%
 %% </li> <li> `GetServiceLastAccessedDetailsWithEntities' – Use this
 %% operation for groups and policies to list information about the associated
-%% entities (users or roles) that attempted to access a specific AWS service.
+%% entities (users or roles) that attempted to access a specific Amazon Web
+%% Services service.
 %%
 %% </li> </ul> To check the status of the
 %% `GenerateServiceLastAccessedDetails' request, use the `JobId' parameter in
@@ -1325,11 +1363,10 @@ generate_organizations_access_report(Client, Input, Options)
 %%
 %% Service last accessed data does not use other policy types when
 %% determining whether a resource could access a service. These other policy
-%% types include resource-based policies, access control lists, AWS
-%% Organizations policies, IAM permissions boundaries, and AWS STS assume
-%% role policies. It only applies permissions policy logic. For more about
-%% the evaluation of policy types, see Evaluating policies in the IAM User
-%% Guide.
+%% types include resource-based policies, access control lists, Organizations
+%% policies, IAM permissions boundaries, and STS assume role policies. It
+%% only applies permissions policy logic. For more about the evaluation of
+%% policy types, see Evaluating policies in the IAM User Guide.
 %%
 %% For more information about service and action last accessed data, see
 %% Reducing permissions using service last accessed data in the IAM User
@@ -1344,9 +1381,9 @@ generate_service_last_accessed_details(Client, Input, Options)
 %% @doc Retrieves information about when the specified access key was last
 %% used.
 %%
-%% The information includes the date and time of last use, along with the AWS
-%% service and Region that were specified in the last request made with that
-%% key.
+%% The information includes the date and time of last use, along with the
+%% Amazon Web Services service and Region that were specified in the last
+%% request made with that key.
 get_access_key_last_used(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_access_key_last_used(Client, Input, []).
@@ -1355,8 +1392,8 @@ get_access_key_last_used(Client, Input, Options)
     request(Client, <<"GetAccessKeyLastUsed">>, Input, Options).
 
 %% @doc Retrieves information about all IAM users, groups, roles, and
-%% policies in your AWS account, including their relationships to one
-%% another.
+%% policies in your Amazon Web Services account, including their
+%% relationships to one another.
 %%
 %% Use this operation to obtain a snapshot of the configuration of IAM
 %% permissions (users, groups, roles, and policies) in your account.
@@ -1376,7 +1413,7 @@ get_account_authorization_details(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetAccountAuthorizationDetails">>, Input, Options).
 
-%% @doc Retrieves the password policy for the AWS account.
+%% @doc Retrieves the password policy for the Amazon Web Services account.
 %%
 %% This tells you the complexity requirements and mandatory rotation periods
 %% for the IAM user passwords in your account. For more information about
@@ -1389,7 +1426,7 @@ get_account_password_policy(Client, Input, Options)
     request(Client, <<"GetAccountPasswordPolicy">>, Input, Options).
 
 %% @doc Retrieves information about IAM entity usage and IAM quotas in the
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% For information about IAM quotas, see IAM and STS quotas in the IAM User
 %% Guide.
@@ -1407,13 +1444,13 @@ get_account_summary(Client, Input, Options)
 %% context keys from policies associated with an IAM user, group, or role,
 %% use `GetContextKeysForPrincipalPolicy'.
 %%
-%% Context keys are variables maintained by AWS and its services that provide
-%% details about the context of an API query request. Context keys can be
-%% evaluated by testing against a value specified in an IAM policy. Use
-%% `GetContextKeysForCustomPolicy' to understand what key names and values
-%% you must supply when you call `SimulateCustomPolicy'. Note that all
-%% parameters are shown in unencoded form here for clarity but must be URL
-%% encoded to be included as a part of a real HTML request.
+%% Context keys are variables maintained by Amazon Web Services and its
+%% services that provide details about the context of an API query request.
+%% Context keys can be evaluated by testing against a value specified in an
+%% IAM policy. Use `GetContextKeysForCustomPolicy' to understand what key
+%% names and values you must supply when you call `SimulateCustomPolicy'.
+%% Note that all parameters are shown in unencoded form here for clarity but
+%% must be URL encoded to be included as a part of a real HTML request.
 get_context_keys_for_custom_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_context_keys_for_custom_policy(Client, Input, []).
@@ -1437,11 +1474,11 @@ get_context_keys_for_custom_policy(Client, Input, Options)
 %% then consider allowing them to use `GetContextKeysForCustomPolicy'
 %% instead.
 %%
-%% Context keys are variables maintained by AWS and its services that provide
-%% details about the context of an API query request. Context keys can be
-%% evaluated by testing against a value in an IAM policy. Use
-%% `GetContextKeysForPrincipalPolicy' to understand what key names and values
-%% you must supply when you call `SimulatePrincipalPolicy'.
+%% Context keys are variables maintained by Amazon Web Services and its
+%% services that provide details about the context of an API query request.
+%% Context keys can be evaluated by testing against a value in an IAM policy.
+%% Use `GetContextKeysForPrincipalPolicy' to understand what key names and
+%% values you must supply when you call `SimulatePrincipalPolicy'.
 get_context_keys_for_principal_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_context_keys_for_principal_policy(Client, Input, []).
@@ -1449,7 +1486,7 @@ get_context_keys_for_principal_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetContextKeysForPrincipalPolicy">>, Input, Options).
 
-%% @doc Retrieves a credential report for the AWS account.
+%% @doc Retrieves a credential report for the Amazon Web Services account.
 %%
 %% For more information about the credential report, see Getting credential
 %% reports in the IAM User Guide.
@@ -1505,11 +1542,22 @@ get_instance_profile(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetInstanceProfile">>, Input, Options).
 
-%% @doc Retrieves the user name and password creation date for the specified
-%% IAM user.
+%% @doc Retrieves the user name for the specified IAM user.
 %%
-%% If the user has not been assigned a password, the operation returns a 404
+%% A login profile is created when you create a password for the user to
+%% access the Amazon Web Services Management Console. If the user does not
+%% exist or does not have a password, the operation returns a 404
 %% (`NoSuchEntity') error.
+%%
+%% If you create an IAM user with access to the console, the `CreateDate'
+%% reflects the date you created the initial password for the user.
+%%
+%% If you create an IAM user with programmatic access, and then later add a
+%% password for the user to access the Amazon Web Services Management
+%% Console, the `CreateDate' reflects the initial password creation date. A
+%% user with programmatic access does not have a login profile unless you
+%% create a password for the user to access the Amazon Web Services
+%% Management Console.
 get_login_profile(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_login_profile(Client, Input, []).
@@ -1526,7 +1574,7 @@ get_open_id_connect_provider(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetOpenIDConnectProvider">>, Input, Options).
 
-%% @doc Retrieves the service last accessed data report for AWS Organizations
+%% @doc Retrieves the service last accessed data report for Organizations
 %% that was previously generated using the `
 %% `GenerateOrganizationsAccessReport' ' operation.
 %%
@@ -1666,8 +1714,8 @@ get_saml_provider(Client, Input, Options)
 %%
 %% For more information about working with server certificates, see Working
 %% with server certificates in the IAM User Guide. This topic includes a list
-%% of AWS services that can use the server certificates that you manage with
-%% IAM.
+%% of Amazon Web Services services that can use the server certificates that
+%% you manage with IAM.
 get_server_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_server_certificate(Client, Input, []).
@@ -1680,17 +1728,16 @@ get_server_certificate(Client, Input, Options)
 %%
 %% You can use the `JobId' parameter in `GetServiceLastAccessedDetails' to
 %% retrieve the status of your report job. When the report is complete, you
-%% can retrieve the generated report. The report includes a list of AWS
-%% services that the resource (user, group, role, or managed policy) can
-%% access.
+%% can retrieve the generated report. The report includes a list of Amazon
+%% Web Services services that the resource (user, group, role, or managed
+%% policy) can access.
 %%
 %% Service last accessed data does not use other policy types when
 %% determining whether a resource could access a service. These other policy
-%% types include resource-based policies, access control lists, AWS
-%% Organizations policies, IAM permissions boundaries, and AWS STS assume
-%% role policies. It only applies permissions policy logic. For more about
-%% the evaluation of policy types, see Evaluating policies in the IAM User
-%% Guide.
+%% types include resource-based policies, access control lists, Organizations
+%% policies, IAM permissions boundaries, and STS assume role policies. It
+%% only applies permissions policy logic. For more about the evaluation of
+%% policy types, see Evaluating policies in the IAM User Guide.
 %%
 %% For each service that the resource could access using permissions
 %% policies, the operation returns details about the most recent access
@@ -1782,10 +1829,10 @@ get_service_linked_role_deletion_status(Client, Input, Options)
 %% key.
 %%
 %% The SSH public key retrieved by this operation is used only for
-%% authenticating the associated IAM user to an AWS CodeCommit repository.
-%% For more information about using SSH keys to authenticate to an AWS
-%% CodeCommit repository, see Set up AWS CodeCommit for SSH connections in
-%% the AWS CodeCommit User Guide.
+%% authenticating the associated IAM user to an CodeCommit repository. For
+%% more information about using SSH keys to authenticate to an CodeCommit
+%% repository, see Set up CodeCommit for SSH connections in the CodeCommit
+%% User Guide.
 get_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ssh_public_key(Client, Input, []).
@@ -1797,7 +1844,8 @@ get_ssh_public_key(Client, Input, Options)
 %% user's creation date, path, unique ID, and ARN.
 %%
 %% If you do not specify a user name, IAM determines the user name implicitly
-%% based on the AWS access key ID used to sign the request to this operation.
+%% based on the Amazon Web Services access key ID used to sign the request to
+%% this operation.
 get_user(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_user(Client, Input, []).
@@ -1837,13 +1885,14 @@ get_user_policy(Client, Input, Options)
 %% paginate the results using the `MaxItems' and `Marker' parameters.
 %%
 %% If the `UserName' field is not specified, the user name is determined
-%% implicitly based on the AWS access key ID used to sign the request. This
-%% operation works for access keys under the AWS account. Consequently, you
-%% can use this operation to manage AWS account root user credentials even if
-%% the AWS account has no associated users.
+%% implicitly based on the Amazon Web Services access key ID used to sign the
+%% request. This operation works for access keys under the Amazon Web
+%% Services account. Consequently, you can use this operation to manage
+%% Amazon Web Services account root user credentials even if the Amazon Web
+%% Services account has no associated users.
 %%
-%% To ensure the security of your AWS account, the secret access key is
-%% accessible only during key and user creation.
+%% To ensure the security of your Amazon Web Services account, the secret
+%% access key is accessible only during key and user creation.
 list_access_keys(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_access_keys(Client, Input, []).
@@ -1851,11 +1900,12 @@ list_access_keys(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAccessKeys">>, Input, Options).
 
-%% @doc Lists the account alias associated with the AWS account (Note: you
-%% can have only one).
+%% @doc Lists the account alias associated with the Amazon Web Services
+%% account (Note: you can have only one).
 %%
-%% For information about using an AWS account alias, see Using an alias for
-%% your AWS account ID in the IAM User Guide.
+%% For information about using an Amazon Web Services account alias, see
+%% Using an alias for your Amazon Web Services account ID in the IAM User
+%% Guide.
 list_account_aliases(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_account_aliases(Client, Input, []).
@@ -2035,8 +2085,8 @@ list_mfa_device_tags(Client, Input, Options)
 %%
 %% If the request includes a IAM user name, then this operation lists all the
 %% MFA devices associated with the specified user. If you do not specify a
-%% user name, IAM determines the user name implicitly based on the AWS access
-%% key ID signing the request for this operation.
+%% user name, IAM determines the user name implicitly based on the Amazon Web
+%% Services access key ID signing the request for this operation.
 %%
 %% You can paginate the results using the `MaxItems' and `Marker' parameters.
 list_mfa_devices(Client, Input)
@@ -2062,7 +2112,7 @@ list_open_id_connect_provider_tags(Client, Input, Options)
     request(Client, <<"ListOpenIDConnectProviderTags">>, Input, Options).
 
 %% @doc Lists information about the IAM OpenID Connect (OIDC) provider
-%% resource objects defined in the AWS account.
+%% resource objects defined in the Amazon Web Services account.
 %%
 %% IAM resource-listing operations return a subset of the available
 %% attributes for the resource. For example, this operation does not return
@@ -2076,14 +2126,15 @@ list_open_id_connect_providers(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListOpenIDConnectProviders">>, Input, Options).
 
-%% @doc Lists all the managed policies that are available in your AWS
-%% account, including your own customer-defined managed policies and all AWS
-%% managed policies.
+%% @doc Lists all the managed policies that are available in your Amazon Web
+%% Services account, including your own customer-defined managed policies and
+%% all Amazon Web Services managed policies.
 %%
 %% You can filter the list of policies that is returned using the optional
 %% `OnlyAttached', `Scope', and `PathPrefix' parameters. For example, to list
-%% only the customer managed policies in your AWS account, set `Scope' to
-%% `Local'. To list only AWS managed policies, set `Scope' to `AWS'.
+%% only the customer managed policies in your Amazon Web Services account,
+%% set `Scope' to `Local'. To list only Amazon Web Services managed policies,
+%% set `Scope' to `AWS'.
 %%
 %% You can paginate the results using the `MaxItems' and `Marker' parameters.
 %%
@@ -2106,10 +2157,10 @@ list_policies(Client, Input, Options)
 %%
 %% This operation does not use other policy types when determining whether a
 %% resource could access a service. These other policy types include
-%% resource-based policies, access control lists, AWS Organizations policies,
-%% IAM permissions boundaries, and AWS STS assume role policies. It only
-%% applies permissions policy logic. For more about the evaluation of policy
-%% types, see Evaluating policies in the IAM User Guide.
+%% resource-based policies, access control lists, Organizations policies, IAM
+%% permissions boundaries, and STS assume role policies. It only applies
+%% permissions policy logic. For more about the evaluation of policy types,
+%% see Evaluating policies in the IAM User Guide.
 %%
 %% The list of policies returned by the operation depends on the ARN of the
 %% identity that you provide.
@@ -2252,9 +2303,9 @@ list_saml_providers(Client, Input, Options)
 %% The returned list of tags is sorted by tag key. For more information about
 %% tagging, see Tagging IAM resources in the IAM User Guide.
 %%
-%% For certificates in a Region supported by AWS Certificate Manager (ACM),
-%% we recommend that you don't use IAM server certificates. Instead, use ACM
-%% to provision, manage, and deploy your server certificates. For more
+%% For certificates in a Region supported by Certificate Manager (ACM), we
+%% recommend that you don't use IAM server certificates. Instead, use ACM to
+%% provision, manage, and deploy your server certificates. For more
 %% information about IAM server certificates, Working with server
 %% certificates in the IAM User Guide.
 list_server_certificate_tags(Client, Input)
@@ -2273,8 +2324,8 @@ list_server_certificate_tags(Client, Input, Options)
 %%
 %% For more information about working with server certificates, see Working
 %% with server certificates in the IAM User Guide. This topic also includes a
-%% list of AWS services that can use the server certificates that you manage
-%% with IAM.
+%% list of Amazon Web Services services that can use the server certificates
+%% that you manage with IAM.
 %%
 %% IAM resource-listing operations return a subset of the available
 %% attributes for the resource. For example, this operation does not return
@@ -2294,8 +2345,9 @@ list_server_certificates(Client, Input, Options)
 %% If none exists, the operation returns an empty list. The service-specific
 %% credentials returned by this operation are used only for authenticating
 %% the IAM user to a specific service. For more information about using
-%% service-specific credentials to authenticate to an AWS service, see Set up
-%% service-specific credentials in the AWS CodeCommit User Guide.
+%% service-specific credentials to authenticate to an Amazon Web Services
+%% service, see Set up service-specific credentials in the CodeCommit User
+%% Guide.
 list_service_specific_credentials(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_service_specific_credentials(Client, Input, []).
@@ -2313,10 +2365,11 @@ list_service_specific_credentials(Client, Input, Options)
 %% parameters.
 %%
 %% If the `UserName' field is not specified, the user name is determined
-%% implicitly based on the AWS access key ID used to sign the request for
-%% this operation. This operation works for access keys under the AWS
-%% account. Consequently, you can use this operation to manage AWS account
-%% root user credentials even if the AWS account has no associated users.
+%% implicitly based on the Amazon Web Services access key ID used to sign the
+%% request for this operation. This operation works for access keys under the
+%% Amazon Web Services account. Consequently, you can use this operation to
+%% manage Amazon Web Services account root user credentials even if the
+%% Amazon Web Services account has no associated users.
 list_signing_certificates(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_signing_certificates(Client, Input, []).
@@ -2330,10 +2383,10 @@ list_signing_certificates(Client, Input, Options)
 %% If none exists, the operation returns an empty list.
 %%
 %% The SSH public keys returned by this operation are used only for
-%% authenticating the IAM user to an AWS CodeCommit repository. For more
-%% information about using SSH keys to authenticate to an AWS CodeCommit
-%% repository, see Set up AWS CodeCommit for SSH connections in the AWS
-%% CodeCommit User Guide.
+%% authenticating the IAM user to an CodeCommit repository. For more
+%% information about using SSH keys to authenticate to an CodeCommit
+%% repository, see Set up CodeCommit for SSH connections in the CodeCommit
+%% User Guide.
 %%
 %% Although each user is limited to a small number of keys, you can still
 %% paginate the results using the `MaxItems' and `Marker' parameters.
@@ -2375,8 +2428,9 @@ list_user_tags(Client, Input, Options)
 
 %% @doc Lists the IAM users that have the specified path prefix.
 %%
-%% If no path prefix is specified, the operation returns all users in the AWS
-%% account. If there are none, the operation returns an empty list.
+%% If no path prefix is specified, the operation returns all users in the
+%% Amazon Web Services account. If there are none, the operation returns an
+%% empty list.
 %%
 %% IAM resource-listing operations return a subset of the available
 %% attributes for the resource. For example, this operation does not return
@@ -2391,8 +2445,8 @@ list_users(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListUsers">>, Input, Options).
 
-%% @doc Lists the virtual MFA devices defined in the AWS account by
-%% assignment status.
+%% @doc Lists the virtual MFA devices defined in the Amazon Web Services
+%% account by assignment status.
 %%
 %% If you do not specify an assignment status, the operation returns a list
 %% of all virtual MFA devices. Assignment status can be `Assigned',
@@ -2436,10 +2490,10 @@ put_group_policy(Client, Input, Options)
 %% @doc Adds or updates the policy that is specified as the IAM role's
 %% permissions boundary.
 %%
-%% You can use an AWS managed policy or a customer managed policy to set the
-%% boundary for a role. Use the boundary to control the maximum permissions
-%% that the role can have. Setting a permissions boundary is an advanced
-%% feature that can affect the permissions for the role.
+%% You can use an Amazon Web Services managed policy or a customer managed
+%% policy to set the boundary for a role. Use the boundary to control the
+%% maximum permissions that the role can have. Setting a permissions boundary
+%% is an advanced feature that can affect the permissions for the role.
 %%
 %% You cannot set the boundary for a service-linked role.
 %%
@@ -2485,10 +2539,10 @@ put_role_policy(Client, Input, Options)
 %% @doc Adds or updates the policy that is specified as the IAM user's
 %% permissions boundary.
 %%
-%% You can use an AWS managed policy or a customer managed policy to set the
-%% boundary for a user. Use the boundary to control the maximum permissions
-%% that the user can have. Setting a permissions boundary is an advanced
-%% feature that can affect the permissions for the user.
+%% You can use an Amazon Web Services managed policy or a customer managed
+%% policy to set the boundary for a user. Use the boundary to control the
+%% maximum permissions that the user can have. Setting a permissions boundary
+%% is an advanced feature that can affect the permissions for the user.
 %%
 %% Policies that are used as permissions boundaries do not provide
 %% permissions. You must also attach a permissions policy to the user. To
@@ -2562,9 +2616,9 @@ remove_user_from_group(Client, Input, Options)
 
 %% @doc Resets the password for a service-specific credential.
 %%
-%% The new password is AWS generated and cryptographically strong. It cannot
-%% be configured by the user. Resetting the password immediately invalidates
-%% the previous password associated with this user.
+%% The new password is Amazon Web Services generated and cryptographically
+%% strong. It cannot be configured by the user. Resetting the password
+%% immediately invalidates the previous password associated with this user.
 reset_service_specific_credential(Client, Input)
   when is_map(Client), is_map(Input) ->
     reset_service_specific_credential(Client, Input, []).
@@ -2573,7 +2627,7 @@ reset_service_specific_credential(Client, Input, Options)
     request(Client, <<"ResetServiceSpecificCredential">>, Input, Options).
 
 %% @doc Synchronizes the specified MFA device with its IAM resource object on
-%% the AWS servers.
+%% the Amazon Web Services servers.
 %%
 %% For more information about creating and working with virtual MFA devices,
 %% see Using a virtual MFA device in the IAM User Guide.
@@ -2601,25 +2655,25 @@ set_default_policy_version(Client, Input, Options)
     request(Client, <<"SetDefaultPolicyVersion">>, Input, Options).
 
 %% @doc Sets the specified version of the global endpoint token as the token
-%% version used for the AWS account.
+%% version used for the Amazon Web Services account.
 %%
-%% By default, AWS Security Token Service (STS) is available as a global
-%% service, and all STS requests go to a single endpoint at
-%% `https://sts.amazonaws.com'. AWS recommends using Regional STS endpoints
-%% to reduce latency, build in redundancy, and increase session token
-%% availability. For information about Regional endpoints for STS, see AWS
-%% AWS Security Token Service endpoints and quotas in the AWS General
-%% Reference.
+%% By default, Security Token Service (STS) is available as a global service,
+%% and all STS requests go to a single endpoint at
+%% `https://sts.amazonaws.com'. Amazon Web Services recommends using Regional
+%% STS endpoints to reduce latency, build in redundancy, and increase session
+%% token availability. For information about Regional endpoints for STS, see
+%% Security Token Service endpoints and quotas in the Amazon Web Services
+%% General Reference.
 %%
 %% If you make an STS call to the global endpoint, the resulting session
 %% tokens might be valid in some Regions but not others. It depends on the
 %% version that is set in this operation. Version 1 tokens are valid only in
-%% AWS Regions that are available by default. These tokens do not work in
-%% manually enabled Regions, such as Asia Pacific (Hong Kong). Version 2
-%% tokens are valid in all Regions. However, version 2 tokens are longer and
-%% might affect systems where you temporarily store tokens. For information,
-%% see Activating and deactivating STS in an AWS region in the IAM User
-%% Guide.
+%% Amazon Web Services Regions that are available by default. These tokens do
+%% not work in manually enabled Regions, such as Asia Pacific (Hong Kong).
+%% Version 2 tokens are valid in all Regions. However, version 2 tokens are
+%% longer and might affect systems where you temporarily store tokens. For
+%% information, see Activating and deactivating STS in an Amazon Web Services
+%% Region in the IAM User Guide.
 %%
 %% To view the current session token version, see the
 %% `GlobalEndpointTokenVersion' entry in the response of the
@@ -2632,8 +2686,8 @@ set_security_token_service_preferences(Client, Input, Options)
     request(Client, <<"SetSecurityTokenServicePreferences">>, Input, Options).
 
 %% @doc Simulate how a set of IAM policies and optionally a resource-based
-%% policy works with a list of API operations and AWS resources to determine
-%% the policies' effective permissions.
+%% policy works with a list of API operations and Amazon Web Services
+%% resources to determine the policies' effective permissions.
 %%
 %% The policies are provided as strings.
 %%
@@ -2644,11 +2698,11 @@ set_security_token_service_preferences(Client, Input, Options)
 %% If you want to simulate existing policies that are attached to an IAM
 %% user, group, or role, use `SimulatePrincipalPolicy' instead.
 %%
-%% Context keys are variables that are maintained by AWS and its services and
-%% which provide details about the context of an API query request. You can
-%% use the `Condition' element of an IAM policy to evaluate context keys. To
-%% get the list of context keys that the policies require for correct
-%% simulation, use `GetContextKeysForCustomPolicy'.
+%% Context keys are variables that are maintained by Amazon Web Services and
+%% its services and which provide details about the context of an API query
+%% request. You can use the `Condition' element of an IAM policy to evaluate
+%% context keys. To get the list of context keys that the policies require
+%% for correct simulation, use `GetContextKeysForCustomPolicy'.
 %%
 %% If the output is long, you can use `MaxItems' and `Marker' parameters to
 %% paginate the results.
@@ -2663,8 +2717,8 @@ simulate_custom_policy(Client, Input, Options)
     request(Client, <<"SimulateCustomPolicy">>, Input, Options).
 
 %% @doc Simulate how a set of IAM policies attached to an IAM entity works
-%% with a list of API operations and AWS resources to determine the policies'
-%% effective permissions.
+%% with a list of API operations and Amazon Web Services resources to
+%% determine the policies' effective permissions.
 %%
 %% The entity can be an IAM user, group, or role. If you specify a user, then
 %% the simulation also includes all of the policies that are attached to
@@ -2686,11 +2740,11 @@ simulate_custom_policy(Client, Input, Options)
 %% to other users. If you do not want users to see other user's permissions,
 %% then consider allowing them to use `SimulateCustomPolicy' instead.
 %%
-%% Context keys are variables maintained by AWS and its services that provide
-%% details about the context of an API query request. You can use the
-%% `Condition' element of an IAM policy to evaluate context keys. To get the
-%% list of context keys that the policies require for correct simulation, use
-%% `GetContextKeysForPrincipalPolicy'.
+%% Context keys are variables maintained by Amazon Web Services and its
+%% services that provide details about the context of an API query request.
+%% You can use the `Condition' element of an IAM policy to evaluate context
+%% keys. To get the list of context keys that the policies require for
+%% correct simulation, use `GetContextKeysForPrincipalPolicy'.
 %%
 %% If the output is long, you can use the `MaxItems' and `Marker' parameters
 %% to paginate the results.
@@ -2729,9 +2783,9 @@ simulate_principal_policy(Client, Input, Options)
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_instance_profile(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_instance_profile(Client, Input, []).
@@ -2765,9 +2819,9 @@ tag_instance_profile(Client, Input, Options)
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_mfa_device(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_mfa_device(Client, Input, []).
@@ -2802,9 +2856,9 @@ tag_mfa_device(Client, Input, Options)
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_open_id_connect_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_open_id_connect_provider(Client, Input, []).
@@ -2837,9 +2891,9 @@ tag_open_id_connect_provider(Client, Input, Options)
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_policy(Client, Input, []).
@@ -2870,16 +2924,16 @@ tag_policy(Client, Input, Options)
 %% using IAM tags in the IAM User Guide.
 %%
 %% </li> <li> Cost allocation - Use tags to help track which individuals and
-%% teams are using which AWS resources.
+%% teams are using which Amazon Web Services resources.
 %%
 %% </li> </ul> If any one of the tags is invalid or if you exceed the allowed
 %% maximum number of tags, then the entire request fails and the resource is
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 %%
 %% For more information about tagging, see Tagging IAM identities in the IAM
 %% User Guide.
@@ -2917,9 +2971,9 @@ tag_role(Client, Input, Options)
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_saml_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_saml_provider(Client, Input, []).
@@ -2932,9 +2986,9 @@ tag_saml_provider(Client, Input, Options)
 %% If a tag with the same key name already exists, then that tag is
 %% overwritten with the new value.
 %%
-%% For certificates in a Region supported by AWS Certificate Manager (ACM),
-%% we recommend that you don't use IAM server certificates. Instead, use ACM
-%% to provision, manage, and deploy your server certificates. For more
+%% For certificates in a Region supported by Certificate Manager (ACM), we
+%% recommend that you don't use IAM server certificates. Instead, use ACM to
+%% provision, manage, and deploy your server certificates. For more
 %% information about IAM server certificates, Working with server
 %% certificates in the IAM User Guide.
 %%
@@ -2954,16 +3008,16 @@ tag_saml_provider(Client, Input, Options)
 %% using IAM tags in the IAM User Guide.
 %%
 %% </li> <li> Cost allocation - Use tags to help track which individuals and
-%% teams are using which AWS resources.
+%% teams are using which Amazon Web Services resources.
 %%
 %% </li> </ul> If any one of the tags is invalid or if you exceed the allowed
 %% maximum number of tags, then the entire request fails and the resource is
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 tag_server_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_server_certificate(Client, Input, []).
@@ -2993,16 +3047,16 @@ tag_server_certificate(Client, Input, Options)
 %% Control access using IAM tags in the IAM User Guide.
 %%
 %% </li> <li> Cost allocation - Use tags to help track which individuals and
-%% teams are using which AWS resources.
+%% teams are using which Amazon Web Services resources.
 %%
 %% </li> </ul> If any one of the tags is invalid or if you exceed the allowed
 %% maximum number of tags, then the entire request fails and the resource is
 %% not created. For more information about tagging, see Tagging IAM resources
 %% in the IAM User Guide.
 %%
-%% AWS always interprets the tag `Value' as a single string. If you need to
-%% store an array, you can store comma-separated values in the string.
-%% However, you must interpret the value in your code.
+%% Amazon Web Services always interprets the tag `Value' as a single string.
+%% If you need to store an array, you can store comma-separated values in the
+%% string. However, you must interpret the value in your code.
 %%
 %% For more information about tagging, see Tagging IAM identities in the IAM
 %% User Guide.
@@ -3089,9 +3143,9 @@ untag_saml_provider(Client, Input, Options)
 %% For more information about tagging, see Tagging IAM resources in the IAM
 %% User Guide.
 %%
-%% For certificates in a Region supported by AWS Certificate Manager (ACM),
-%% we recommend that you don't use IAM server certificates. Instead, use ACM
-%% to provision, manage, and deploy your server certificates. For more
+%% For certificates in a Region supported by Certificate Manager (ACM), we
+%% recommend that you don't use IAM server certificates. Instead, use ACM to
+%% provision, manage, and deploy your server certificates. For more
 %% information about IAM server certificates, Working with server
 %% certificates in the IAM User Guide.
 untag_server_certificate(Client, Input)
@@ -3119,9 +3173,10 @@ untag_user(Client, Input, Options)
 %% rotation workflow.
 %%
 %% If the `UserName' is not specified, the user name is determined implicitly
-%% based on the AWS access key ID used to sign the request. This operation
-%% works for access keys under the AWS account. Consequently, you can use
-%% this operation to manage AWS account root user credentials even if the AWS
+%% based on the Amazon Web Services access key ID used to sign the request.
+%% This operation works for access keys under the Amazon Web Services
+%% account. Consequently, you can use this operation to manage Amazon Web
+%% Services account root user credentials even if the Amazon Web Services
 %% account has no associated users.
 %%
 %% For information about rotating keys, see Managing keys and certificates in
@@ -3133,7 +3188,8 @@ update_access_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateAccessKey">>, Input, Options).
 
-%% @doc Updates the password policy settings for the AWS account.
+%% @doc Updates the password policy settings for the Amazon Web Services
+%% account.
 %%
 %% This operation does not support partial updates. No parameters are
 %% required, but if you do not specify a parameter, that parameter's value
@@ -3185,10 +3241,10 @@ update_group(Client, Input, Options)
 
 %% @doc Changes the password for the specified IAM user.
 %%
-%% You can use the AWS CLI, the AWS API, or the Users page in the IAM console
-%% to change the password for any IAM user. Use `ChangePassword' to change
-%% your own password in the My Security Credentials page in the AWS
-%% Management Console.
+%% You can use the CLI, the Amazon Web Services API, or the Users page in the
+%% IAM console to change the password for any IAM user. Use `ChangePassword'
+%% to change your own password in the My Security Credentials page in the
+%% Amazon Web Services Management Console.
 %%
 %% For more information about modifying passwords, see Managing passwords in
 %% the IAM User Guide.
@@ -3206,13 +3262,21 @@ update_login_profile(Client, Input, Options)
 %% The list that you pass with this operation completely replaces the
 %% existing list of thumbprints. (The lists are not merged.)
 %%
-%% Typically, you need to update a thumbprint only when the identity
-%% provider's certificate changes, which occurs rarely. However, if the
-%% provider's certificate does change, any attempt to assume an IAM role that
-%% specifies the OIDC provider as a principal fails until the certificate
-%% thumbprint is updated.
+%% Typically, you need to update a thumbprint only when the identity provider
+%% certificate changes, which occurs rarely. However, if the provider's
+%% certificate does change, any attempt to assume an IAM role that specifies
+%% the OIDC provider as a principal fails until the certificate thumbprint is
+%% updated.
 %%
-%% Trust for the OIDC provider is derived from the provider's certificate and
+%% Amazon Web Services secures communication with some OIDC identity
+%% providers (IdPs) through our library of trusted certificate authorities
+%% (CAs) instead of using a certificate thumbprint to verify your IdP server
+%% certificate. These OIDC IdPs include Google, and those that use an Amazon
+%% S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these cases, your
+%% legacy thumbprint remains in your configuration, but is no longer used for
+%% validation.
+%%
+%% Trust for the OIDC provider is derived from the provider certificate and
 %% is validated by the thumbprint. Therefore, it is best to limit access to
 %% the `UpdateOpenIDConnectProviderThumbprint' operation to highly privileged
 %% users.
@@ -3259,8 +3323,8 @@ update_saml_provider(Client, Input, Options)
 %%
 %% For more information about working with server certificates, see Working
 %% with server certificates in the IAM User Guide. This topic also includes a
-%% list of AWS services that can use the server certificates that you manage
-%% with IAM.
+%% list of Amazon Web Services services that can use the server certificates
+%% that you manage with IAM.
 %%
 %% You should understand the implications of changing a server certificate's
 %% path or name. For more information, see Renaming a server certificate in
@@ -3302,10 +3366,11 @@ update_service_specific_credential(Client, Input, Options)
 %% part of a certificate rotation work flow.
 %%
 %% If the `UserName' field is not specified, the user name is determined
-%% implicitly based on the AWS access key ID used to sign the request. This
-%% operation works for access keys under the AWS account. Consequently, you
-%% can use this operation to manage AWS account root user credentials even if
-%% the AWS account has no associated users.
+%% implicitly based on the Amazon Web Services access key ID used to sign the
+%% request. This operation works for access keys under the Amazon Web
+%% Services account. Consequently, you can use this operation to manage
+%% Amazon Web Services account root user credentials even if the Amazon Web
+%% Services account has no associated users.
 update_signing_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_signing_certificate(Client, Input, []).
@@ -3321,10 +3386,10 @@ update_signing_certificate(Client, Input, Options)
 %% rotation work flow.
 %%
 %% The SSH public key affected by this operation is used only for
-%% authenticating the associated IAM user to an AWS CodeCommit repository.
-%% For more information about using SSH keys to authenticate to an AWS
-%% CodeCommit repository, see Set up AWS CodeCommit for SSH connections in
-%% the AWS CodeCommit User Guide.
+%% authenticating the associated IAM user to an CodeCommit repository. For
+%% more information about using SSH keys to authenticate to an CodeCommit
+%% repository, see Set up CodeCommit for SSH connections in the CodeCommit
+%% User Guide.
 update_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_ssh_public_key(Client, Input, []).
@@ -3350,21 +3415,22 @@ update_user(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateUser">>, Input, Options).
 
-%% @doc Uploads a server certificate entity for the AWS account.
+%% @doc Uploads a server certificate entity for the Amazon Web Services
+%% account.
 %%
 %% The server certificate entity includes a public key certificate, a private
 %% key, and an optional certificate chain, which should all be PEM-encoded.
 %%
-%% We recommend that you use AWS Certificate Manager to provision, manage,
-%% and deploy your server certificates. With ACM you can request a
-%% certificate, deploy it to AWS resources, and let ACM handle certificate
+%% We recommend that you use Certificate Manager to provision, manage, and
+%% deploy your server certificates. With ACM you can request a certificate,
+%% deploy it to Amazon Web Services resources, and let ACM handle certificate
 %% renewals for you. Certificates provided by ACM are free. For more
-%% information about using ACM, see the AWS Certificate Manager User Guide.
+%% information about using ACM, see the Certificate Manager User Guide.
 %%
 %% For more information about working with server certificates, see Working
 %% with server certificates in the IAM User Guide. This topic includes a list
-%% of AWS services that can use the server certificates that you manage with
-%% IAM.
+%% of Amazon Web Services services that can use the server certificates that
+%% you manage with IAM.
 %%
 %% For information about the number of server certificates you can upload,
 %% see IAM and STS quotas in the IAM User Guide.
@@ -3372,10 +3438,10 @@ update_user(Client, Input, Options)
 %% Because the body of the public key certificate, private key, and the
 %% certificate chain can be large, you should use POST rather than GET when
 %% calling `UploadServerCertificate'. For information about setting up
-%% signatures and authorization through the API, see Signing AWS API requests
-%% in the AWS General Reference. For general information about using the
-%% Query API with IAM, see Calling the API by making HTTP query requests in
-%% the IAM User Guide.
+%% signatures and authorization through the API, see Signing Amazon Web
+%% Services API requests in the Amazon Web Services General Reference. For
+%% general information about using the Query API with IAM, see Calling the
+%% API by making HTTP query requests in the IAM User Guide.
 upload_server_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     upload_server_certificate(Client, Input, []).
@@ -3386,25 +3452,26 @@ upload_server_certificate(Client, Input, Options)
 %% @doc Uploads an X.509 signing certificate and associates it with the
 %% specified IAM user.
 %%
-%% Some AWS services require you to use certificates to validate requests
-%% that are signed with a corresponding private key. When you upload the
-%% certificate, its default status is `Active'.
+%% Some Amazon Web Services services require you to use certificates to
+%% validate requests that are signed with a corresponding private key. When
+%% you upload the certificate, its default status is `Active'.
 %%
 %% For information about when you would use an X.509 signing certificate, see
 %% Managing server certificates in IAM in the IAM User Guide.
 %%
 %% If the `UserName' is not specified, the IAM user name is determined
-%% implicitly based on the AWS access key ID used to sign the request. This
-%% operation works for access keys under the AWS account. Consequently, you
-%% can use this operation to manage AWS account root user credentials even if
-%% the AWS account has no associated users.
+%% implicitly based on the Amazon Web Services access key ID used to sign the
+%% request. This operation works for access keys under the Amazon Web
+%% Services account. Consequently, you can use this operation to manage
+%% Amazon Web Services account root user credentials even if the Amazon Web
+%% Services account has no associated users.
 %%
 %% Because the body of an X.509 certificate can be large, you should use POST
 %% rather than GET when calling `UploadSigningCertificate'. For information
 %% about setting up signatures and authorization through the API, see Signing
-%% AWS API requests in the AWS General Reference. For general information
-%% about using the Query API with IAM, see Making query requests in the IAM
-%% User Guide.
+%% Amazon Web Services API requests in the Amazon Web Services General
+%% Reference. For general information about using the Query API with IAM, see
+%% Making query requests in the IAM User Guide.
 upload_signing_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     upload_signing_certificate(Client, Input, []).
@@ -3416,10 +3483,10 @@ upload_signing_certificate(Client, Input, Options)
 %% user.
 %%
 %% The SSH public key uploaded by this operation can be used only for
-%% authenticating the associated IAM user to an AWS CodeCommit repository.
-%% For more information about using SSH keys to authenticate to an AWS
-%% CodeCommit repository, see Set up AWS CodeCommit for SSH connections in
-%% the AWS CodeCommit User Guide.
+%% authenticating the associated IAM user to an CodeCommit repository. For
+%% more information about using SSH keys to authenticate to an CodeCommit
+%% repository, see Set up CodeCommit for SSH connections in the CodeCommit
+%% User Guide.
 upload_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     upload_ssh_public_key(Client, Input, []).

--- a/src/aws_identitystore.erl
+++ b/src/aws_identitystore.erl
@@ -1,7 +1,10 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-
+%% @doc The AWS Single Sign-On (SSO) Identity Store service provides a single
+%% place to retrieve all of your identities (users and groups).
+%%
+%% For more information about AWS, see the AWS Single Sign-On User Guide.
 -module(aws_identitystore).
 
 -export([describe_group/2,

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -1,10 +1,11 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc EC2 Image Builder is a fully managed AWS service that makes it easier
-%% to automate the creation, management, and deployment of customized,
-%% secure, and up-to-date "golden" server images that are pre-installed and
-%% pre-configured with software and settings to meet specific IT standards.
+%% @doc EC2 Image Builder is a fully managed Amazon Web Services service that
+%% makes it easier to automate the creation, management, and deployment of
+%% customized, secure, and up-to-date "golden" server images that are
+%% pre-installed and pre-configured with software and settings to meet
+%% specific IT standards.
 -module(aws_imagebuilder).
 
 -export([cancel_image_creation/2,
@@ -227,7 +228,9 @@ create_distribution_configuration(Client, Input0, Options0) ->
 %% @doc Creates a new image.
 %%
 %% This request will create a new image along with all of the configured
-%% output resources defined in the distribution configuration.
+%% output resources defined in the distribution configuration. You must
+%% specify exactly one recipe for your image, using either a
+%% ContainerRecipeArn or an ImageRecipeArn.
 create_image(Client, Input) ->
     create_image(Client, Input, []).
 create_image(Client, Input0, Options0) ->
@@ -399,7 +402,23 @@ delete_distribution_configuration(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an image.
+%% @doc Deletes an Image Builder image resource.
+%%
+%% This does not delete any EC2 AMIs or ECR container images that are created
+%% during the image build process. You must clean those up separately, using
+%% the appropriate Amazon EC2 or Amazon ECR console actions, or API or CLI
+%% commands.
+%%
+%% <ul> <li> To deregister an EC2 Linux AMI, see Deregister your Linux AMI in
+%% the Amazon EC2 User Guide .
+%%
+%% </li> <li> To deregister an EC2 Windows AMI, see Deregister your Windows
+%% AMI in the Amazon EC2 Windows Guide .
+%%
+%% </li> <li> To delete a container image from Amazon ECR, see Deleting an
+%% image in the Amazon ECR User Guide.
+%%
+%% </li> </ul>
 delete_image(Client, Input) ->
     delete_image(Client, Input, []).
 delete_image(Client, Input0, Options0) ->
@@ -818,6 +837,15 @@ import_component(Client, Input0, Options0) ->
 
 %% @doc Returns the list of component build versions for the specified
 %% semantic version.
+%%
+%% The semantic version has four nodes: <major>.<minor>.<patch>/<build>. You
+%% can assign values for the first three, and can filter on all of them.
+%%
+%% Filtering: With semantic versioning, you have the flexibility to use
+%% wildcards (x) to specify the most recent versions or nodes when selecting
+%% the base image or components for your recipe. When you use a wildcard in
+%% any node, all nodes to the right of the first wildcard must also be
+%% wildcards.
 list_component_build_versions(Client, Input) ->
     list_component_build_versions(Client, Input, []).
 list_component_build_versions(Client, Input0, Options0) ->
@@ -842,6 +870,15 @@ list_component_build_versions(Client, Input0, Options0) ->
 
 %% @doc Returns the list of component build versions for the specified
 %% semantic version.
+%%
+%% The semantic version has four nodes: <major>.<minor>.<patch>/<build>. You
+%% can assign values for the first three, and can filter on all of them.
+%%
+%% Filtering: With semantic versioning, you have the flexibility to use
+%% wildcards (x) to specify the most recent versions or nodes when selecting
+%% the base image or components for your recipe. When you use a wildcard in
+%% any node, all nodes to the right of the first wildcard must also be
+%% wildcards.
 list_components(Client, Input) ->
     list_components(Client, Input, []).
 list_components(Client, Input0, Options0) ->
@@ -934,7 +971,7 @@ list_image_build_versions(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc List the Packages that are associated with an Image Build Version, as
-%% determined by AWS Systems Manager Inventory at build time.
+%% determined by Amazon Web Services Systems Manager Inventory at build time.
 list_image_packages(Client, Input) ->
     list_image_packages(Client, Input, []).
 list_image_packages(Client, Input0, Options0) ->
@@ -1310,10 +1347,14 @@ update_distribution_configuration(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates a new image pipeline.
+%% @doc Updates an image pipeline.
 %%
 %% Image pipelines enable you to automate the creation and distribution of
 %% images.
+%%
+%% UpdateImagePipeline does not support selective updates for the pipeline.
+%% You must specify all of the required properties in the update request, not
+%% just the properties that have changed.
 update_image_pipeline(Client, Input) ->
     update_image_pipeline(Client, Input, []).
 update_image_pipeline(Client, Input0, Options0) ->
@@ -1397,6 +1438,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -1,11 +1,11 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS IoT
+%% @doc IoT
 %%
-%% AWS IoT provides secure, bi-directional communication between
+%% IoT provides secure, bi-directional communication between
 %% Internet-connected devices (such as sensors, actuators, embedded devices,
-%% or smart appliances) and the AWS cloud.
+%% or smart appliances) and the Amazon Web Services cloud.
 %%
 %% You can discover your custom IoT-Data endpoint to communicate with,
 %% configure rules for data processing and integration with other services,
@@ -13,17 +13,17 @@
 %% logging, and create and manage policies and credentials to authenticate
 %% devices.
 %%
-%% The service endpoints that expose this API are listed in AWS IoT Core
-%% Endpoints and Quotas. You must use the endpoint for the region that has
-%% the resources you want to access.
+%% The service endpoints that expose this API are listed in Amazon Web
+%% Services IoT Core Endpoints and Quotas. You must use the endpoint for the
+%% region that has the resources you want to access.
 %%
-%% The service name used by AWS Signature Version 4 to sign the request is:
-%% execute-api.
+%% The service name used by Amazon Web Services Signature Version 4 to sign
+%% the request is: execute-api.
 %%
-%% For more information about how AWS IoT works, see the Developer Guide.
+%% For more information about how IoT works, see the Developer Guide.
 %%
-%% For information about how to use the credentials provider for AWS IoT, see
-%% Authorizing Direct Calls to AWS Services.
+%% For information about how to use the credentials provider for IoT, see
+%% Authorizing Direct Calls to Amazon Web Services Services.
 -module(aws_iot).
 
 -export([accept_certificate_transfer/3,
@@ -75,8 +75,12 @@
          create_domain_configuration/4,
          create_dynamic_thing_group/3,
          create_dynamic_thing_group/4,
+         create_fleet_metric/3,
+         create_fleet_metric/4,
          create_job/3,
          create_job/4,
+         create_job_template/3,
+         create_job_template/4,
          create_keys_and_certificate/2,
          create_keys_and_certificate/3,
          create_mitigation_action/3,
@@ -131,10 +135,14 @@
          delete_domain_configuration/4,
          delete_dynamic_thing_group/3,
          delete_dynamic_thing_group/4,
+         delete_fleet_metric/3,
+         delete_fleet_metric/4,
          delete_job/3,
          delete_job/4,
          delete_job_execution/5,
          delete_job_execution/6,
+         delete_job_template/3,
+         delete_job_template/4,
          delete_mitigation_action/3,
          delete_mitigation_action/4,
          delete_ota_update/3,
@@ -218,6 +226,9 @@
          describe_event_configurations/1,
          describe_event_configurations/3,
          describe_event_configurations/4,
+         describe_fleet_metric/2,
+         describe_fleet_metric/4,
+         describe_fleet_metric/5,
          describe_index/2,
          describe_index/4,
          describe_index/5,
@@ -227,6 +238,9 @@
          describe_job_execution/3,
          describe_job_execution/5,
          describe_job_execution/6,
+         describe_job_template/2,
+         describe_job_template/4,
+         describe_job_template/5,
          describe_mitigation_action/2,
          describe_mitigation_action/4,
          describe_mitigation_action/5,
@@ -275,6 +289,8 @@
          get_behavior_model_training_summaries/1,
          get_behavior_model_training_summaries/3,
          get_behavior_model_training_summaries/4,
+         get_buckets_aggregation/2,
+         get_buckets_aggregation/3,
          get_cardinality/2,
          get_cardinality/3,
          get_effective_policies/2,
@@ -361,6 +377,9 @@
          list_domain_configurations/1,
          list_domain_configurations/3,
          list_domain_configurations/4,
+         list_fleet_metrics/1,
+         list_fleet_metrics/3,
+         list_fleet_metrics/4,
          list_indices/1,
          list_indices/3,
          list_indices/4,
@@ -370,6 +389,9 @@
          list_job_executions_for_thing/2,
          list_job_executions_for_thing/4,
          list_job_executions_for_thing/5,
+         list_job_templates/1,
+         list_job_templates/3,
+         list_job_templates/4,
          list_jobs/1,
          list_jobs/3,
          list_jobs/4,
@@ -465,6 +487,8 @@
          list_violation_events/3,
          list_violation_events/5,
          list_violation_events/6,
+         put_verification_state_on_violation/3,
+         put_verification_state_on_violation/4,
          register_ca_certificate/2,
          register_ca_certificate/3,
          register_certificate/2,
@@ -535,6 +559,8 @@
          update_dynamic_thing_group/4,
          update_event_configurations/2,
          update_event_configurations/3,
+         update_fleet_metric/3,
+         update_fleet_metric/4,
          update_indexing_configuration/2,
          update_indexing_configuration/3,
          update_job/3,
@@ -574,6 +600,8 @@
 %%
 %% To check for pending certificate transfers, call `ListCertificates' to
 %% enumerate your certificates.
+%%
+%% Requires permission to access the AcceptCertificateTransfer action.
 accept_certificate_transfer(Client, CertificateId, Input) ->
     accept_certificate_transfer(Client, CertificateId, Input, []).
 accept_certificate_transfer(Client, CertificateId, Input0, Options0) ->
@@ -598,6 +626,8 @@ accept_certificate_transfer(Client, CertificateId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Adds a thing to a billing group.
+%%
+%% Requires permission to access the AddThingToBillingGroup action.
 add_thing_to_billing_group(Client, Input) ->
     add_thing_to_billing_group(Client, Input, []).
 add_thing_to_billing_group(Client, Input0, Options0) ->
@@ -621,6 +651,8 @@ add_thing_to_billing_group(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Adds a thing to a thing group.
+%%
+%% Requires permission to access the AddThingToThingGroup action.
 add_thing_to_thing_group(Client, Input) ->
     add_thing_to_thing_group(Client, Input, []).
 add_thing_to_thing_group(Client, Input0, Options0) ->
@@ -655,7 +687,8 @@ add_thing_to_thing_group(Client, Input0, Options0) ->
 %% </li> <li> The total number of targets associated with a job must not
 %% exceed 100.
 %%
-%% </li> </ul>
+%% </li> </ul> Requires permission to access the AssociateTargetsWithJob
+%% action.
 associate_targets_with_job(Client, JobId, Input) ->
     associate_targets_with_job(Client, JobId, Input, []).
 associate_targets_with_job(Client, JobId, Input0, Options0) ->
@@ -679,7 +712,10 @@ associate_targets_with_job(Client, JobId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Attaches a policy to the specified target.
+%% @doc Attaches the specified policy to the specified principal (certificate
+%% or other credential).
+%%
+%% Requires permission to access the AttachPolicy action.
 attach_policy(Client, PolicyName, Input) ->
     attach_policy(Client, PolicyName, Input, []).
 attach_policy(Client, PolicyName, Input0, Options0) ->
@@ -705,7 +741,9 @@ attach_policy(Client, PolicyName, Input0, Options0) ->
 %% @doc Attaches the specified policy to the specified principal (certificate
 %% or other credential).
 %%
-%% Note: This API is deprecated. Please use `AttachPolicy' instead.
+%% Note: This action is deprecated. Please use `AttachPolicy' instead.
+%%
+%% Requires permission to access the AttachPrincipalPolicy action.
 attach_principal_policy(Client, PolicyName, Input) ->
     attach_principal_policy(Client, PolicyName, Input, []).
 attach_principal_policy(Client, PolicyName, Input0, Options0) ->
@@ -735,6 +773,8 @@ attach_principal_policy(Client, PolicyName, Input0, Options0) ->
 %%
 %% Each thing group or account can have up to five security profiles
 %% associated with it.
+%%
+%% Requires permission to access the AttachSecurityProfile action.
 attach_security_profile(Client, SecurityProfileName, Input) ->
     attach_security_profile(Client, SecurityProfileName, Input, []).
 attach_security_profile(Client, SecurityProfileName, Input0, Options0) ->
@@ -762,6 +802,8 @@ attach_security_profile(Client, SecurityProfileName, Input0, Options0) ->
 %%
 %% A principal can be X.509 certificates, IAM users, groups, and roles,
 %% Amazon Cognito identities or federated identities.
+%%
+%% Requires permission to access the AttachThingPrincipal action.
 attach_thing_principal(Client, ThingName, Input) ->
     attach_thing_principal(Client, ThingName, Input, []).
 attach_thing_principal(Client, ThingName, Input0, Options0) ->
@@ -789,6 +831,8 @@ attach_thing_principal(Client, ThingName, Input0, Options0) ->
 %% @doc Cancels a mitigation action task that is in progress.
 %%
 %% If the task is not in progress, an InvalidRequestException occurs.
+%%
+%% Requires permission to access the CancelAuditMitigationActionsTask action.
 cancel_audit_mitigation_actions_task(Client, TaskId, Input) ->
     cancel_audit_mitigation_actions_task(Client, TaskId, Input, []).
 cancel_audit_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
@@ -815,6 +859,8 @@ cancel_audit_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
 %%
 %% The audit can be either scheduled or on demand. If the audit isn't in
 %% progress, an "InvalidRequestException" occurs.
+%%
+%% Requires permission to access the CancelAuditTask action.
 cancel_audit_task(Client, TaskId, Input) ->
     cancel_audit_task(Client, TaskId, Input, []).
 cancel_audit_task(Client, TaskId, Input0, Options0) ->
@@ -841,12 +887,14 @@ cancel_audit_task(Client, TaskId, Input0, Options0) ->
 %%
 %% Note Only the transfer source account can use this operation to cancel a
 %% transfer. (Transfer destinations can use `RejectCertificateTransfer'
-%% instead.) After transfer, AWS IoT returns the certificate to the source
+%% instead.) After transfer, IoT returns the certificate to the source
 %% account in the INACTIVE state. After the destination account has accepted
 %% the transfer, the transfer cannot be cancelled.
 %%
 %% After a certificate transfer is cancelled, the status of the certificate
 %% changes from PENDING_TRANSFER to INACTIVE.
+%%
+%% Requires permission to access the CancelCertificateTransfer action.
 cancel_certificate_transfer(Client, CertificateId, Input) ->
     cancel_certificate_transfer(Client, CertificateId, Input, []).
 cancel_certificate_transfer(Client, CertificateId, Input0, Options0) ->
@@ -870,6 +918,9 @@ cancel_certificate_transfer(Client, CertificateId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Cancels a Device Defender ML Detect mitigation action.
+%%
+%% Requires permission to access the CancelDetectMitigationActionsTask
+%% action.
 cancel_detect_mitigation_actions_task(Client, TaskId, Input) ->
     cancel_detect_mitigation_actions_task(Client, TaskId, Input, []).
 cancel_detect_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
@@ -893,6 +944,8 @@ cancel_detect_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Cancels a job.
+%%
+%% Requires permission to access the CancelJob action.
 cancel_job(Client, JobId, Input) ->
     cancel_job(Client, JobId, Input, []).
 cancel_job(Client, JobId, Input0, Options0) ->
@@ -917,6 +970,8 @@ cancel_job(Client, JobId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Cancels the execution of a job for a given thing.
+%%
+%% Requires permission to access the CancelJobExecution action.
 cancel_job_execution(Client, JobId, ThingName, Input) ->
     cancel_job_execution(Client, JobId, ThingName, Input, []).
 cancel_job_execution(Client, JobId, ThingName, Input0, Options0) ->
@@ -941,6 +996,8 @@ cancel_job_execution(Client, JobId, ThingName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Clears the default authorizer.
+%%
+%% Requires permission to access the ClearDefaultAuthorizer action.
 clear_default_authorizer(Client, Input) ->
     clear_default_authorizer(Client, Input, []).
 clear_default_authorizer(Client, Input0, Options0) ->
@@ -965,11 +1022,12 @@ clear_default_authorizer(Client, Input0, Options0) ->
 
 %% @doc Confirms a topic rule destination.
 %%
-%% When you create a rule requiring a destination, AWS IoT sends a
-%% confirmation message to the endpoint or base address you specify. The
-%% message includes a token which you pass back when calling
-%% `ConfirmTopicRuleDestination' to confirm that you own or have access to
-%% the endpoint.
+%% When you create a rule requiring a destination, IoT sends a confirmation
+%% message to the endpoint or base address you specify. The message includes
+%% a token which you pass back when calling `ConfirmTopicRuleDestination' to
+%% confirm that you own or have access to the endpoint.
+%%
+%% Requires permission to access the ConfirmTopicRuleDestination action.
 confirm_topic_rule_destination(Client, ConfirmationToken)
   when is_map(Client) ->
     confirm_topic_rule_destination(Client, ConfirmationToken, #{}, #{}).
@@ -993,6 +1051,8 @@ confirm_topic_rule_destination(Client, ConfirmationToken, QueryMap, HeadersMap, 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Creates a Device Defender audit suppression.
+%%
+%% Requires permission to access the CreateAuditSuppression action.
 create_audit_suppression(Client, Input) ->
     create_audit_suppression(Client, Input, []).
 create_audit_suppression(Client, Input0, Options0) ->
@@ -1016,6 +1076,8 @@ create_audit_suppression(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates an authorizer.
+%%
+%% Requires permission to access the CreateAuthorizer action.
 create_authorizer(Client, AuthorizerName, Input) ->
     create_authorizer(Client, AuthorizerName, Input, []).
 create_authorizer(Client, AuthorizerName, Input0, Options0) ->
@@ -1039,6 +1101,8 @@ create_authorizer(Client, AuthorizerName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a billing group.
+%%
+%% Requires permission to access the CreateBillingGroup action.
 create_billing_group(Client, BillingGroupName, Input) ->
     create_billing_group(Client, BillingGroupName, Input, []).
 create_billing_group(Client, BillingGroupName, Input0, Options0) ->
@@ -1071,6 +1135,8 @@ create_billing_group(Client, BillingGroupName, Input0, Options0) ->
 %% Note: Reusing the same certificate signing request (CSR) results in a
 %% distinct certificate.
 %%
+%% Requires permission to access the CreateCertificateFromCsr action.
+%%
 %% You can create multiple certificates in a batch by creating a directory,
 %% copying multiple .csr files into that directory, and then specifying that
 %% directory on the command line. The following commands show how to create a
@@ -1085,8 +1151,8 @@ create_billing_group(Client, BillingGroupName, Input0, Options0) ->
 %% --certificate-signing-request file://my-csr-directory/{}
 %%
 %% This command lists all of the CSRs in my-csr-directory and pipes each CSR
-%% file name to the aws iot create-certificate-from-csr AWS CLI command to
-%% create a certificate for the corresponding CSR.
+%% file name to the aws iot create-certificate-from-csr Amazon Web Services
+%% CLI command to create a certificate for the corresponding CSR.
 %%
 %% The aws iot create-certificate-from-csr part of the command can also be
 %% run in parallel to speed up the certificate creation process:
@@ -1131,6 +1197,8 @@ create_certificate_from_csr(Client, Input0, Options0) ->
 
 %% @doc Use this API to define a Custom Metric published by your devices to
 %% Device Defender.
+%%
+%% Requires permission to access the CreateCustomMetric action.
 create_custom_metric(Client, MetricName, Input) ->
     create_custom_metric(Client, MetricName, Input, []).
 create_custom_metric(Client, MetricName, Input0, Options0) ->
@@ -1154,11 +1222,13 @@ create_custom_metric(Client, MetricName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Create a dimension that you can use to limit the scope of a metric
-%% used in a security profile for AWS IoT Device Defender.
+%% used in a security profile for IoT Device Defender.
 %%
 %% For example, using a `TOPIC_FILTER' dimension, you can narrow down the
 %% scope of the metric only to MQTT topics whose name match the pattern
 %% specified in the dimension.
+%%
+%% Requires permission to access the CreateDimension action.
 create_dimension(Client, Name, Input) ->
     create_dimension(Client, Name, Input, []).
 create_dimension(Client, Name, Input0, Options0) ->
@@ -1183,8 +1253,7 @@ create_dimension(Client, Name, Input0, Options0) ->
 
 %% @doc Creates a domain configuration.
 %%
-%% The domain configuration feature is in public preview and is subject to
-%% change.
+%% Requires permission to access the CreateDomainConfiguration action.
 create_domain_configuration(Client, DomainConfigurationName, Input) ->
     create_domain_configuration(Client, DomainConfigurationName, Input, []).
 create_domain_configuration(Client, DomainConfigurationName, Input0, Options0) ->
@@ -1208,6 +1277,8 @@ create_domain_configuration(Client, DomainConfigurationName, Input0, Options0) -
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a dynamic thing group.
+%%
+%% Requires permission to access the CreateDynamicThingGroup action.
 create_dynamic_thing_group(Client, ThingGroupName, Input) ->
     create_dynamic_thing_group(Client, ThingGroupName, Input, []).
 create_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
@@ -1230,12 +1301,64 @@ create_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates a fleet metric.
+%%
+%% Requires permission to access the CreateFleetMetric action.
+create_fleet_metric(Client, MetricName, Input) ->
+    create_fleet_metric(Client, MetricName, Input, []).
+create_fleet_metric(Client, MetricName, Input0, Options0) ->
+    Method = put,
+    Path = ["/fleet-metric/", aws_util:encode_uri(MetricName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a job.
+%%
+%% Requires permission to access the CreateJob action.
 create_job(Client, JobId, Input) ->
     create_job(Client, JobId, Input, []).
 create_job(Client, JobId, Input0, Options0) ->
     Method = put,
     Path = ["/jobs/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a job template.
+%%
+%% Requires permission to access the CreateJobTemplate action.
+create_job_template(Client, JobTemplateId, Input) ->
+    create_job_template(Client, JobTemplateId, Input, []).
+create_job_template(Client, JobTemplateId, Input0, Options0) ->
+    Method = put,
+    Path = ["/job-templates/", aws_util:encode_uri(JobTemplateId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1259,8 +1382,10 @@ create_job(Client, JobId, Input0, Options0) ->
 %% You can also call `CreateKeysAndCertificate' over MQTT from a device, for
 %% more information, see Provisioning MQTT API.
 %%
-%% Note This is the only time AWS IoT issues the private key for this
+%% Note This is the only time IoT issues the private key for this
 %% certificate, so it is important to keep it in a secure location.
+%%
+%% Requires permission to access the CreateKeysAndCertificate action.
 create_keys_and_certificate(Client, Input) ->
     create_keys_and_certificate(Client, Input, []).
 create_keys_and_certificate(Client, Input0, Options0) ->
@@ -1290,6 +1415,8 @@ create_keys_and_certificate(Client, Input0, Options0) ->
 %% Only certain types of mitigation actions can be applied to specific check
 %% names. For more information, see Mitigation actions. Each mitigation
 %% action can apply only one type of change.
+%%
+%% Requires permission to access the CreateMitigationAction action.
 create_mitigation_action(Client, ActionName, Input) ->
     create_mitigation_action(Client, ActionName, Input, []).
 create_mitigation_action(Client, ActionName, Input0, Options0) ->
@@ -1312,7 +1439,9 @@ create_mitigation_action(Client, ActionName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an AWS IoT OTAUpdate on a target group of things or groups.
+%% @doc Creates an IoT OTA update on a target group of things or groups.
+%%
+%% Requires permission to access the CreateOTAUpdate action.
 create_ota_update(Client, OtaUpdateId, Input) ->
     create_ota_update(Client, OtaUpdateId, Input, []).
 create_ota_update(Client, OtaUpdateId, Input0, Options0) ->
@@ -1335,11 +1464,13 @@ create_ota_update(Client, OtaUpdateId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an AWS IoT policy.
+%% @doc Creates an IoT policy.
 %%
 %% The created policy is the default version for the policy. This operation
 %% creates a policy version with a version identifier of 1 and sets 1 as the
 %% policy's default version.
+%%
+%% Requires permission to access the CreatePolicy action.
 create_policy(Client, PolicyName, Input) ->
     create_policy(Client, PolicyName, Input, []).
 create_policy(Client, PolicyName, Input0, Options0) ->
@@ -1362,7 +1493,7 @@ create_policy(Client, PolicyName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a new version of the specified AWS IoT policy.
+%% @doc Creates a new version of the specified IoT policy.
 %%
 %% To update a policy, create a new policy version. A managed policy can have
 %% up to five versions. If the policy has five versions, you must use
@@ -1372,6 +1503,8 @@ create_policy(Client, PolicyName, Input0, Options0) ->
 %% Optionally, you can set the new version as the policy's default version.
 %% The default version is the operative version (that is, the version that is
 %% in effect for the certificates to which the policy is attached).
+%%
+%% Requires permission to access the CreatePolicyVersion action.
 create_policy_version(Client, PolicyName, Input) ->
     create_policy_version(Client, PolicyName, Input, []).
 create_policy_version(Client, PolicyName, Input0, Options0) ->
@@ -1396,6 +1529,8 @@ create_policy_version(Client, PolicyName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a provisioning claim.
+%%
+%% Requires permission to access the CreateProvisioningClaim action.
 create_provisioning_claim(Client, TemplateName, Input) ->
     create_provisioning_claim(Client, TemplateName, Input, []).
 create_provisioning_claim(Client, TemplateName, Input0, Options0) ->
@@ -1419,6 +1554,8 @@ create_provisioning_claim(Client, TemplateName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a fleet provisioning template.
+%%
+%% Requires permission to access the CreateProvisioningTemplate action.
 create_provisioning_template(Client, Input) ->
     create_provisioning_template(Client, Input, []).
 create_provisioning_template(Client, Input0, Options0) ->
@@ -1442,6 +1579,9 @@ create_provisioning_template(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a new version of a fleet provisioning template.
+%%
+%% Requires permission to access the CreateProvisioningTemplateVersion
+%% action.
 create_provisioning_template_version(Client, TemplateName, Input) ->
     create_provisioning_template_version(Client, TemplateName, Input, []).
 create_provisioning_template_version(Client, TemplateName, Input0, Options0) ->
@@ -1466,6 +1606,8 @@ create_provisioning_template_version(Client, TemplateName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a role alias.
+%%
+%% Requires permission to access the CreateRoleAlias action.
 create_role_alias(Client, RoleAlias, Input) ->
     create_role_alias(Client, RoleAlias, Input, []).
 create_role_alias(Client, RoleAlias, Input0, Options0) ->
@@ -1489,6 +1631,8 @@ create_role_alias(Client, RoleAlias, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a scheduled audit that is run at a specified time interval.
+%%
+%% Requires permission to access the CreateScheduledAudit action.
 create_scheduled_audit(Client, ScheduledAuditName, Input) ->
     create_scheduled_audit(Client, ScheduledAuditName, Input, []).
 create_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
@@ -1512,6 +1656,8 @@ create_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a Device Defender security profile.
+%%
+%% Requires permission to access the CreateSecurityProfile action.
 create_security_profile(Client, SecurityProfileName, Input) ->
     create_security_profile(Client, SecurityProfileName, Input, []).
 create_security_profile(Client, SecurityProfileName, Input0, Options0) ->
@@ -1540,6 +1686,8 @@ create_security_profile(Client, SecurityProfileName, Input0, Options0) ->
 %% A stream transports data bytes in chunks or blocks packaged as MQTT
 %% messages from a source like S3. You can have one or more files associated
 %% with a stream.
+%%
+%% Requires permission to access the CreateStream action.
 create_stream(Client, StreamId, Input) ->
     create_stream(Client, StreamId, Input, []).
 create_stream(Client, StreamId, Input0, Options0) ->
@@ -1571,6 +1719,8 @@ create_stream(Client, StreamId, Input0, Options0) ->
 %%
 %% This is a control plane operation. See Authorization for information about
 %% authorizing control plane actions.
+%%
+%% Requires permission to access the CreateThing action.
 create_thing(Client, ThingName, Input) ->
     create_thing(Client, ThingName, Input, []).
 create_thing(Client, ThingName, Input0, Options0) ->
@@ -1597,6 +1747,8 @@ create_thing(Client, ThingName, Input0, Options0) ->
 %%
 %% This is a control plane operation. See Authorization for information about
 %% authorizing control plane actions.
+%%
+%% Requires permission to access the CreateThingGroup action.
 create_thing_group(Client, ThingGroupName, Input) ->
     create_thing_group(Client, ThingGroupName, Input, []).
 create_thing_group(Client, ThingGroupName, Input0, Options0) ->
@@ -1620,6 +1772,8 @@ create_thing_group(Client, ThingGroupName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a new thing type.
+%%
+%% Requires permission to access the CreateThingType action.
 create_thing_type(Client, ThingTypeName, Input) ->
     create_thing_type(Client, ThingTypeName, Input, []).
 create_thing_type(Client, ThingTypeName, Input0, Options0) ->
@@ -1647,6 +1801,8 @@ create_thing_type(Client, ThingTypeName, Input0, Options0) ->
 %% Creating rules is an administrator-level action. Any user who has
 %% permission to create rules will be able to access data processed by the
 %% rule.
+%%
+%% Requires permission to access the CreateTopicRule action.
 create_topic_rule(Client, RuleName, Input) ->
     create_topic_rule(Client, RuleName, Input, []).
 create_topic_rule(Client, RuleName, Input0, Options0) ->
@@ -1674,6 +1830,8 @@ create_topic_rule(Client, RuleName, Input0, Options0) ->
 %% @doc Creates a topic rule destination.
 %%
 %% The destination must be confirmed prior to use.
+%%
+%% Requires permission to access the CreateTopicRuleDestination action.
 create_topic_rule_destination(Client, Input) ->
     create_topic_rule_destination(Client, Input, []).
 create_topic_rule_destination(Client, Input0, Options0) ->
@@ -1701,6 +1859,8 @@ create_topic_rule_destination(Client, Input0, Options0) ->
 %%
 %% Any configuration data you entered is deleted and all audit checks are
 %% reset to disabled.
+%%
+%% Requires permission to access the DeleteAccountAuditConfiguration action.
 delete_account_audit_configuration(Client, Input) ->
     delete_account_audit_configuration(Client, Input, []).
 delete_account_audit_configuration(Client, Input0, Options0) ->
@@ -1725,6 +1885,8 @@ delete_account_audit_configuration(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a Device Defender audit suppression.
+%%
+%% Requires permission to access the DeleteAuditSuppression action.
 delete_audit_suppression(Client, Input) ->
     delete_audit_suppression(Client, Input, []).
 delete_audit_suppression(Client, Input0, Options0) ->
@@ -1748,6 +1910,8 @@ delete_audit_suppression(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes an authorizer.
+%%
+%% Requires permission to access the DeleteAuthorizer action.
 delete_authorizer(Client, AuthorizerName, Input) ->
     delete_authorizer(Client, AuthorizerName, Input, []).
 delete_authorizer(Client, AuthorizerName, Input0, Options0) ->
@@ -1771,6 +1935,8 @@ delete_authorizer(Client, AuthorizerName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the billing group.
+%%
+%% Requires permission to access the DeleteBillingGroup action.
 delete_billing_group(Client, BillingGroupName, Input) ->
     delete_billing_group(Client, BillingGroupName, Input, []).
 delete_billing_group(Client, BillingGroupName, Input0, Options0) ->
@@ -1795,6 +1961,8 @@ delete_billing_group(Client, BillingGroupName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a registered CA certificate.
+%%
+%% Requires permission to access the DeleteCACertificate action.
 delete_ca_certificate(Client, CertificateId, Input) ->
     delete_ca_certificate(Client, CertificateId, Input, []).
 delete_ca_certificate(Client, CertificateId, Input0, Options0) ->
@@ -1821,8 +1989,10 @@ delete_ca_certificate(Client, CertificateId, Input0, Options0) ->
 %%
 %% A certificate cannot be deleted if it has a policy or IoT thing attached
 %% to it or if its status is set to ACTIVE. To delete a certificate, first
-%% use the `DetachPrincipalPolicy' API to detach all policies. Next, use the
-%% `UpdateCertificate' API to set the certificate to the INACTIVE status.
+%% use the `DetachPolicy' action to detach all policies. Next, use the
+%% `UpdateCertificate' action to set the certificate to the INACTIVE status.
+%%
+%% Requires permission to access the DeleteCertificate action.
 delete_certificate(Client, CertificateId, Input) ->
     delete_certificate(Client, CertificateId, Input, []).
 delete_certificate(Client, CertificateId, Input0, Options0) ->
@@ -1846,14 +2016,14 @@ delete_certificate(Client, CertificateId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Before you can delete a custom metric, you must first remove the
-%% custom metric from all security profiles it's a part of.
+%% @doc Deletes a Device Defender detect custom metric.
 %%
-%% The security profile associated with the custom metric can be found using
-%% the ListSecurityProfiles API with `metricName' set to your custom metric
-%% name.
+%% Requires permission to access the DeleteCustomMetric action.
 %%
-%% Deletes a Device Defender detect custom metric.
+%% Before you can delete a custom metric, you must first remove the custom
+%% metric from all security profiles it's a part of. The security profile
+%% associated with the custom metric can be found using the
+%% ListSecurityProfiles API with `metricName' set to your custom metric name.
 delete_custom_metric(Client, MetricName, Input) ->
     delete_custom_metric(Client, MetricName, Input, []).
 delete_custom_metric(Client, MetricName, Input0, Options0) ->
@@ -1876,7 +2046,10 @@ delete_custom_metric(Client, MetricName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes the specified dimension from your AWS account.
+%% @doc Removes the specified dimension from your Amazon Web Services
+%% accounts.
+%%
+%% Requires permission to access the DeleteDimension action.
 delete_dimension(Client, Name, Input) ->
     delete_dimension(Client, Name, Input, []).
 delete_dimension(Client, Name, Input0, Options0) ->
@@ -1901,8 +2074,7 @@ delete_dimension(Client, Name, Input0, Options0) ->
 
 %% @doc Deletes the specified domain configuration.
 %%
-%% The domain configuration feature is in public preview and is subject to
-%% change.
+%% Requires permission to access the DeleteDomainConfiguration action.
 delete_domain_configuration(Client, DomainConfigurationName, Input) ->
     delete_domain_configuration(Client, DomainConfigurationName, Input, []).
 delete_domain_configuration(Client, DomainConfigurationName, Input0, Options0) ->
@@ -1926,11 +2098,42 @@ delete_domain_configuration(Client, DomainConfigurationName, Input0, Options0) -
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a dynamic thing group.
+%%
+%% Requires permission to access the DeleteDynamicThingGroup action.
 delete_dynamic_thing_group(Client, ThingGroupName, Input) ->
     delete_dynamic_thing_group(Client, ThingGroupName, Input, []).
 delete_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
     Method = delete,
     Path = ["/dynamic-thing-groups/", aws_util:encode_uri(ThingGroupName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"expectedVersion">>, <<"expectedVersion">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified fleet metric.
+%%
+%% Returns successfully with no error if the deletion is successful or you
+%% specify a fleet metric that doesn't exist.
+%%
+%% Requires permission to access the DeleteFleetMetric action.
+delete_fleet_metric(Client, MetricName, Input) ->
+    delete_fleet_metric(Client, MetricName, Input, []).
+delete_fleet_metric(Client, MetricName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/fleet-metric/", aws_util:encode_uri(MetricName), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1959,6 +2162,8 @@ delete_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
 %%
 %% Only 10 jobs may have status "DELETION_IN_PROGRESS" at the same time, or a
 %% LimitExceededException will occur.
+%%
+%% Requires permission to access the DeleteJob action.
 delete_job(Client, JobId, Input) ->
     delete_job(Client, JobId, Input, []).
 delete_job(Client, JobId, Input0, Options0) ->
@@ -1984,6 +2189,8 @@ delete_job(Client, JobId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a job execution.
+%%
+%% Requires permission to access the DeleteJobExecution action.
 delete_job_execution(Client, ExecutionNumber, JobId, ThingName, Input) ->
     delete_job_execution(Client, ExecutionNumber, JobId, ThingName, Input, []).
 delete_job_execution(Client, ExecutionNumber, JobId, ThingName, Input0, Options0) ->
@@ -2008,7 +2215,33 @@ delete_job_execution(Client, ExecutionNumber, JobId, ThingName, Input0, Options0
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a defined mitigation action from your AWS account.
+%% @doc Deletes the specified job template.
+delete_job_template(Client, JobTemplateId, Input) ->
+    delete_job_template(Client, JobTemplateId, Input, []).
+delete_job_template(Client, JobTemplateId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/job-templates/", aws_util:encode_uri(JobTemplateId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a defined mitigation action from your Amazon Web Services
+%% accounts.
+%%
+%% Requires permission to access the DeleteMitigationAction action.
 delete_mitigation_action(Client, ActionName, Input) ->
     delete_mitigation_action(Client, ActionName, Input, []).
 delete_mitigation_action(Client, ActionName, Input0, Options0) ->
@@ -2032,6 +2265,8 @@ delete_mitigation_action(Client, ActionName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Delete an OTA update.
+%%
+%% Requires permission to access the DeleteOTAUpdate action.
 delete_ota_update(Client, OtaUpdateId, Input) ->
     delete_ota_update(Client, OtaUpdateId, Input, []).
 delete_ota_update(Client, OtaUpdateId, Input0, Options0) ->
@@ -2061,13 +2296,19 @@ delete_ota_update(Client, OtaUpdateId, Input0, Options0) ->
 %% A policy cannot be deleted if it has non-default versions or it is
 %% attached to any certificate.
 %%
-%% To delete a policy, use the DeletePolicyVersion API to delete all
-%% non-default versions of the policy; use the DetachPrincipalPolicy API to
-%% detach the policy from any certificate; and then use the DeletePolicy API
-%% to delete the policy.
+%% To delete a policy, use the `DeletePolicyVersion' action to delete all
+%% non-default versions of the policy; use the `DetachPolicy' action to
+%% detach the policy from any certificate; and then use the DeletePolicy
+%% action to delete the policy.
 %%
 %% When a policy is deleted using DeletePolicy, its default version is
 %% deleted with it.
+%%
+%% Because of the distributed nature of Amazon Web Services, it can take up
+%% to five minutes after a policy is detached before it's ready to be
+%% deleted.
+%%
+%% Requires permission to access the DeletePolicy action.
 delete_policy(Client, PolicyName, Input) ->
     delete_policy(Client, PolicyName, Input, []).
 delete_policy(Client, PolicyName, Input0, Options0) ->
@@ -2092,10 +2333,12 @@ delete_policy(Client, PolicyName, Input0, Options0) ->
 
 %% @doc Deletes the specified version of the specified policy.
 %%
-%% You cannot delete the default version of a policy using this API. To
+%% You cannot delete the default version of a policy using this action. To
 %% delete the default version of a policy, use `DeletePolicy'. To find out
 %% which version of a policy is marked as the default version, use
 %% ListPolicyVersions.
+%%
+%% Requires permission to access the DeletePolicyVersion action.
 delete_policy_version(Client, PolicyName, PolicyVersionId, Input) ->
     delete_policy_version(Client, PolicyName, PolicyVersionId, Input, []).
 delete_policy_version(Client, PolicyName, PolicyVersionId, Input0, Options0) ->
@@ -2119,6 +2362,8 @@ delete_policy_version(Client, PolicyName, PolicyVersionId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a fleet provisioning template.
+%%
+%% Requires permission to access the DeleteProvisioningTemplate action.
 delete_provisioning_template(Client, TemplateName, Input) ->
     delete_provisioning_template(Client, TemplateName, Input, []).
 delete_provisioning_template(Client, TemplateName, Input0, Options0) ->
@@ -2142,6 +2387,9 @@ delete_provisioning_template(Client, TemplateName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a fleet provisioning template version.
+%%
+%% Requires permission to access the DeleteProvisioningTemplateVersion
+%% action.
 delete_provisioning_template_version(Client, TemplateName, VersionId, Input) ->
     delete_provisioning_template_version(Client, TemplateName, VersionId, Input, []).
 delete_provisioning_template_version(Client, TemplateName, VersionId, Input0, Options0) ->
@@ -2165,6 +2413,8 @@ delete_provisioning_template_version(Client, TemplateName, VersionId, Input0, Op
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a CA certificate registration code.
+%%
+%% Requires permission to access the DeleteRegistrationCode action.
 delete_registration_code(Client, Input) ->
     delete_registration_code(Client, Input, []).
 delete_registration_code(Client, Input0, Options0) ->
@@ -2188,6 +2438,8 @@ delete_registration_code(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a role alias
+%%
+%% Requires permission to access the DeleteRoleAlias action.
 delete_role_alias(Client, RoleAlias, Input) ->
     delete_role_alias(Client, RoleAlias, Input, []).
 delete_role_alias(Client, RoleAlias, Input0, Options0) ->
@@ -2211,6 +2463,8 @@ delete_role_alias(Client, RoleAlias, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a scheduled audit.
+%%
+%% Requires permission to access the DeleteScheduledAudit action.
 delete_scheduled_audit(Client, ScheduledAuditName, Input) ->
     delete_scheduled_audit(Client, ScheduledAuditName, Input, []).
 delete_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
@@ -2234,6 +2488,8 @@ delete_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a Device Defender security profile.
+%%
+%% Requires permission to access the DeleteSecurityProfile action.
 delete_security_profile(Client, SecurityProfileName, Input) ->
     delete_security_profile(Client, SecurityProfileName, Input, []).
 delete_security_profile(Client, SecurityProfileName, Input0, Options0) ->
@@ -2258,6 +2514,8 @@ delete_security_profile(Client, SecurityProfileName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a stream.
+%%
+%% Requires permission to access the DeleteStream action.
 delete_stream(Client, StreamId, Input) ->
     delete_stream(Client, StreamId, Input, []).
 delete_stream(Client, StreamId, Input0, Options0) ->
@@ -2284,6 +2542,8 @@ delete_stream(Client, StreamId, Input0, Options0) ->
 %%
 %% Returns successfully with no error if the deletion is successful or you
 %% specify a thing that doesn't exist.
+%%
+%% Requires permission to access the DeleteThing action.
 delete_thing(Client, ThingName, Input) ->
     delete_thing(Client, ThingName, Input, []).
 delete_thing(Client, ThingName, Input0, Options0) ->
@@ -2308,6 +2568,8 @@ delete_thing(Client, ThingName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a thing group.
+%%
+%% Requires permission to access the DeleteThingGroup action.
 delete_thing_group(Client, ThingGroupName, Input) ->
     delete_thing_group(Client, ThingGroupName, Input, []).
 delete_thing_group(Client, ThingGroupName, Input0, Options0) ->
@@ -2338,6 +2600,8 @@ delete_thing_group(Client, ThingGroupName, Input0, Options0) ->
 %% `DeprecateThingType', then remove any associated things by calling
 %% `UpdateThing' to change the thing type on any associated thing, and
 %% finally use `DeleteThingType' to delete the thing type.
+%%
+%% Requires permission to access the DeleteThingType action.
 delete_thing_type(Client, ThingTypeName, Input) ->
     delete_thing_type(Client, ThingTypeName, Input, []).
 delete_thing_type(Client, ThingTypeName, Input0, Options0) ->
@@ -2361,6 +2625,8 @@ delete_thing_type(Client, ThingTypeName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the rule.
+%%
+%% Requires permission to access the DeleteTopicRule action.
 delete_topic_rule(Client, RuleName, Input) ->
     delete_topic_rule(Client, RuleName, Input, []).
 delete_topic_rule(Client, RuleName, Input0, Options0) ->
@@ -2384,6 +2650,8 @@ delete_topic_rule(Client, RuleName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a topic rule destination.
+%%
+%% Requires permission to access the DeleteTopicRuleDestination action.
 delete_topic_rule_destination(Client, Arn, Input) ->
     delete_topic_rule_destination(Client, Arn, Input, []).
 delete_topic_rule_destination(Client, Arn, Input0, Options0) ->
@@ -2407,6 +2675,8 @@ delete_topic_rule_destination(Client, Arn, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a logging level.
+%%
+%% Requires permission to access the DeleteV2LoggingLevel action.
 delete_v2_logging_level(Client, Input) ->
     delete_v2_logging_level(Client, Input, []).
 delete_v2_logging_level(Client, Input0, Options0) ->
@@ -2434,6 +2704,8 @@ delete_v2_logging_level(Client, Input0, Options0) ->
 %% @doc Deprecates a thing type.
 %%
 %% You can not associate new things with deprecated thing type.
+%%
+%% Requires permission to access the DeprecateThingType action.
 deprecate_thing_type(Client, ThingTypeName, Input) ->
     deprecate_thing_type(Client, ThingTypeName, Input, []).
 deprecate_thing_type(Client, ThingTypeName, Input0, Options0) ->
@@ -2461,6 +2733,9 @@ deprecate_thing_type(Client, ThingTypeName, Input0, Options0) ->
 %%
 %% Settings include how audit notifications are sent and which audit checks
 %% are enabled or disabled.
+%%
+%% Requires permission to access the DescribeAccountAuditConfiguration
+%% action.
 describe_account_audit_configuration(Client)
   when is_map(Client) ->
     describe_account_audit_configuration(Client, #{}, #{}).
@@ -2487,6 +2762,8 @@ describe_account_audit_configuration(Client, QueryMap, HeadersMap, Options0)
 %%
 %% Properties include the reason for noncompliance, the severity of the
 %% issue, and the start time when the audit that returned the finding.
+%%
+%% Requires permission to access the DescribeAuditFinding action.
 describe_audit_finding(Client, FindingId)
   when is_map(Client) ->
     describe_audit_finding(Client, FindingId, #{}, #{}).
@@ -2560,6 +2837,8 @@ describe_audit_suppression(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets information about a Device Defender audit.
+%%
+%% Requires permission to access the DescribeAuditTask action.
 describe_audit_task(Client, TaskId)
   when is_map(Client) ->
     describe_audit_task(Client, TaskId, #{}, #{}).
@@ -2583,6 +2862,8 @@ describe_audit_task(Client, TaskId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes an authorizer.
+%%
+%% Requires permission to access the DescribeAuthorizer action.
 describe_authorizer(Client, AuthorizerName)
   when is_map(Client) ->
     describe_authorizer(Client, AuthorizerName, #{}, #{}).
@@ -2606,6 +2887,8 @@ describe_authorizer(Client, AuthorizerName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns information about a billing group.
+%%
+%% Requires permission to access the DescribeBillingGroup action.
 describe_billing_group(Client, BillingGroupName)
   when is_map(Client) ->
     describe_billing_group(Client, BillingGroupName, #{}, #{}).
@@ -2629,6 +2912,8 @@ describe_billing_group(Client, BillingGroupName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes a registered CA certificate.
+%%
+%% Requires permission to access the DescribeCACertificate action.
 describe_ca_certificate(Client, CertificateId)
   when is_map(Client) ->
     describe_ca_certificate(Client, CertificateId, #{}, #{}).
@@ -2652,6 +2937,8 @@ describe_ca_certificate(Client, CertificateId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about the specified certificate.
+%%
+%% Requires permission to access the DescribeCertificate action.
 describe_certificate(Client, CertificateId)
   when is_map(Client) ->
     describe_certificate(Client, CertificateId, #{}, #{}).
@@ -2675,6 +2962,8 @@ describe_certificate(Client, CertificateId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a Device Defender detect custom metric.
+%%
+%% Requires permission to access the DescribeCustomMetric action.
 describe_custom_metric(Client, MetricName)
   when is_map(Client) ->
     describe_custom_metric(Client, MetricName, #{}, #{}).
@@ -2698,6 +2987,8 @@ describe_custom_metric(Client, MetricName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes the default authorizer.
+%%
+%% Requires permission to access the DescribeDefaultAuthorizer action.
 describe_default_authorizer(Client)
   when is_map(Client) ->
     describe_default_authorizer(Client, #{}, #{}).
@@ -2721,6 +3012,9 @@ describe_default_authorizer(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a Device Defender ML Detect mitigation action.
+%%
+%% Requires permission to access the DescribeDetectMitigationActionsTask
+%% action.
 describe_detect_mitigation_actions_task(Client, TaskId)
   when is_map(Client) ->
     describe_detect_mitigation_actions_task(Client, TaskId, #{}, #{}).
@@ -2743,8 +3037,10 @@ describe_detect_mitigation_actions_task(Client, TaskId, QueryMap, HeadersMap, Op
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Provides details about a dimension that is defined in your AWS
-%% account.
+%% @doc Provides details about a dimension that is defined in your Amazon Web
+%% Services accounts.
+%%
+%% Requires permission to access the DescribeDimension action.
 describe_dimension(Client, Name)
   when is_map(Client) ->
     describe_dimension(Client, Name, #{}, #{}).
@@ -2769,8 +3065,7 @@ describe_dimension(Client, Name, QueryMap, HeadersMap, Options0)
 
 %% @doc Gets summary information about a domain configuration.
 %%
-%% The domain configuration feature is in public preview and is subject to
-%% change.
+%% Requires permission to access the DescribeDomainConfiguration action.
 describe_domain_configuration(Client, DomainConfigurationName)
   when is_map(Client) ->
     describe_domain_configuration(Client, DomainConfigurationName, #{}, #{}).
@@ -2793,8 +3088,10 @@ describe_domain_configuration(Client, DomainConfigurationName, QueryMap, Headers
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a unique endpoint specific to the AWS account making the
-%% call.
+%% @doc Returns a unique endpoint specific to the Amazon Web Services account
+%% making the call.
+%%
+%% Requires permission to access the DescribeEndpoint action.
 describe_endpoint(Client)
   when is_map(Client) ->
     describe_endpoint(Client, #{}, #{}).
@@ -2822,6 +3119,8 @@ describe_endpoint(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes event configurations.
+%%
+%% Requires permission to access the DescribeEventConfigurations action.
 describe_event_configurations(Client)
   when is_map(Client) ->
     describe_event_configurations(Client, #{}, #{}).
@@ -2844,7 +3143,34 @@ describe_event_configurations(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets information about the specified fleet metric.
+%%
+%% Requires permission to access the DescribeFleetMetric action.
+describe_fleet_metric(Client, MetricName)
+  when is_map(Client) ->
+    describe_fleet_metric(Client, MetricName, #{}, #{}).
+
+describe_fleet_metric(Client, MetricName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_fleet_metric(Client, MetricName, QueryMap, HeadersMap, []).
+
+describe_fleet_metric(Client, MetricName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/fleet-metric/", aws_util:encode_uri(MetricName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Describes a search index.
+%%
+%% Requires permission to access the DescribeIndex action.
 describe_index(Client, IndexName)
   when is_map(Client) ->
     describe_index(Client, IndexName, #{}, #{}).
@@ -2868,6 +3194,8 @@ describe_index(Client, IndexName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes a job.
+%%
+%% Requires permission to access the DescribeJob action.
 describe_job(Client, JobId)
   when is_map(Client) ->
     describe_job(Client, JobId, #{}, #{}).
@@ -2891,6 +3219,8 @@ describe_job(Client, JobId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes a job execution.
+%%
+%% Requires permission to access the DescribeJobExecution action.
 describe_job_execution(Client, JobId, ThingName)
   when is_map(Client) ->
     describe_job_execution(Client, JobId, ThingName, #{}, #{}).
@@ -2917,7 +3247,32 @@ describe_job_execution(Client, JobId, ThingName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns information about a job template.
+describe_job_template(Client, JobTemplateId)
+  when is_map(Client) ->
+    describe_job_template(Client, JobTemplateId, #{}, #{}).
+
+describe_job_template(Client, JobTemplateId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_job_template(Client, JobTemplateId, QueryMap, HeadersMap, []).
+
+describe_job_template(Client, JobTemplateId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/job-templates/", aws_util:encode_uri(JobTemplateId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets information about a mitigation action.
+%%
+%% Requires permission to access the DescribeMitigationAction action.
 describe_mitigation_action(Client, ActionName)
   when is_map(Client) ->
     describe_mitigation_action(Client, ActionName, #{}, #{}).
@@ -2941,6 +3296,8 @@ describe_mitigation_action(Client, ActionName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns information about a fleet provisioning template.
+%%
+%% Requires permission to access the DescribeProvisioningTemplate action.
 describe_provisioning_template(Client, TemplateName)
   when is_map(Client) ->
     describe_provisioning_template(Client, TemplateName, #{}, #{}).
@@ -2964,6 +3321,9 @@ describe_provisioning_template(Client, TemplateName, QueryMap, HeadersMap, Optio
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns information about a fleet provisioning template version.
+%%
+%% Requires permission to access the DescribeProvisioningTemplateVersion
+%% action.
 describe_provisioning_template_version(Client, TemplateName, VersionId)
   when is_map(Client) ->
     describe_provisioning_template_version(Client, TemplateName, VersionId, #{}, #{}).
@@ -2987,6 +3347,8 @@ describe_provisioning_template_version(Client, TemplateName, VersionId, QueryMap
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes a role alias.
+%%
+%% Requires permission to access the DescribeRoleAlias action.
 describe_role_alias(Client, RoleAlias)
   when is_map(Client) ->
     describe_role_alias(Client, RoleAlias, #{}, #{}).
@@ -3010,6 +3372,8 @@ describe_role_alias(Client, RoleAlias, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a scheduled audit.
+%%
+%% Requires permission to access the DescribeScheduledAudit action.
 describe_scheduled_audit(Client, ScheduledAuditName)
   when is_map(Client) ->
     describe_scheduled_audit(Client, ScheduledAuditName, #{}, #{}).
@@ -3033,6 +3397,8 @@ describe_scheduled_audit(Client, ScheduledAuditName, QueryMap, HeadersMap, Optio
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a Device Defender security profile.
+%%
+%% Requires permission to access the DescribeSecurityProfile action.
 describe_security_profile(Client, SecurityProfileName)
   when is_map(Client) ->
     describe_security_profile(Client, SecurityProfileName, #{}, #{}).
@@ -3056,6 +3422,8 @@ describe_security_profile(Client, SecurityProfileName, QueryMap, HeadersMap, Opt
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a stream.
+%%
+%% Requires permission to access the DescribeStream action.
 describe_stream(Client, StreamId)
   when is_map(Client) ->
     describe_stream(Client, StreamId, #{}, #{}).
@@ -3079,6 +3447,8 @@ describe_stream(Client, StreamId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about the specified thing.
+%%
+%% Requires permission to access the DescribeThing action.
 describe_thing(Client, ThingName)
   when is_map(Client) ->
     describe_thing(Client, ThingName, #{}, #{}).
@@ -3102,6 +3472,8 @@ describe_thing(Client, ThingName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describe a thing group.
+%%
+%% Requires permission to access the DescribeThingGroup action.
 describe_thing_group(Client, ThingGroupName)
   when is_map(Client) ->
     describe_thing_group(Client, ThingGroupName, #{}, #{}).
@@ -3125,6 +3497,8 @@ describe_thing_group(Client, ThingGroupName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Describes a bulk thing provisioning task.
+%%
+%% Requires permission to access the DescribeThingRegistrationTask action.
 describe_thing_registration_task(Client, TaskId)
   when is_map(Client) ->
     describe_thing_registration_task(Client, TaskId, #{}, #{}).
@@ -3148,6 +3522,8 @@ describe_thing_registration_task(Client, TaskId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about the specified thing type.
+%%
+%% Requires permission to access the DescribeThingType action.
 describe_thing_type(Client, ThingTypeName)
   when is_map(Client) ->
     describe_thing_type(Client, ThingTypeName, #{}, #{}).
@@ -3171,6 +3547,12 @@ describe_thing_type(Client, ThingTypeName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Detaches a policy from the specified target.
+%%
+%% Because of the distributed nature of Amazon Web Services, it can take up
+%% to five minutes after a policy is detached before it's ready to be
+%% deleted.
+%%
+%% Requires permission to access the DetachPolicy action.
 detach_policy(Client, PolicyName, Input) ->
     detach_policy(Client, PolicyName, Input, []).
 detach_policy(Client, PolicyName, Input0, Options0) ->
@@ -3195,7 +3577,9 @@ detach_policy(Client, PolicyName, Input0, Options0) ->
 
 %% @doc Removes the specified policy from the specified certificate.
 %%
-%% Note: This API is deprecated. Please use `DetachPolicy' instead.
+%% This action is deprecated. Please use `DetachPolicy' instead.
+%%
+%% Requires permission to access the DetachPrincipalPolicy action.
 detach_principal_policy(Client, PolicyName, Input) ->
     detach_principal_policy(Client, PolicyName, Input, []).
 detach_principal_policy(Client, PolicyName, Input0, Options0) ->
@@ -3222,6 +3606,8 @@ detach_principal_policy(Client, PolicyName, Input0, Options0) ->
 
 %% @doc Disassociates a Device Defender security profile from a thing group
 %% or from this account.
+%%
+%% Requires permission to access the DetachSecurityProfile action.
 detach_security_profile(Client, SecurityProfileName, Input) ->
     detach_security_profile(Client, SecurityProfileName, Input, []).
 detach_security_profile(Client, SecurityProfileName, Input0, Options0) ->
@@ -3252,6 +3638,8 @@ detach_security_profile(Client, SecurityProfileName, Input0, Options0) ->
 %%
 %% This call is asynchronous. It might take several seconds for the
 %% detachment to propagate.
+%%
+%% Requires permission to access the DetachThingPrincipal action.
 detach_thing_principal(Client, ThingName, Input) ->
     detach_thing_principal(Client, ThingName, Input, []).
 detach_thing_principal(Client, ThingName, Input0, Options0) ->
@@ -3277,6 +3665,8 @@ detach_thing_principal(Client, ThingName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Disables the rule.
+%%
+%% Requires permission to access the DisableTopicRule action.
 disable_topic_rule(Client, RuleName, Input) ->
     disable_topic_rule(Client, RuleName, Input, []).
 disable_topic_rule(Client, RuleName, Input0, Options0) ->
@@ -3300,6 +3690,8 @@ disable_topic_rule(Client, RuleName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Enables the rule.
+%%
+%% Requires permission to access the EnableTopicRule action.
 enable_topic_rule(Client, RuleName, Input) ->
     enable_topic_rule(Client, RuleName, Input, []).
 enable_topic_rule(Client, RuleName, Input0, Options0) ->
@@ -3324,6 +3716,9 @@ enable_topic_rule(Client, RuleName, Input0, Options0) ->
 
 %% @doc Returns a Device Defender's ML Detect Security Profile training
 %% model's status.
+%%
+%% Requires permission to access the GetBehaviorModelTrainingSummaries
+%% action.
 get_behavior_model_training_summaries(Client)
   when is_map(Client) ->
     get_behavior_model_training_summaries(Client, #{}, #{}).
@@ -3352,7 +3747,35 @@ get_behavior_model_training_summaries(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Aggregates on indexed data with search queries pertaining to
+%% particular fields.
+%%
+%% Requires permission to access the GetBucketsAggregation action.
+get_buckets_aggregation(Client, Input) ->
+    get_buckets_aggregation(Client, Input, []).
+get_buckets_aggregation(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/indices/buckets"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Returns the approximate count of unique values that match the query.
+%%
+%% Requires permission to access the GetCardinality action.
 get_cardinality(Client, Input) ->
     get_cardinality(Client, Input, []).
 get_cardinality(Client, Input0, Options0) ->
@@ -3376,8 +3799,10 @@ get_cardinality(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets a list of the policies that have an effect on the authorization
-%% behavior of the specified device when it connects to the AWS IoT device
+%% behavior of the specified device when it connects to the IoT device
 %% gateway.
+%%
+%% Requires permission to access the GetEffectivePolicies action.
 get_effective_policies(Client, Input) ->
     get_effective_policies(Client, Input, []).
 get_effective_policies(Client, Input0, Options0) ->
@@ -3402,6 +3827,8 @@ get_effective_policies(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets the indexing configuration.
+%%
+%% Requires permission to access the GetIndexingConfiguration action.
 get_indexing_configuration(Client)
   when is_map(Client) ->
     get_indexing_configuration(Client, #{}, #{}).
@@ -3425,6 +3852,8 @@ get_indexing_configuration(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets a job document.
+%%
+%% Requires permission to access the GetJobDocument action.
 get_job_document(Client, JobId)
   when is_map(Client) ->
     get_job_document(Client, JobId, #{}, #{}).
@@ -3451,6 +3880,8 @@ get_job_document(Client, JobId, QueryMap, HeadersMap, Options0)
 %%
 %% NOTE: use of this command is not recommended. Use `GetV2LoggingOptions'
 %% instead.
+%%
+%% Requires permission to access the GetLoggingOptions action.
 get_logging_options(Client)
   when is_map(Client) ->
     get_logging_options(Client, #{}, #{}).
@@ -3474,6 +3905,8 @@ get_logging_options(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets an OTA update.
+%%
+%% Requires permission to access the GetOTAUpdate action.
 get_ota_update(Client, OtaUpdateId)
   when is_map(Client) ->
     get_ota_update(Client, OtaUpdateId, #{}, #{}).
@@ -3508,6 +3941,8 @@ get_ota_update(Client, OtaUpdateId, QueryMap, HeadersMap, Options0)
 %% occurs in approximately five percent of the values that match the query,
 %% and so on. The result is an approximation, the more values that match the
 %% query, the more accurate the percentile values.
+%%
+%% Requires permission to access the GetPercentiles action.
 get_percentiles(Client, Input) ->
     get_percentiles(Client, Input, []).
 get_percentiles(Client, Input0, Options0) ->
@@ -3532,6 +3967,8 @@ get_percentiles(Client, Input0, Options0) ->
 
 %% @doc Gets information about the specified policy with the policy document
 %% of the default version.
+%%
+%% Requires permission to access the GetPolicy action.
 get_policy(Client, PolicyName)
   when is_map(Client) ->
     get_policy(Client, PolicyName, #{}, #{}).
@@ -3555,6 +3992,8 @@ get_policy(Client, PolicyName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about the specified policy version.
+%%
+%% Requires permission to access the GetPolicyVersion action.
 get_policy_version(Client, PolicyName, PolicyVersionId)
   when is_map(Client) ->
     get_policy_version(Client, PolicyName, PolicyVersionId, #{}, #{}).
@@ -3577,8 +4016,9 @@ get_policy_version(Client, PolicyName, PolicyVersionId, QueryMap, HeadersMap, Op
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Gets a registration code used to register a CA certificate with AWS
-%% IoT.
+%% @doc Gets a registration code used to register a CA certificate with IoT.
+%%
+%% Requires permission to access the GetRegistrationCode action.
 get_registration_code(Client)
   when is_map(Client) ->
     get_registration_code(Client, #{}, #{}).
@@ -3606,6 +4046,8 @@ get_registration_code(Client, QueryMap, HeadersMap, Options0)
 %%
 %% If the aggregation field is of type `String', only the count statistic is
 %% returned.
+%%
+%% Requires permission to access the GetStatistics action.
 get_statistics(Client, Input) ->
     get_statistics(Client, Input, []).
 get_statistics(Client, Input0, Options0) ->
@@ -3629,6 +4071,8 @@ get_statistics(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets information about the rule.
+%%
+%% Requires permission to access the GetTopicRule action.
 get_topic_rule(Client, RuleName)
   when is_map(Client) ->
     get_topic_rule(Client, RuleName, #{}, #{}).
@@ -3652,6 +4096,8 @@ get_topic_rule(Client, RuleName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about a topic rule destination.
+%%
+%% Requires permission to access the GetTopicRuleDestination action.
 get_topic_rule_destination(Client, Arn)
   when is_map(Client) ->
     get_topic_rule_destination(Client, Arn, #{}, #{}).
@@ -3675,6 +4121,8 @@ get_topic_rule_destination(Client, Arn, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets the fine grained logging options.
+%%
+%% Requires permission to access the GetV2LoggingOptions action.
 get_v2_logging_options(Client)
   when is_map(Client) ->
     get_v2_logging_options(Client, #{}, #{}).
@@ -3699,6 +4147,8 @@ get_v2_logging_options(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists the active violations for a given Device Defender security
 %% profile.
+%%
+%% Requires permission to access the ListActiveViolations action.
 list_active_violations(Client)
   when is_map(Client) ->
     list_active_violations(Client, #{}, #{}).
@@ -3724,13 +4174,16 @@ list_active_violations(Client, QueryMap, HeadersMap, Options0)
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
         {<<"securityProfileName">>, maps:get(<<"securityProfileName">>, QueryMap, undefined)},
-        {<<"thingName">>, maps:get(<<"thingName">>, QueryMap, undefined)}
+        {<<"thingName">>, maps:get(<<"thingName">>, QueryMap, undefined)},
+        {<<"verificationState">>, maps:get(<<"verificationState">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the policies attached to the specified thing group.
+%%
+%% Requires permission to access the ListAttachedPolicies action.
 list_attached_policies(Client, Target, Input) ->
     list_attached_policies(Client, Target, Input, []).
 list_attached_policies(Client, Target, Input0, Options0) ->
@@ -3760,6 +4213,8 @@ list_attached_policies(Client, Target, Input0, Options0) ->
 %% audits performed during a specified time period.
 %%
 %% (Findings are retained for 90 days.)
+%%
+%% Requires permission to access the ListAuditFindings action.
 list_audit_findings(Client, Input) ->
     list_audit_findings(Client, Input, []).
 list_audit_findings(Client, Input0, Options0) ->
@@ -3783,6 +4238,9 @@ list_audit_findings(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets the status of audit mitigation action tasks that were executed.
+%%
+%% Requires permission to access the ListAuditMitigationActionsExecutions
+%% action.
 list_audit_mitigation_actions_executions(Client, FindingId, TaskId)
   when is_map(Client) ->
     list_audit_mitigation_actions_executions(Client, FindingId, TaskId, #{}, #{}).
@@ -3815,6 +4273,8 @@ list_audit_mitigation_actions_executions(Client, FindingId, TaskId, QueryMap, He
 
 %% @doc Gets a list of audit mitigation action tasks that match the specified
 %% filters.
+%%
+%% Requires permission to access the ListAuditMitigationActionsTasks action.
 list_audit_mitigation_actions_tasks(Client, EndTime, StartTime)
   when is_map(Client) ->
     list_audit_mitigation_actions_tasks(Client, EndTime, StartTime, #{}, #{}).
@@ -3848,6 +4308,8 @@ list_audit_mitigation_actions_tasks(Client, EndTime, StartTime, QueryMap, Header
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists your Device Defender audit listings.
+%%
+%% Requires permission to access the ListAuditSuppressions action.
 list_audit_suppressions(Client, Input) ->
     list_audit_suppressions(Client, Input, []).
 list_audit_suppressions(Client, Input0, Options0) ->
@@ -3872,6 +4334,8 @@ list_audit_suppressions(Client, Input0, Options0) ->
 
 %% @doc Lists the Device Defender audits that have been performed during a
 %% given time period.
+%%
+%% Requires permission to access the ListAuditTasks action.
 list_audit_tasks(Client, EndTime, StartTime)
   when is_map(Client) ->
     list_audit_tasks(Client, EndTime, StartTime, #{}, #{}).
@@ -3904,6 +4368,8 @@ list_audit_tasks(Client, EndTime, StartTime, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the authorizers registered in your account.
+%%
+%% Requires permission to access the ListAuthorizers action.
 list_authorizers(Client)
   when is_map(Client) ->
     list_authorizers(Client, #{}, #{}).
@@ -3934,6 +4400,8 @@ list_authorizers(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the billing groups you have created.
+%%
+%% Requires permission to access the ListBillingGroups action.
 list_billing_groups(Client)
   when is_map(Client) ->
     list_billing_groups(Client, #{}, #{}).
@@ -3962,10 +4430,13 @@ list_billing_groups(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists the CA certificates registered for your AWS account.
+%% @doc Lists the CA certificates registered for your Amazon Web Services
+%% account.
 %%
 %% The results are paginated with a default page size of 25. You can use the
 %% returned marker to retrieve additional results.
+%%
+%% Requires permission to access the ListCACertificates action.
 list_ca_certificates(Client)
   when is_map(Client) ->
     list_ca_certificates(Client, #{}, #{}).
@@ -3994,10 +4465,13 @@ list_ca_certificates(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists the certificates registered in your AWS account.
+%% @doc Lists the certificates registered in your Amazon Web Services
+%% account.
 %%
 %% The results are paginated with a default page size of 25. You can use the
 %% returned marker to retrieve additional results.
+%%
+%% Requires permission to access the ListCertificates action.
 list_certificates(Client)
   when is_map(Client) ->
     list_certificates(Client, #{}, #{}).
@@ -4027,6 +4501,8 @@ list_certificates(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List the device certificates signed by the specified CA certificate.
+%%
+%% Requires permission to access the ListCertificatesByCA action.
 list_certificates_by_ca(Client, CaCertificateId)
   when is_map(Client) ->
     list_certificates_by_ca(Client, CaCertificateId, #{}, #{}).
@@ -4056,6 +4532,8 @@ list_certificates_by_ca(Client, CaCertificateId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists your Device Defender detect custom metrics.
+%%
+%% Requires permission to access the ListCustomMetrics action.
 list_custom_metrics(Client)
   when is_map(Client) ->
     list_custom_metrics(Client, #{}, #{}).
@@ -4085,6 +4563,9 @@ list_custom_metrics(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists mitigation actions executions for a Device Defender ML Detect
 %% Security Profile.
+%%
+%% Requires permission to access the ListDetectMitigationActionsExecutions
+%% action.
 list_detect_mitigation_actions_executions(Client)
   when is_map(Client) ->
     list_detect_mitigation_actions_executions(Client, #{}, #{}).
@@ -4118,6 +4599,8 @@ list_detect_mitigation_actions_executions(Client, QueryMap, HeadersMap, Options0
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List of Device Defender ML Detect mitigation actions tasks.
+%%
+%% Requires permission to access the ListDetectMitigationActionsTasks action.
 list_detect_mitigation_actions_tasks(Client, EndTime, StartTime)
   when is_map(Client) ->
     list_detect_mitigation_actions_tasks(Client, EndTime, StartTime, #{}, #{}).
@@ -4147,7 +4630,10 @@ list_detect_mitigation_actions_tasks(Client, EndTime, StartTime, QueryMap, Heade
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc List the set of dimensions that are defined for your AWS account.
+%% @doc List the set of dimensions that are defined for your Amazon Web
+%% Services accounts.
+%%
+%% Requires permission to access the ListDimensions action.
 list_dimensions(Client)
   when is_map(Client) ->
     list_dimensions(Client, #{}, #{}).
@@ -4179,8 +4665,7 @@ list_dimensions(Client, QueryMap, HeadersMap, Options0)
 %%
 %% This list is sorted alphabetically by domain configuration name.
 %%
-%% The domain configuration feature is in public preview and is subject to
-%% change.
+%% Requires permission to access the ListDomainConfigurations action.
 list_domain_configurations(Client)
   when is_map(Client) ->
     list_domain_configurations(Client, #{}, #{}).
@@ -4209,7 +4694,39 @@ list_domain_configurations(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Lists all your fleet metrics.
+%%
+%% Requires permission to access the ListFleetMetrics action.
+list_fleet_metrics(Client)
+  when is_map(Client) ->
+    list_fleet_metrics(Client, #{}, #{}).
+
+list_fleet_metrics(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_fleet_metrics(Client, QueryMap, HeadersMap, []).
+
+list_fleet_metrics(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/fleet-metrics"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Lists the search indices.
+%%
+%% Requires permission to access the ListIndices action.
 list_indices(Client)
   when is_map(Client) ->
     list_indices(Client, #{}, #{}).
@@ -4238,6 +4755,8 @@ list_indices(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the job executions for a job.
+%%
+%% Requires permission to access the ListJobExecutionsForJob action.
 list_job_executions_for_job(Client, JobId)
   when is_map(Client) ->
     list_job_executions_for_job(Client, JobId, #{}, #{}).
@@ -4267,6 +4786,8 @@ list_job_executions_for_job(Client, JobId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the job executions for the specified thing.
+%%
+%% Requires permission to access the ListJobExecutionsForThing action.
 list_job_executions_for_thing(Client, ThingName)
   when is_map(Client) ->
     list_job_executions_for_thing(Client, ThingName, #{}, #{}).
@@ -4296,7 +4817,39 @@ list_job_executions_for_thing(Client, ThingName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns a list of job templates.
+%%
+%% Requires permission to access the ListJobTemplates action.
+list_job_templates(Client)
+  when is_map(Client) ->
+    list_job_templates(Client, #{}, #{}).
+
+list_job_templates(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_job_templates(Client, QueryMap, HeadersMap, []).
+
+list_job_templates(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/job-templates"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Lists jobs.
+%%
+%% Requires permission to access the ListJobs action.
 list_jobs(Client)
   when is_map(Client) ->
     list_jobs(Client, #{}, #{}).
@@ -4331,6 +4884,8 @@ list_jobs(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Gets a list of all mitigation actions that match the specified filter
 %% criteria.
+%%
+%% Requires permission to access the ListMitigationActions action.
 list_mitigation_actions(Client)
   when is_map(Client) ->
     list_mitigation_actions(Client, #{}, #{}).
@@ -4360,6 +4915,8 @@ list_mitigation_actions(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists OTA updates.
+%%
+%% Requires permission to access the ListOTAUpdates action.
 list_ota_updates(Client)
   when is_map(Client) ->
     list_ota_updates(Client, #{}, #{}).
@@ -4389,6 +4946,8 @@ list_ota_updates(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists certificates that are being transferred but not yet accepted.
+%%
+%% Requires permission to access the ListOutgoingCertificates action.
 list_outgoing_certificates(Client)
   when is_map(Client) ->
     list_outgoing_certificates(Client, #{}, #{}).
@@ -4418,6 +4977,8 @@ list_outgoing_certificates(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists your policies.
+%%
+%% Requires permission to access the ListPolicies action.
 list_policies(Client)
   when is_map(Client) ->
     list_policies(Client, #{}, #{}).
@@ -4448,7 +5009,10 @@ list_policies(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists the principals associated with the specified policy.
 %%
-%% Note: This API is deprecated. Please use `ListTargetsForPolicy' instead.
+%% Note: This action is deprecated. Please use `ListTargetsForPolicy'
+%% instead.
+%%
+%% Requires permission to access the ListPolicyPrincipals action.
 list_policy_principals(Client, PolicyName)
   when is_map(Client) ->
     list_policy_principals(Client, PolicyName, #{}, #{}).
@@ -4483,6 +5047,8 @@ list_policy_principals(Client, PolicyName, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists the versions of the specified policy and identifies the default
 %% version.
+%%
+%% Requires permission to access the ListPolicyVersions action.
 list_policy_versions(Client, PolicyName)
   when is_map(Client) ->
     list_policy_versions(Client, PolicyName, #{}, #{}).
@@ -4510,7 +5076,10 @@ list_policy_versions(Client, PolicyName, QueryMap, HeadersMap, Options0)
 %% If you use an Cognito identity, the ID must be in AmazonCognito Identity
 %% format.
 %%
-%% Note: This API is deprecated. Please use `ListAttachedPolicies' instead.
+%% Note: This action is deprecated. Please use `ListAttachedPolicies'
+%% instead.
+%%
+%% Requires permission to access the ListPrincipalPolicies action.
 list_principal_policies(Client, Principal)
   when is_map(Client) ->
     list_principal_policies(Client, Principal, #{}, #{}).
@@ -4547,6 +5116,8 @@ list_principal_policies(Client, Principal, QueryMap, HeadersMap, Options0)
 %%
 %% A principal can be X.509 certificates, IAM users, groups, and roles,
 %% Amazon Cognito identities or federated identities.
+%%
+%% Requires permission to access the ListPrincipalThings action.
 list_principal_things(Client, Principal)
   when is_map(Client) ->
     list_principal_things(Client, Principal, #{}, #{}).
@@ -4579,6 +5150,8 @@ list_principal_things(Client, Principal, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc A list of fleet provisioning template versions.
+%%
+%% Requires permission to access the ListProvisioningTemplateVersions action.
 list_provisioning_template_versions(Client, TemplateName)
   when is_map(Client) ->
     list_provisioning_template_versions(Client, TemplateName, #{}, #{}).
@@ -4606,7 +5179,10 @@ list_provisioning_template_versions(Client, TemplateName, QueryMap, HeadersMap, 
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists the fleet provisioning templates in your AWS account.
+%% @doc Lists the fleet provisioning templates in your Amazon Web Services
+%% account.
+%%
+%% Requires permission to access the ListProvisioningTemplates action.
 list_provisioning_templates(Client)
   when is_map(Client) ->
     list_provisioning_templates(Client, #{}, #{}).
@@ -4635,6 +5211,8 @@ list_provisioning_templates(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the role aliases registered in your account.
+%%
+%% Requires permission to access the ListRoleAliases action.
 list_role_aliases(Client)
   when is_map(Client) ->
     list_role_aliases(Client, #{}, #{}).
@@ -4664,6 +5242,8 @@ list_role_aliases(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists all of your scheduled audits.
+%%
+%% Requires permission to access the ListScheduledAudits action.
 list_scheduled_audits(Client)
   when is_map(Client) ->
     list_scheduled_audits(Client, #{}, #{}).
@@ -4694,6 +5274,8 @@ list_scheduled_audits(Client, QueryMap, HeadersMap, Options0)
 %% @doc Lists the Device Defender security profiles you've created.
 %%
 %% You can filter security profiles by dimension or custom metric.
+%%
+%% Requires permission to access the ListSecurityProfiles action.
 %%
 %% `dimensionName' and `metricName' cannot be used in the same request.
 list_security_profiles(Client)
@@ -4727,6 +5309,8 @@ list_security_profiles(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists the Device Defender security profiles attached to a target
 %% (thing group).
+%%
+%% Requires permission to access the ListSecurityProfilesForTarget action.
 list_security_profiles_for_target(Client, SecurityProfileTargetArn)
   when is_map(Client) ->
     list_security_profiles_for_target(Client, SecurityProfileTargetArn, #{}, #{}).
@@ -4756,7 +5340,9 @@ list_security_profiles_for_target(Client, SecurityProfileTargetArn, QueryMap, He
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all of the streams in your AWS account.
+%% @doc Lists all of the streams in your Amazon Web Services account.
+%%
+%% Requires permission to access the ListStreams action.
 list_streams(Client)
   when is_map(Client) ->
     list_streams(Client, #{}, #{}).
@@ -4786,6 +5372,8 @@ list_streams(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the tags (metadata) you have assigned to the resource.
+%%
+%% Requires permission to access the ListTagsForResource action.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -4814,6 +5402,8 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List targets for the specified policy.
+%%
+%% Requires permission to access the ListTargetsForPolicy action.
 list_targets_for_policy(Client, PolicyName, Input) ->
     list_targets_for_policy(Client, PolicyName, Input, []).
 list_targets_for_policy(Client, PolicyName, Input0, Options0) ->
@@ -4840,6 +5430,8 @@ list_targets_for_policy(Client, PolicyName, Input0, Options0) ->
 
 %% @doc Lists the targets (thing groups) associated with a given Device
 %% Defender security profile.
+%%
+%% Requires permission to access the ListTargetsForSecurityProfile action.
 list_targets_for_security_profile(Client, SecurityProfileName)
   when is_map(Client) ->
     list_targets_for_security_profile(Client, SecurityProfileName, #{}, #{}).
@@ -4868,6 +5460,8 @@ list_targets_for_security_profile(Client, SecurityProfileName, QueryMap, Headers
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List the thing groups in your account.
+%%
+%% Requires permission to access the ListThingGroups action.
 list_thing_groups(Client)
   when is_map(Client) ->
     list_thing_groups(Client, #{}, #{}).
@@ -4899,6 +5493,8 @@ list_thing_groups(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List the thing groups to which the specified thing belongs.
+%%
+%% Requires permission to access the ListThingGroupsForThing action.
 list_thing_groups_for_thing(Client, ThingName)
   when is_map(Client) ->
     list_thing_groups_for_thing(Client, ThingName, #{}, #{}).
@@ -4930,6 +5526,8 @@ list_thing_groups_for_thing(Client, ThingName, QueryMap, HeadersMap, Options0)
 %%
 %% A principal can be X.509 certificates, IAM users, groups, and roles,
 %% Amazon Cognito identities or federated identities.
+%%
+%% Requires permission to access the ListThingPrincipals action.
 list_thing_principals(Client, ThingName)
   when is_map(Client) ->
     list_thing_principals(Client, ThingName, #{}, #{}).
@@ -4987,6 +5585,8 @@ list_thing_registration_task_reports(Client, TaskId, ReportType, QueryMap, Heade
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc List bulk thing provisioning tasks.
+%%
+%% Requires permission to access the ListThingRegistrationTasks action.
 list_thing_registration_tasks(Client)
   when is_map(Client) ->
     list_thing_registration_tasks(Client, #{}, #{}).
@@ -5016,6 +5616,8 @@ list_thing_registration_tasks(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the existing thing types.
+%%
+%% Requires permission to access the ListThingTypes action.
 list_thing_types(Client)
   when is_map(Client) ->
     list_thing_types(Client, #{}, #{}).
@@ -5051,6 +5653,8 @@ list_thing_types(Client, QueryMap, HeadersMap, Options0)
 %% attributeValue=Red retrieves all things in the registry that contain an
 %% attribute Color with the value Red.
 %%
+%% Requires permission to access the ListThings action.
+%%
 %% You will not be charged for calling this API if an `Access denied' error
 %% is returned. You will also not be charged if no attributes or pagination
 %% token was provided in request and no pagination token and no results were
@@ -5079,13 +5683,16 @@ list_things(Client, QueryMap, HeadersMap, Options0)
         {<<"attributeValue">>, maps:get(<<"attributeValue">>, QueryMap, undefined)},
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
-        {<<"thingTypeName">>, maps:get(<<"thingTypeName">>, QueryMap, undefined)}
+        {<<"thingTypeName">>, maps:get(<<"thingTypeName">>, QueryMap, undefined)},
+        {<<"usePrefixAttributeValue">>, maps:get(<<"usePrefixAttributeValue">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the things you have added to the given billing group.
+%%
+%% Requires permission to access the ListThingsInBillingGroup action.
 list_things_in_billing_group(Client, BillingGroupName)
   when is_map(Client) ->
     list_things_in_billing_group(Client, BillingGroupName, #{}, #{}).
@@ -5114,6 +5721,8 @@ list_things_in_billing_group(Client, BillingGroupName, QueryMap, HeadersMap, Opt
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the things in the specified group.
+%%
+%% Requires permission to access the ListThingsInThingGroup action.
 list_things_in_thing_group(Client, ThingGroupName)
   when is_map(Client) ->
     list_things_in_thing_group(Client, ThingGroupName, #{}, #{}).
@@ -5142,7 +5751,10 @@ list_things_in_thing_group(Client, ThingGroupName, QueryMap, HeadersMap, Options
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the topic rule destinations in your AWS account.
+%% @doc Lists all the topic rule destinations in your Amazon Web Services
+%% account.
+%%
+%% Requires permission to access the ListTopicRuleDestinations action.
 list_topic_rule_destinations(Client)
   when is_map(Client) ->
     list_topic_rule_destinations(Client, #{}, #{}).
@@ -5171,6 +5783,8 @@ list_topic_rule_destinations(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the rules for the specific topic.
+%%
+%% Requires permission to access the ListTopicRules action.
 list_topic_rules(Client)
   when is_map(Client) ->
     list_topic_rules(Client, #{}, #{}).
@@ -5201,6 +5815,8 @@ list_topic_rules(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists logging levels.
+%%
+%% Requires permission to access the ListV2LoggingLevels action.
 list_v2_logging_levels(Client)
   when is_map(Client) ->
     list_v2_logging_levels(Client, #{}, #{}).
@@ -5234,6 +5850,8 @@ list_v2_logging_levels(Client, QueryMap, HeadersMap, Options0)
 %%
 %% You can use filters to limit the results to those alerts issued for a
 %% particular security profile, behavior, or thing (device).
+%%
+%% Requires permission to access the ListViolationEvents action.
 list_violation_events(Client, EndTime, StartTime)
   when is_map(Client) ->
     list_violation_events(Client, EndTime, StartTime, #{}, #{}).
@@ -5261,21 +5879,48 @@ list_violation_events(Client, EndTime, StartTime, QueryMap, HeadersMap, Options0
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
         {<<"securityProfileName">>, maps:get(<<"securityProfileName">>, QueryMap, undefined)},
         {<<"startTime">>, StartTime},
-        {<<"thingName">>, maps:get(<<"thingName">>, QueryMap, undefined)}
+        {<<"thingName">>, maps:get(<<"thingName">>, QueryMap, undefined)},
+        {<<"verificationState">>, maps:get(<<"verificationState">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Registers a CA certificate with AWS IoT.
+%% @doc Set a verification state and provide a description of that
+%% verification state on a violation (detect alarm).
+put_verification_state_on_violation(Client, ViolationId, Input) ->
+    put_verification_state_on_violation(Client, ViolationId, Input, []).
+put_verification_state_on_violation(Client, ViolationId, Input0, Options0) ->
+    Method = post,
+    Path = ["/violations/verification-state/", aws_util:encode_uri(ViolationId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Registers a CA certificate with IoT.
 %%
 %% This CA certificate can then be used to sign device certificates, which
-%% can be then registered with AWS IoT. You can register up to 10 CA
-%% certificates per AWS account that have the same subject field. This
+%% can be then registered with IoT. You can register up to 10 CA certificates
+%% per Amazon Web Services account that have the same subject field. This
 %% enables you to have up to 10 certificate authorities sign your device
 %% certificates. If you have more than one CA certificate registered, make
 %% sure you pass the CA certificate when you register your device
-%% certificates with the RegisterCertificate API.
+%% certificates with the `RegisterCertificate' action.
+%%
+%% Requires permission to access the RegisterCACertificate action.
 register_ca_certificate(Client, Input) ->
     register_ca_certificate(Client, Input, []).
 register_ca_certificate(Client, Input0, Options0) ->
@@ -5300,11 +5945,13 @@ register_ca_certificate(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Registers a device certificate with AWS IoT.
+%% @doc Registers a device certificate with IoT.
 %%
 %% If you have more than one CA certificate that has the same subject field,
 %% you must specify the CA certificate that was used to sign the device
 %% certificate being registered.
+%%
+%% Requires permission to access the RegisterCertificate action.
 register_certificate(Client, Input) ->
     register_certificate(Client, Input, []).
 register_certificate(Client, Input0, Options0) ->
@@ -5354,10 +6001,12 @@ register_certificate_without_ca(Client, Input0, Options0) ->
 
 %% @doc Provisions a thing in the device registry.
 %%
-%% RegisterThing calls other AWS IoT control plane APIs. These calls might
-%% exceed your account level AWS IoT Throttling Limits and cause throttle
-%% errors. Please contact AWS Customer Support to raise your throttling
+%% RegisterThing calls other IoT control plane APIs. These calls might exceed
+%% your account level IoT Throttling Limits and cause throttle errors. Please
+%% contact Amazon Web Services Customer Support to raise your throttling
 %% limits if necessary.
+%%
+%% Requires permission to access the RegisterThing action.
 register_thing(Client, Input) ->
     register_thing(Client, Input, []).
 register_thing(Client, Input0, Options0) ->
@@ -5382,8 +6031,8 @@ register_thing(Client, Input0, Options0) ->
 
 %% @doc Rejects a pending certificate transfer.
 %%
-%% After AWS IoT rejects a certificate transfer, the certificate status
-%% changes from PENDING_TRANSFER to INACTIVE.
+%% After IoT rejects a certificate transfer, the certificate status changes
+%% from PENDING_TRANSFER to INACTIVE.
 %%
 %% To check for pending certificate transfers, call `ListCertificates' to
 %% enumerate your certificates.
@@ -5391,6 +6040,8 @@ register_thing(Client, Input0, Options0) ->
 %% This operation can only be called by the transfer destination. After it is
 %% called, the certificate will be returned to the source's account in the
 %% INACTIVE state.
+%%
+%% Requires permission to access the RejectCertificateTransfer action.
 reject_certificate_transfer(Client, CertificateId, Input) ->
     reject_certificate_transfer(Client, CertificateId, Input, []).
 reject_certificate_transfer(Client, CertificateId, Input0, Options0) ->
@@ -5414,6 +6065,8 @@ reject_certificate_transfer(Client, CertificateId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Removes the given thing from the billing group.
+%%
+%% Requires permission to access the RemoveThingFromBillingGroup action.
 remove_thing_from_billing_group(Client, Input) ->
     remove_thing_from_billing_group(Client, Input, []).
 remove_thing_from_billing_group(Client, Input0, Options0) ->
@@ -5441,6 +6094,8 @@ remove_thing_from_billing_group(Client, Input0, Options0) ->
 %% You must specify either a `thingGroupArn' or a `thingGroupName' to
 %% identify the thing group and either a `thingArn' or a `thingName' to
 %% identify the thing to remove from the thing group.
+%%
+%% Requires permission to access the RemoveThingFromThingGroup action.
 remove_thing_from_thing_group(Client, Input) ->
     remove_thing_from_thing_group(Client, Input, []).
 remove_thing_from_thing_group(Client, Input0, Options0) ->
@@ -5468,6 +6123,8 @@ remove_thing_from_thing_group(Client, Input0, Options0) ->
 %% You must specify all parameters for the new rule. Creating rules is an
 %% administrator-level action. Any user who has permission to create rules
 %% will be able to access data processed by the rule.
+%%
+%% Requires permission to access the ReplaceTopicRule action.
 replace_topic_rule(Client, RuleName, Input) ->
     replace_topic_rule(Client, RuleName, Input, []).
 replace_topic_rule(Client, RuleName, Input0, Options0) ->
@@ -5491,6 +6148,8 @@ replace_topic_rule(Client, RuleName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc The query search index.
+%%
+%% Requires permission to access the SearchIndex action.
 search_index(Client, Input) ->
     search_index(Client, Input, []).
 search_index(Client, Input0, Options0) ->
@@ -5517,6 +6176,8 @@ search_index(Client, Input0, Options0) ->
 %%
 %% This will be used if a websocket connection is made without specifying an
 %% authorizer.
+%%
+%% Requires permission to access the SetDefaultAuthorizer action.
 set_default_authorizer(Client, Input) ->
     set_default_authorizer(Client, Input, []).
 set_default_authorizer(Client, Input0, Options0) ->
@@ -5543,8 +6204,10 @@ set_default_authorizer(Client, Input0, Options0) ->
 %% default (operative) version.
 %%
 %% This action affects all certificates to which the policy is attached. To
-%% list the principals the policy is attached to, use the ListPrincipalPolicy
-%% API.
+%% list the principals the policy is attached to, use the
+%% `ListPrincipalPolicies' action.
+%%
+%% Requires permission to access the SetDefaultPolicyVersion action.
 set_default_policy_version(Client, PolicyName, PolicyVersionId, Input) ->
     set_default_policy_version(Client, PolicyName, PolicyVersionId, Input, []).
 set_default_policy_version(Client, PolicyName, PolicyVersionId, Input0, Options0) ->
@@ -5571,6 +6234,8 @@ set_default_policy_version(Client, PolicyName, PolicyVersionId, Input0, Options0
 %%
 %% NOTE: use of this command is not recommended. Use `SetV2LoggingOptions'
 %% instead.
+%%
+%% Requires permission to access the SetLoggingOptions action.
 set_logging_options(Client, Input) ->
     set_logging_options(Client, Input, []).
 set_logging_options(Client, Input0, Options0) ->
@@ -5594,6 +6259,8 @@ set_logging_options(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Sets the logging level.
+%%
+%% Requires permission to access the SetV2LoggingLevel action.
 set_v2_logging_level(Client, Input) ->
     set_v2_logging_level(Client, Input, []).
 set_v2_logging_level(Client, Input0, Options0) ->
@@ -5617,6 +6284,8 @@ set_v2_logging_level(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Sets the logging options for the V2 logging service.
+%%
+%% Requires permission to access the SetV2LoggingOptions action.
 set_v2_logging_options(Client, Input) ->
     set_v2_logging_options(Client, Input, []).
 set_v2_logging_options(Client, Input0, Options0) ->
@@ -5641,6 +6310,8 @@ set_v2_logging_options(Client, Input0, Options0) ->
 
 %% @doc Starts a task that applies a set of mitigation actions to the
 %% specified target.
+%%
+%% Requires permission to access the StartAuditMitigationActionsTask action.
 start_audit_mitigation_actions_task(Client, TaskId, Input) ->
     start_audit_mitigation_actions_task(Client, TaskId, Input, []).
 start_audit_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
@@ -5664,6 +6335,8 @@ start_audit_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Starts a Device Defender ML Detect mitigation actions task.
+%%
+%% Requires permission to access the StartDetectMitigationActionsTask action.
 start_detect_mitigation_actions_task(Client, TaskId, Input) ->
     start_detect_mitigation_actions_task(Client, TaskId, Input, []).
 start_detect_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
@@ -5687,6 +6360,8 @@ start_detect_mitigation_actions_task(Client, TaskId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Starts an on-demand Device Defender audit.
+%%
+%% Requires permission to access the StartOnDemandAuditTask action.
 start_on_demand_audit_task(Client, Input) ->
     start_on_demand_audit_task(Client, Input, []).
 start_on_demand_audit_task(Client, Input0, Options0) ->
@@ -5710,6 +6385,8 @@ start_on_demand_audit_task(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a bulk thing provisioning task.
+%%
+%% Requires permission to access the StartThingRegistrationTask action.
 start_thing_registration_task(Client, Input) ->
     start_thing_registration_task(Client, Input, []).
 start_thing_registration_task(Client, Input0, Options0) ->
@@ -5733,6 +6410,8 @@ start_thing_registration_task(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Cancels a bulk thing provisioning task.
+%%
+%% Requires permission to access the StopThingRegistrationTask action.
 stop_thing_registration_task(Client, TaskId, Input) ->
     stop_thing_registration_task(Client, TaskId, Input, []).
 stop_thing_registration_task(Client, TaskId, Input0, Options0) ->
@@ -5758,6 +6437,8 @@ stop_thing_registration_task(Client, TaskId, Input0, Options0) ->
 %% @doc Adds to or modifies the tags of the given resource.
 %%
 %% Tags are metadata which can be used to manage a resource.
+%%
+%% Requires permission to access the TagResource action.
 tag_resource(Client, Input) ->
     tag_resource(Client, Input, []).
 tag_resource(Client, Input0, Options0) ->
@@ -5780,11 +6461,13 @@ tag_resource(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Tests if a specified principal is authorized to perform an AWS IoT
-%% action on a specified resource.
+%% @doc Tests if a specified principal is authorized to perform an IoT action
+%% on a specified resource.
 %%
 %% Use this to test and debug the authorization behavior of devices that
-%% connect to the AWS IoT device gateway.
+%% connect to the IoT device gateway.
+%%
+%% Requires permission to access the TestAuthorization action.
 test_authorization(Client, Input) ->
     test_authorization(Client, Input, []).
 test_authorization(Client, Input0, Options0) ->
@@ -5812,7 +6495,9 @@ test_authorization(Client, Input0, Options0) ->
 %% authorizer.
 %%
 %% Use this to test and debug the custom authorization behavior of devices
-%% that connect to the AWS IoT device gateway.
+%% that connect to the IoT device gateway.
+%%
+%% Requires permission to access the TestInvokeAuthorizer action.
 test_invoke_authorizer(Client, AuthorizerName, Input) ->
     test_invoke_authorizer(Client, AuthorizerName, Input, []).
 test_invoke_authorizer(Client, AuthorizerName, Input0, Options0) ->
@@ -5835,7 +6520,10 @@ test_invoke_authorizer(Client, AuthorizerName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Transfers the specified certificate to the specified AWS account.
+%% @doc Transfers the specified certificate to the specified Amazon Web
+%% Services account.
+%%
+%% Requires permission to access the TransferCertificate action.
 %%
 %% You can cancel the transfer until it is acknowledged by the recipient.
 %%
@@ -5843,10 +6531,10 @@ test_invoke_authorizer(Client, AuthorizerName, Input0, Options0) ->
 %% the caller to notify the transfer target.
 %%
 %% The certificate being transferred must not be in the ACTIVE state. You can
-%% use the UpdateCertificate API to deactivate it.
+%% use the `UpdateCertificate' action to deactivate it.
 %%
 %% The certificate must not have any policies attached to it. You can use the
-%% DetachPrincipalPolicy API to detach them.
+%% `DetachPolicy' action to detach them.
 transfer_certificate(Client, CertificateId, Input) ->
     transfer_certificate(Client, CertificateId, Input, []).
 transfer_certificate(Client, CertificateId, Input0, Options0) ->
@@ -5871,6 +6559,8 @@ transfer_certificate(Client, CertificateId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Removes the given tags (metadata) from the resource.
+%%
+%% Requires permission to access the UntagResource action.
 untag_resource(Client, Input) ->
     untag_resource(Client, Input, []).
 untag_resource(Client, Input0, Options0) ->
@@ -5898,6 +6588,8 @@ untag_resource(Client, Input0, Options0) ->
 %%
 %% Settings include how audit notifications are sent and which audit checks
 %% are enabled or disabled.
+%%
+%% Requires permission to access the UpdateAccountAuditConfiguration action.
 update_account_audit_configuration(Client, Input) ->
     update_account_audit_configuration(Client, Input, []).
 update_account_audit_configuration(Client, Input0, Options0) ->
@@ -5944,6 +6636,8 @@ update_audit_suppression(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates an authorizer.
+%%
+%% Requires permission to access the UpdateAuthorizer action.
 update_authorizer(Client, AuthorizerName, Input) ->
     update_authorizer(Client, AuthorizerName, Input, []).
 update_authorizer(Client, AuthorizerName, Input0, Options0) ->
@@ -5967,6 +6661,8 @@ update_authorizer(Client, AuthorizerName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates information about the billing group.
+%%
+%% Requires permission to access the UpdateBillingGroup action.
 update_billing_group(Client, BillingGroupName, Input) ->
     update_billing_group(Client, BillingGroupName, Input, []).
 update_billing_group(Client, BillingGroupName, Input0, Options0) ->
@@ -5990,6 +6686,8 @@ update_billing_group(Client, BillingGroupName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a registered CA certificate.
+%%
+%% Requires permission to access the UpdateCACertificate action.
 update_ca_certificate(Client, CertificateId, Input) ->
     update_ca_certificate(Client, CertificateId, Input, []).
 update_ca_certificate(Client, CertificateId, Input0, Options0) ->
@@ -6018,13 +6716,15 @@ update_ca_certificate(Client, CertificateId, Input0, Options0) ->
 %%
 %% This operation is idempotent.
 %%
+%% Requires permission to access the UpdateCertificate action.
+%%
 %% Certificates must be in the ACTIVE state to authenticate devices that use
-%% a certificate to connect to AWS IoT.
+%% a certificate to connect to IoT.
 %%
 %% Within a few minutes of updating a certificate from the ACTIVE state to
-%% any other state, AWS IoT disconnects all devices that used that
-%% certificate to connect. Devices cannot use a certificate that is not in
-%% the ACTIVE state to reconnect.
+%% any other state, IoT disconnects all devices that used that certificate to
+%% connect. Devices cannot use a certificate that is not in the ACTIVE state
+%% to reconnect.
 update_certificate(Client, CertificateId, Input) ->
     update_certificate(Client, CertificateId, Input, []).
 update_certificate(Client, CertificateId, Input0, Options0) ->
@@ -6049,6 +6749,8 @@ update_certificate(Client, CertificateId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a Device Defender detect custom metric.
+%%
+%% Requires permission to access the UpdateCustomMetric action.
 update_custom_metric(Client, MetricName, Input) ->
     update_custom_metric(Client, MetricName, Input, []).
 update_custom_metric(Client, MetricName, Input0, Options0) ->
@@ -6075,6 +6777,8 @@ update_custom_metric(Client, MetricName, Input0, Options0) ->
 %%
 %% You cannot change the type of a dimension after it is created (you can
 %% delete it and recreate it).
+%%
+%% Requires permission to access the UpdateDimension action.
 update_dimension(Client, Name, Input) ->
     update_dimension(Client, Name, Input, []).
 update_dimension(Client, Name, Input0, Options0) ->
@@ -6101,8 +6805,7 @@ update_dimension(Client, Name, Input0, Options0) ->
 %%
 %% Domain configurations for default endpoints can't be updated.
 %%
-%% The domain configuration feature is in public preview and is subject to
-%% change.
+%% Requires permission to access the UpdateDomainConfiguration action.
 update_domain_configuration(Client, DomainConfigurationName, Input) ->
     update_domain_configuration(Client, DomainConfigurationName, Input, []).
 update_domain_configuration(Client, DomainConfigurationName, Input0, Options0) ->
@@ -6126,6 +6829,8 @@ update_domain_configuration(Client, DomainConfigurationName, Input0, Options0) -
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a dynamic thing group.
+%%
+%% Requires permission to access the UpdateDynamicThingGroup action.
 update_dynamic_thing_group(Client, ThingGroupName, Input) ->
     update_dynamic_thing_group(Client, ThingGroupName, Input, []).
 update_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
@@ -6149,6 +6854,8 @@ update_dynamic_thing_group(Client, ThingGroupName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the event configurations.
+%%
+%% Requires permission to access the UpdateEventConfigurations action.
 update_event_configurations(Client, Input) ->
     update_event_configurations(Client, Input, []).
 update_event_configurations(Client, Input0, Options0) ->
@@ -6171,7 +6878,34 @@ update_event_configurations(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates the data for a fleet metric.
+%%
+%% Requires permission to access the UpdateFleetMetric action.
+update_fleet_metric(Client, MetricName, Input) ->
+    update_fleet_metric(Client, MetricName, Input, []).
+update_fleet_metric(Client, MetricName, Input0, Options0) ->
+    Method = patch,
+    Path = ["/fleet-metric/", aws_util:encode_uri(MetricName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates the search configuration.
+%%
+%% Requires permission to access the UpdateIndexingConfiguration action.
 update_indexing_configuration(Client, Input) ->
     update_indexing_configuration(Client, Input, []).
 update_indexing_configuration(Client, Input0, Options0) ->
@@ -6195,6 +6929,8 @@ update_indexing_configuration(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates supported fields of the specified job.
+%%
+%% Requires permission to access the UpdateJob action.
 update_job(Client, JobId, Input) ->
     update_job(Client, JobId, Input, []).
 update_job(Client, JobId, Input0, Options0) ->
@@ -6219,6 +6955,8 @@ update_job(Client, JobId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the definition for the specified mitigation action.
+%%
+%% Requires permission to access the UpdateMitigationAction action.
 update_mitigation_action(Client, ActionName, Input) ->
     update_mitigation_action(Client, ActionName, Input, []).
 update_mitigation_action(Client, ActionName, Input0, Options0) ->
@@ -6242,6 +6980,8 @@ update_mitigation_action(Client, ActionName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a fleet provisioning template.
+%%
+%% Requires permission to access the UpdateProvisioningTemplate action.
 update_provisioning_template(Client, TemplateName, Input) ->
     update_provisioning_template(Client, TemplateName, Input, []).
 update_provisioning_template(Client, TemplateName, Input0, Options0) ->
@@ -6265,6 +7005,8 @@ update_provisioning_template(Client, TemplateName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a role alias.
+%%
+%% Requires permission to access the UpdateRoleAlias action.
 update_role_alias(Client, RoleAlias, Input) ->
     update_role_alias(Client, RoleAlias, Input, []).
 update_role_alias(Client, RoleAlias, Input0, Options0) ->
@@ -6289,6 +7031,8 @@ update_role_alias(Client, RoleAlias, Input0, Options0) ->
 
 %% @doc Updates a scheduled audit, including which checks are performed and
 %% how often the audit takes place.
+%%
+%% Requires permission to access the UpdateScheduledAudit action.
 update_scheduled_audit(Client, ScheduledAuditName, Input) ->
     update_scheduled_audit(Client, ScheduledAuditName, Input, []).
 update_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
@@ -6312,6 +7056,8 @@ update_scheduled_audit(Client, ScheduledAuditName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates a Device Defender security profile.
+%%
+%% Requires permission to access the UpdateSecurityProfile action.
 update_security_profile(Client, SecurityProfileName, Input) ->
     update_security_profile(Client, SecurityProfileName, Input, []).
 update_security_profile(Client, SecurityProfileName, Input0, Options0) ->
@@ -6338,6 +7084,8 @@ update_security_profile(Client, SecurityProfileName, Input0, Options0) ->
 %% @doc Updates an existing stream.
 %%
 %% The stream version will be incremented by one.
+%%
+%% Requires permission to access the UpdateStream action.
 update_stream(Client, StreamId, Input) ->
     update_stream(Client, StreamId, Input, []).
 update_stream(Client, StreamId, Input0, Options0) ->
@@ -6361,6 +7109,8 @@ update_stream(Client, StreamId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the data for a thing.
+%%
+%% Requires permission to access the UpdateThing action.
 update_thing(Client, ThingName, Input) ->
     update_thing(Client, ThingName, Input, []).
 update_thing(Client, ThingName, Input0, Options0) ->
@@ -6384,6 +7134,8 @@ update_thing(Client, ThingName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Update a thing group.
+%%
+%% Requires permission to access the UpdateThingGroup action.
 update_thing_group(Client, ThingGroupName, Input) ->
     update_thing_group(Client, ThingGroupName, Input, []).
 update_thing_group(Client, ThingGroupName, Input0, Options0) ->
@@ -6407,6 +7159,8 @@ update_thing_group(Client, ThingGroupName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the groups to which the thing belongs.
+%%
+%% Requires permission to access the UpdateThingGroupsForThing action.
 update_thing_groups_for_thing(Client, Input) ->
     update_thing_groups_for_thing(Client, Input, []).
 update_thing_groups_for_thing(Client, Input0, Options0) ->
@@ -6433,6 +7187,8 @@ update_thing_groups_for_thing(Client, Input0, Options0) ->
 %%
 %% You use this to change the status, endpoint URL, or confirmation URL of
 %% the destination.
+%%
+%% Requires permission to access the UpdateTopicRuleDestination action.
 update_topic_rule_destination(Client, Input) ->
     update_topic_rule_destination(Client, Input, []).
 update_topic_rule_destination(Client, Input0, Options0) ->
@@ -6456,6 +7212,8 @@ update_topic_rule_destination(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Validates a Device Defender security profile behaviors specification.
+%%
+%% Requires permission to access the ValidateSecurityProfileBehaviors action.
 validate_security_profile_behaviors(Client, Input) ->
     validate_security_profile_behaviors(Client, Input, []).
 validate_security_profile_behaviors(Client, Input0, Options0) ->
@@ -6513,6 +7271,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_1click_devices.erl
+++ b/src/aws_iot_1click_devices.erl
@@ -426,6 +426,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_1click_projects.erl
+++ b/src/aws_iot_1click_projects.erl
@@ -486,6 +486,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -1,34 +1,40 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS IoT
+%% @doc IoT data
 %%
-%% AWS IoT-Data enables secure, bi-directional communication between
+%% IoT data enables secure, bi-directional communication between
 %% Internet-connected things (such as sensors, actuators, embedded devices,
-%% or smart appliances) and the AWS cloud.
+%% or smart appliances) and the Amazon Web Services cloud.
 %%
 %% It implements a broker for applications and things to publish messages
 %% over HTTP (Publish) and retrieve, update, and delete shadows. A shadow is
-%% a persistent representation of your things and their state in the AWS
-%% cloud.
+%% a persistent representation of your things and their state in the Amazon
+%% Web Services cloud.
 %%
-%% Find the endpoint address for actions in the AWS IoT data plane by running
-%% this CLI command:
+%% Find the endpoint address for actions in IoT data by running this CLI
+%% command:
 %%
 %% `aws iot describe-endpoint --endpoint-type iot:Data-ATS'
 %%
-%% The service name used by AWS Signature Version 4 to sign requests is:
-%% iotdevicegateway.
+%% The service name used by Amazon Web ServicesSignature Version 4 to sign
+%% requests is: iotdevicegateway.
 -module(aws_iot_data_plane).
 
 -export([delete_thing_shadow/3,
          delete_thing_shadow/4,
+         get_retained_message/2,
+         get_retained_message/4,
+         get_retained_message/5,
          get_thing_shadow/2,
          get_thing_shadow/4,
          get_thing_shadow/5,
          list_named_shadows_for_thing/2,
          list_named_shadows_for_thing/4,
          list_named_shadows_for_thing/5,
+         list_retained_messages/1,
+         list_retained_messages/3,
+         list_retained_messages/4,
          publish/3,
          publish/4,
          update_thing_shadow/3,
@@ -42,8 +48,9 @@
 
 %% @doc Deletes the shadow for the specified thing.
 %%
-%% For more information, see DeleteThingShadow in the AWS IoT Developer
-%% Guide.
+%% Requires permission to access the DeleteThingShadow action.
+%%
+%% For more information, see DeleteThingShadow in the IoT Developer Guide.
 delete_thing_shadow(Client, ThingName, Input) ->
     delete_thing_shadow(Client, ThingName, Input, []).
 delete_thing_shadow(Client, ThingName, Input0, Options0) ->
@@ -67,9 +74,44 @@ delete_thing_shadow(Client, ThingName, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Gets the details of a single retained message for the specified
+%% topic.
+%%
+%% This action returns the message payload of the retained message, which can
+%% incur messaging costs. To list only the topic names of the retained
+%% messages, call ListRetainedMessages.
+%%
+%% Requires permission to access the GetRetainedMessage action.
+%%
+%% For more information about messaging costs, see IoT Core pricing -
+%% Messaging.
+get_retained_message(Client, Topic)
+  when is_map(Client) ->
+    get_retained_message(Client, Topic, #{}, #{}).
+
+get_retained_message(Client, Topic, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_retained_message(Client, Topic, QueryMap, HeadersMap, []).
+
+get_retained_message(Client, Topic, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/retainedMessage/", aws_util:encode_uri(Topic), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets the shadow for the specified thing.
 %%
-%% For more information, see GetThingShadow in the AWS IoT Developer Guide.
+%% Requires permission to access the GetThingShadow action.
+%%
+%% For more information, see GetThingShadow in the IoT Developer Guide.
 get_thing_shadow(Client, ThingName)
   when is_map(Client) ->
     get_thing_shadow(Client, ThingName, #{}, #{}).
@@ -97,6 +139,8 @@ get_thing_shadow(Client, ThingName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the shadows for the specified thing.
+%%
+%% Requires permission to access the ListNamedShadowsForThing action.
 list_named_shadows_for_thing(Client, ThingName)
   when is_map(Client) ->
     list_named_shadows_for_thing(Client, ThingName, #{}, #{}).
@@ -124,9 +168,56 @@ list_named_shadows_for_thing(Client, ThingName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Publishes state information.
+%% @doc Lists summary information about the retained messages stored for the
+%% account.
 %%
-%% For more information, see HTTP Protocol in the AWS IoT Developer Guide.
+%% This action returns only the topic names of the retained messages. It
+%% doesn't return any message payloads. Although this action doesn't return a
+%% message payload, it can still incur messaging costs.
+%%
+%% To get the message payload of a retained message, call GetRetainedMessage
+%% with the topic name of the retained message.
+%%
+%% Requires permission to access the ListRetainedMessages action.
+%%
+%% For more information about messaging costs, see IoT Core pricing -
+%% Messaging.
+list_retained_messages(Client)
+  when is_map(Client) ->
+    list_retained_messages(Client, #{}, #{}).
+
+list_retained_messages(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_retained_messages(Client, QueryMap, HeadersMap, []).
+
+list_retained_messages(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/retainedMessage"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Publishes an MQTT message.
+%%
+%% Requires permission to access the Publish action.
+%%
+%% For more information about MQTT messages, see MQTT Protocol in the IoT
+%% Developer Guide.
+%%
+%% For more information about messaging costs, see IoT Core pricing -
+%% Messaging.
 publish(Client, Topic, Input) ->
     publish(Client, Topic, Input, []).
 publish(Client, Topic, Input0, Options0) ->
@@ -145,15 +236,17 @@ publish(Client, Topic, Input0, Options0) ->
     Input2 = Input1,
 
     QueryMapping = [
-                     {<<"qos">>, <<"qos">>}
+                     {<<"qos">>, <<"qos">>},
+                     {<<"retain">>, <<"retain">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the shadow for the specified thing.
 %%
-%% For more information, see UpdateThingShadow in the AWS IoT Developer
-%% Guide.
+%% Requires permission to access the UpdateThingShadow action.
+%%
+%% For more information, see UpdateThingShadow in the IoT Developer Guide.
 update_thing_shadow(Client, ThingName, Input) ->
     update_thing_shadow(Client, ThingName, Input, []).
 update_thing_shadow(Client, ThingName, Input0, Options0) ->
@@ -212,6 +305,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -4,17 +4,36 @@
 %% @doc AWS IoT Events monitors your equipment or device fleets for failures
 %% or changes in operation, and triggers actions when such events occur.
 %%
-%% AWS IoT Events Data API commands enable you to send inputs to detectors,
+%% You can use AWS IoT Events Data API commands to send inputs to detectors,
 %% list detectors, and view or update a detector's status.
+%%
+%% For more information, see What is AWS IoT Events? in the AWS IoT Events
+%% Developer Guide.
 -module(aws_iot_events_data).
 
--export([batch_put_message/2,
+-export([batch_acknowledge_alarm/2,
+         batch_acknowledge_alarm/3,
+         batch_disable_alarm/2,
+         batch_disable_alarm/3,
+         batch_enable_alarm/2,
+         batch_enable_alarm/3,
+         batch_put_message/2,
          batch_put_message/3,
+         batch_reset_alarm/2,
+         batch_reset_alarm/3,
+         batch_snooze_alarm/2,
+         batch_snooze_alarm/3,
          batch_update_detector/2,
          batch_update_detector/3,
+         describe_alarm/2,
+         describe_alarm/4,
+         describe_alarm/5,
          describe_detector/2,
          describe_detector/4,
          describe_detector/5,
+         list_alarms/2,
+         list_alarms/4,
+         list_alarms/5,
          list_detectors/2,
          list_detectors/4,
          list_detectors/5]).
@@ -24,6 +43,81 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Acknowledges one or more alarms.
+%%
+%% The alarms change to the `ACKNOWLEDGED' state after you acknowledge them.
+batch_acknowledge_alarm(Client, Input) ->
+    batch_acknowledge_alarm(Client, Input, []).
+batch_acknowledge_alarm(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/alarms/acknowledge"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Disables one or more alarms.
+%%
+%% The alarms change to the `DISABLED' state after you disable them.
+batch_disable_alarm(Client, Input) ->
+    batch_disable_alarm(Client, Input, []).
+batch_disable_alarm(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/alarms/disable"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Enables one or more alarms.
+%%
+%% The alarms change to the `NORMAL' state after you enable them.
+batch_enable_alarm(Client, Input) ->
+    batch_enable_alarm(Client, Input, []).
+batch_enable_alarm(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/alarms/enable"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Sends a set of messages to the AWS IoT Events system.
 %%
@@ -38,6 +132,57 @@ batch_put_message(Client, Input0, Options0) ->
     Method = post,
     Path = ["/inputs/messages"],
     SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Resets one or more alarms.
+%%
+%% The alarms return to the `NORMAL' state after you reset them.
+batch_reset_alarm(Client, Input) ->
+    batch_reset_alarm(Client, Input, []).
+batch_reset_alarm(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/alarms/reset"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Changes one or more alarms to the snooze mode.
+%%
+%% The alarms change to the `SNOOZE_DISABLED' state after you set them to the
+%% snooze mode.
+batch_snooze_alarm(Client, Input) ->
+    batch_snooze_alarm(Client, Input, []).
+batch_snooze_alarm(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/alarms/snooze"],
+    SuccessStatusCode = 202,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -78,6 +223,33 @@ batch_update_detector(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Retrieves information about an alarm.
+describe_alarm(Client, AlarmModelName)
+  when is_map(Client) ->
+    describe_alarm(Client, AlarmModelName, #{}, #{}).
+
+describe_alarm(Client, AlarmModelName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_alarm(Client, AlarmModelName, QueryMap, HeadersMap, []).
+
+describe_alarm(Client, AlarmModelName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/alarms/", aws_util:encode_uri(AlarmModelName), "/keyValues/"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"keyValue">>, maps:get(<<"keyValue">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns information about the specified detector (instance).
 describe_detector(Client, DetectorModelName)
   when is_map(Client) ->
@@ -100,6 +272,36 @@ describe_detector(Client, DetectorModelName, QueryMap, HeadersMap, Options0)
     Query0_ =
       [
         {<<"keyValue">>, maps:get(<<"keyValue">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists one or more alarms.
+%%
+%% The operation returns only the metadata associated with each alarm.
+list_alarms(Client, AlarmModelName)
+  when is_map(Client) ->
+    list_alarms(Client, AlarmModelName, #{}, #{}).
+
+list_alarms(Client, AlarmModelName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_alarms(Client, AlarmModelName, QueryMap, HeadersMap, []).
+
+list_alarms(Client, AlarmModelName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/alarms/", aws_util:encode_uri(AlarmModelName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -169,6 +371,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -172,6 +172,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iot_wireless.erl
+++ b/src/aws_iot_wireless.erl
@@ -6,16 +6,28 @@
 
 -export([associate_aws_account_with_partner_account/2,
          associate_aws_account_with_partner_account/3,
+         associate_multicast_group_with_fuota_task/3,
+         associate_multicast_group_with_fuota_task/4,
+         associate_wireless_device_with_fuota_task/3,
+         associate_wireless_device_with_fuota_task/4,
+         associate_wireless_device_with_multicast_group/3,
+         associate_wireless_device_with_multicast_group/4,
          associate_wireless_device_with_thing/3,
          associate_wireless_device_with_thing/4,
          associate_wireless_gateway_with_certificate/3,
          associate_wireless_gateway_with_certificate/4,
          associate_wireless_gateway_with_thing/3,
          associate_wireless_gateway_with_thing/4,
+         cancel_multicast_group_session/3,
+         cancel_multicast_group_session/4,
          create_destination/2,
          create_destination/3,
          create_device_profile/2,
          create_device_profile/3,
+         create_fuota_task/2,
+         create_fuota_task/3,
+         create_multicast_group/2,
+         create_multicast_group/3,
          create_service_profile/2,
          create_service_profile/3,
          create_wireless_device/2,
@@ -30,6 +42,10 @@
          delete_destination/4,
          delete_device_profile/3,
          delete_device_profile/4,
+         delete_fuota_task/3,
+         delete_fuota_task/4,
+         delete_multicast_group/3,
+         delete_multicast_group/4,
          delete_service_profile/3,
          delete_service_profile/4,
          delete_wireless_device/3,
@@ -42,6 +58,12 @@
          delete_wireless_gateway_task_definition/4,
          disassociate_aws_account_from_partner_account/3,
          disassociate_aws_account_from_partner_account/4,
+         disassociate_multicast_group_from_fuota_task/4,
+         disassociate_multicast_group_from_fuota_task/5,
+         disassociate_wireless_device_from_fuota_task/4,
+         disassociate_wireless_device_from_fuota_task/5,
+         disassociate_wireless_device_from_multicast_group/4,
+         disassociate_wireless_device_from_multicast_group/5,
          disassociate_wireless_device_from_thing/3,
          disassociate_wireless_device_from_thing/4,
          disassociate_wireless_gateway_from_certificate/3,
@@ -54,9 +76,27 @@
          get_device_profile/2,
          get_device_profile/4,
          get_device_profile/5,
+         get_fuota_task/2,
+         get_fuota_task/4,
+         get_fuota_task/5,
+         get_log_levels_by_resource_types/1,
+         get_log_levels_by_resource_types/3,
+         get_log_levels_by_resource_types/4,
+         get_multicast_group/2,
+         get_multicast_group/4,
+         get_multicast_group/5,
+         get_multicast_group_session/2,
+         get_multicast_group_session/4,
+         get_multicast_group_session/5,
          get_partner_account/3,
          get_partner_account/5,
          get_partner_account/6,
+         get_resource_event_configuration/3,
+         get_resource_event_configuration/5,
+         get_resource_event_configuration/6,
+         get_resource_log_level/3,
+         get_resource_log_level/5,
+         get_resource_log_level/6,
          get_service_endpoint/1,
          get_service_endpoint/3,
          get_service_endpoint/4,
@@ -93,6 +133,15 @@
          list_device_profiles/1,
          list_device_profiles/3,
          list_device_profiles/4,
+         list_fuota_tasks/1,
+         list_fuota_tasks/3,
+         list_fuota_tasks/4,
+         list_multicast_groups/1,
+         list_multicast_groups/3,
+         list_multicast_groups/4,
+         list_multicast_groups_by_fuota_task/2,
+         list_multicast_groups_by_fuota_task/4,
+         list_multicast_groups_by_fuota_task/5,
          list_partner_accounts/1,
          list_partner_accounts/3,
          list_partner_accounts/4,
@@ -111,8 +160,24 @@
          list_wireless_gateways/1,
          list_wireless_gateways/3,
          list_wireless_gateways/4,
+         put_resource_log_level/3,
+         put_resource_log_level/4,
+         reset_all_resource_log_levels/2,
+         reset_all_resource_log_levels/3,
+         reset_resource_log_level/3,
+         reset_resource_log_level/4,
+         send_data_to_multicast_group/3,
+         send_data_to_multicast_group/4,
          send_data_to_wireless_device/3,
          send_data_to_wireless_device/4,
+         start_bulk_associate_wireless_device_with_multicast_group/3,
+         start_bulk_associate_wireless_device_with_multicast_group/4,
+         start_bulk_disassociate_wireless_device_from_multicast_group/3,
+         start_bulk_disassociate_wireless_device_from_multicast_group/4,
+         start_fuota_task/3,
+         start_fuota_task/4,
+         start_multicast_group_session/3,
+         start_multicast_group_session/4,
          tag_resource/2,
          tag_resource/3,
          test_wireless_device/3,
@@ -121,8 +186,16 @@
          untag_resource/3,
          update_destination/3,
          update_destination/4,
+         update_fuota_task/3,
+         update_fuota_task/4,
+         update_log_levels_by_resource_types/2,
+         update_log_levels_by_resource_types/3,
+         update_multicast_group/3,
+         update_multicast_group/4,
          update_partner_account/3,
          update_partner_account/4,
+         update_resource_event_configuration/3,
+         update_resource_event_configuration/4,
          update_wireless_device/3,
          update_wireless_device/4,
          update_wireless_gateway/3,
@@ -141,6 +214,75 @@ associate_aws_account_with_partner_account(Client, Input0, Options0) ->
     Method = post,
     Path = ["/partner-accounts"],
     SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Associate a multicast group with a FUOTA task.
+associate_multicast_group_with_fuota_task(Client, Id, Input) ->
+    associate_multicast_group_with_fuota_task(Client, Id, Input, []).
+associate_multicast_group_with_fuota_task(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), "/multicast-group"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Associate a wireless device with a FUOTA task.
+associate_wireless_device_with_fuota_task(Client, Id, Input) ->
+    associate_wireless_device_with_fuota_task(Client, Id, Input, []).
+associate_wireless_device_with_fuota_task(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), "/wireless-device"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Associates a wireless device with a multicast group.
+associate_wireless_device_with_multicast_group(Client, Id, Input) ->
+    associate_wireless_device_with_multicast_group(Client, Id, Input, []).
+associate_wireless_device_with_multicast_group(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/wireless-device"],
+    SuccessStatusCode = 204,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -226,6 +368,29 @@ associate_wireless_gateway_with_thing(Client, Id, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Cancels an existing multicast group session.
+cancel_multicast_group_session(Client, Id, Input) ->
+    cancel_multicast_group_session(Client, Id, Input, []).
+cancel_multicast_group_session(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/session"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a new destination that maps a device message to an AWS IoT
 %% rule.
 create_destination(Client, Input) ->
@@ -256,6 +421,52 @@ create_device_profile(Client, Input) ->
 create_device_profile(Client, Input0, Options0) ->
     Method = post,
     Path = ["/device-profiles"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a FUOTA task.
+create_fuota_task(Client, Input) ->
+    create_fuota_task(Client, Input, []).
+create_fuota_task(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/fuota-tasks"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a multicast group.
+create_multicast_group(Client, Input) ->
+    create_multicast_group(Client, Input, []).
+create_multicast_group(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/multicast-groups"],
     SuccessStatusCode = 201,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -434,6 +645,52 @@ delete_device_profile(Client, Id, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes a FUOTA task.
+delete_fuota_task(Client, Id, Input) ->
+    delete_fuota_task(Client, Id, Input, []).
+delete_fuota_task(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a multicast group if it is not in use by a fuota task.
+delete_multicast_group(Client, Id, Input) ->
+    delete_multicast_group(Client, Id, Input, []).
+delete_multicast_group(Client, Id, Input0, Options0) ->
+    Method = delete,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes a service profile.
 delete_service_profile(Client, Id, Input) ->
     delete_service_profile(Client, Id, Input, []).
@@ -579,6 +836,75 @@ disassociate_aws_account_from_partner_account(Client, PartnerAccountId, Input0, 
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Disassociates a multicast group from a fuota task.
+disassociate_multicast_group_from_fuota_task(Client, Id, MulticastGroupId, Input) ->
+    disassociate_multicast_group_from_fuota_task(Client, Id, MulticastGroupId, Input, []).
+disassociate_multicast_group_from_fuota_task(Client, Id, MulticastGroupId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), "/multicast-groups/", aws_util:encode_uri(MulticastGroupId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Disassociates a wireless device from a FUOTA task.
+disassociate_wireless_device_from_fuota_task(Client, Id, WirelessDeviceId, Input) ->
+    disassociate_wireless_device_from_fuota_task(Client, Id, WirelessDeviceId, Input, []).
+disassociate_wireless_device_from_fuota_task(Client, Id, WirelessDeviceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), "/wireless-devices/", aws_util:encode_uri(WirelessDeviceId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Disassociates a wireless device from a multicast group.
+disassociate_wireless_device_from_multicast_group(Client, Id, WirelessDeviceId, Input) ->
+    disassociate_wireless_device_from_multicast_group(Client, Id, WirelessDeviceId, Input, []).
+disassociate_wireless_device_from_multicast_group(Client, Id, WirelessDeviceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/wireless-devices/", aws_util:encode_uri(WirelessDeviceId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Disassociates a wireless device from its currently associated thing.
 disassociate_wireless_device_from_thing(Client, Id, Input) ->
     disassociate_wireless_device_from_thing(Client, Id, Input, []).
@@ -695,6 +1021,101 @@ get_device_profile(Client, Id, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets information about a FUOTA task.
+get_fuota_task(Client, Id)
+  when is_map(Client) ->
+    get_fuota_task(Client, Id, #{}, #{}).
+
+get_fuota_task(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_fuota_task(Client, Id, QueryMap, HeadersMap, []).
+
+get_fuota_task(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns current default log levels or log levels by resource types.
+%%
+%% Based on resource types, log levels can be for wireless device log options
+%% or wireless gateway log options.
+get_log_levels_by_resource_types(Client)
+  when is_map(Client) ->
+    get_log_levels_by_resource_types(Client, #{}, #{}).
+
+get_log_levels_by_resource_types(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_log_levels_by_resource_types(Client, QueryMap, HeadersMap, []).
+
+get_log_levels_by_resource_types(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/log-levels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about a multicast group.
+get_multicast_group(Client, Id)
+  when is_map(Client) ->
+    get_multicast_group(Client, Id, #{}, #{}).
+
+get_multicast_group(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_multicast_group(Client, Id, QueryMap, HeadersMap, []).
+
+get_multicast_group(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about a multicast group session.
+get_multicast_group_session(Client, Id)
+  when is_map(Client) ->
+    get_multicast_group_session(Client, Id, #{}, #{}).
+
+get_multicast_group_session(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_multicast_group_session(Client, Id, QueryMap, HeadersMap, []).
+
+get_multicast_group_session(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/session"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets information about a partner account.
 %%
 %% If `PartnerAccountId' and `PartnerType' are `null', returns all partner
@@ -720,6 +1141,64 @@ get_partner_account(Client, PartnerAccountId, PartnerType, QueryMap, HeadersMap,
     Query0_ =
       [
         {<<"partnerType">>, PartnerType}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get the event configuration for a particular resource identifier.
+get_resource_event_configuration(Client, Identifier, IdentifierType)
+  when is_map(Client) ->
+    get_resource_event_configuration(Client, Identifier, IdentifierType, #{}, #{}).
+
+get_resource_event_configuration(Client, Identifier, IdentifierType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_resource_event_configuration(Client, Identifier, IdentifierType, QueryMap, HeadersMap, []).
+
+get_resource_event_configuration(Client, Identifier, IdentifierType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/event-configurations/", aws_util:encode_uri(Identifier), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"identifierType">>, IdentifierType},
+        {<<"partnerType">>, maps:get(<<"partnerType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Fetches the log-level override, if any, for a given resource-ID and
+%% resource-type.
+%%
+%% It can be used for a wireless device or a wireless gateway.
+get_resource_log_level(Client, ResourceIdentifier, ResourceType)
+  when is_map(Client) ->
+    get_resource_log_level(Client, ResourceIdentifier, ResourceType, #{}, #{}).
+
+get_resource_log_level(Client, ResourceIdentifier, ResourceType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_resource_log_level(Client, ResourceIdentifier, ResourceType, QueryMap, HeadersMap, []).
+
+get_resource_log_level(Client, ResourceIdentifier, ResourceType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/log-levels/", aws_util:encode_uri(ResourceIdentifier), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"resourceType">>, ResourceType}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -1026,6 +1505,90 @@ list_device_profiles(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Lists the FUOTA tasks registered to your AWS account.
+list_fuota_tasks(Client)
+  when is_map(Client) ->
+    list_fuota_tasks(Client, #{}, #{}).
+
+list_fuota_tasks(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_fuota_tasks(Client, QueryMap, HeadersMap, []).
+
+list_fuota_tasks(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/fuota-tasks"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the multicast groups registered to your AWS account.
+list_multicast_groups(Client)
+  when is_map(Client) ->
+    list_multicast_groups(Client, #{}, #{}).
+
+list_multicast_groups(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_multicast_groups(Client, QueryMap, HeadersMap, []).
+
+list_multicast_groups(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/multicast-groups"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all multicast groups associated with a fuota task.
+list_multicast_groups_by_fuota_task(Client, Id)
+  when is_map(Client) ->
+    list_multicast_groups_by_fuota_task(Client, Id, #{}, #{}).
+
+list_multicast_groups_by_fuota_task(Client, Id, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_multicast_groups_by_fuota_task(Client, Id, QueryMap, HeadersMap, []).
+
+list_multicast_groups_by_fuota_task(Client, Id, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), "/multicast-groups"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Lists the partner accounts associated with your AWS account.
 list_partner_accounts(Client)
   when is_map(Client) ->
@@ -1132,7 +1695,9 @@ list_wireless_devices(Client, QueryMap, HeadersMap, Options0)
       [
         {<<"destinationName">>, maps:get(<<"destinationName">>, QueryMap, undefined)},
         {<<"deviceProfileId">>, maps:get(<<"deviceProfileId">>, QueryMap, undefined)},
+        {<<"fuotaTaskId">>, maps:get(<<"fuotaTaskId">>, QueryMap, undefined)},
         {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"multicastGroupId">>, maps:get(<<"multicastGroupId">>, QueryMap, undefined)},
         {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
         {<<"serviceProfileId">>, maps:get(<<"serviceProfileId">>, QueryMap, undefined)},
         {<<"wirelessDeviceType">>, maps:get(<<"wirelessDeviceType">>, QueryMap, undefined)}
@@ -1199,6 +1764,107 @@ list_wireless_gateways(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Sets the log-level override for a resource-ID and resource-type.
+%%
+%% This option can be specified for a wireless gateway or a wireless device.
+%% A limit of 200 log level override can be set per account.
+put_resource_log_level(Client, ResourceIdentifier, Input) ->
+    put_resource_log_level(Client, ResourceIdentifier, Input, []).
+put_resource_log_level(Client, ResourceIdentifier, Input0, Options0) ->
+    Method = put,
+    Path = ["/log-levels/", aws_util:encode_uri(ResourceIdentifier), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"resourceType">>, <<"ResourceType">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the log-level overrides for all resources; both wireless
+%% devices and wireless gateways.
+reset_all_resource_log_levels(Client, Input) ->
+    reset_all_resource_log_levels(Client, Input, []).
+reset_all_resource_log_levels(Client, Input0, Options0) ->
+    Method = delete,
+    Path = ["/log-levels"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the log-level override, if any, for a specific resource-ID
+%% and resource-type.
+%%
+%% It can be used for a wireless device or a wireless gateway.
+reset_resource_log_level(Client, ResourceIdentifier, Input) ->
+    reset_resource_log_level(Client, ResourceIdentifier, Input, []).
+reset_resource_log_level(Client, ResourceIdentifier, Input0, Options0) ->
+    Method = delete,
+    Path = ["/log-levels/", aws_util:encode_uri(ResourceIdentifier), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"resourceType">>, <<"ResourceType">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Sends the specified data to a multicast group.
+send_data_to_multicast_group(Client, Id, Input) ->
+    send_data_to_multicast_group(Client, Id, Input, []).
+send_data_to_multicast_group(Client, Id, Input0, Options0) ->
+    Method = post,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/data"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Sends a decrypted application data frame to a device.
 send_data_to_wireless_device(Client, Id, Input) ->
     send_data_to_wireless_device(Client, Id, Input, []).
@@ -1206,6 +1872,100 @@ send_data_to_wireless_device(Client, Id, Input0, Options0) ->
     Method = post,
     Path = ["/wireless-devices/", aws_util:encode_uri(Id), "/data"],
     SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a bulk association of all qualifying wireless devices with a
+%% multicast group.
+start_bulk_associate_wireless_device_with_multicast_group(Client, Id, Input) ->
+    start_bulk_associate_wireless_device_with_multicast_group(Client, Id, Input, []).
+start_bulk_associate_wireless_device_with_multicast_group(Client, Id, Input0, Options0) ->
+    Method = patch,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/bulk"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a bulk disassociatin of all qualifying wireless devices from a
+%% multicast group.
+start_bulk_disassociate_wireless_device_from_multicast_group(Client, Id, Input) ->
+    start_bulk_disassociate_wireless_device_from_multicast_group(Client, Id, Input, []).
+start_bulk_disassociate_wireless_device_from_multicast_group(Client, Id, Input0, Options0) ->
+    Method = post,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/bulk"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a FUOTA task.
+start_fuota_task(Client, Id, Input) ->
+    start_fuota_task(Client, Id, Input, []).
+start_fuota_task(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a multicast group session.
+start_multicast_group_session(Client, Id, Input) ->
+    start_multicast_group_session(Client, Id, Input, []).
+start_multicast_group_session(Client, Id, Input0, Options0) ->
+    Method = put,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), "/session"],
+    SuccessStatusCode = 204,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -1318,6 +2078,79 @@ update_destination(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates properties of a FUOTA task.
+update_fuota_task(Client, Id, Input) ->
+    update_fuota_task(Client, Id, Input, []).
+update_fuota_task(Client, Id, Input0, Options0) ->
+    Method = patch,
+    Path = ["/fuota-tasks/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Set default log level, or log levels by resource types.
+%%
+%% This can be for wireless device log options or wireless gateways log
+%% options and is used to control the log messages that'll be displayed in
+%% CloudWatch.
+update_log_levels_by_resource_types(Client, Input) ->
+    update_log_levels_by_resource_types(Client, Input, []).
+update_log_levels_by_resource_types(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/log-levels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates properties of a multicast group session.
+update_multicast_group(Client, Id, Input) ->
+    update_multicast_group(Client, Id, Input, []).
+update_multicast_group(Client, Id, Input0, Options0) ->
+    Method = patch,
+    Path = ["/multicast-groups/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates properties of a partner account.
 update_partner_account(Client, PartnerAccountId, Input) ->
     update_partner_account(Client, PartnerAccountId, Input, []).
@@ -1337,6 +2170,31 @@ update_partner_account(Client, PartnerAccountId, Input0, Options0) ->
     Input2 = Input1,
 
     QueryMapping = [
+                     {<<"partnerType">>, <<"PartnerType">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update the event configuration for a particular resource identifier.
+update_resource_event_configuration(Client, Identifier, Input) ->
+    update_resource_event_configuration(Client, Identifier, Input, []).
+update_resource_event_configuration(Client, Identifier, Input0, Options0) ->
+    Method = patch,
+    Path = ["/event-configurations/", aws_util:encode_uri(Identifier), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"identifierType">>, <<"IdentifierType">>},
                      {<<"partnerType">>, <<"PartnerType">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
@@ -1423,6 +2281,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iotanalytics.erl
+++ b/src/aws_iotanalytics.erl
@@ -1,10 +1,10 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS IoT Analytics allows you to collect large amounts of device data,
+%% @doc IoT Analytics allows you to collect large amounts of device data,
 %% process messages, and store them.
 %%
-%% You can then query the data and run sophisticated analytics on it. AWS IoT
+%% You can then query the data and run sophisticated analytics on it. IoT
 %% Analytics enables advanced data exploration through integration with
 %% Jupyter Notebooks and data visualization through integration with Amazon
 %% QuickSight.
@@ -17,15 +17,15 @@
 %% IoT data is often only meaningful in the context of other data from
 %% external sources.
 %%
-%% AWS IoT Analytics automates the steps required to analyze data from IoT
-%% devices. AWS IoT Analytics filters, transforms, and enriches IoT data
-%% before storing it in a time-series data store for analysis. You can set up
-%% the service to collect only the data you need from your devices, apply
+%% IoT Analytics automates the steps required to analyze data from IoT
+%% devices. IoT Analytics filters, transforms, and enriches IoT data before
+%% storing it in a time-series data store for analysis. You can set up the
+%% service to collect only the data you need from your devices, apply
 %% mathematical transforms to process the data, and enrich the data with
 %% device-specific metadata such as device type and location before storing
 %% it. Then, you can analyze your data by running queries using the built-in
 %% SQL query engine, or perform more complex analytics and machine learning
-%% inference. AWS IoT Analytics includes pre-built models for common IoT use
+%% inference. IoT Analytics includes pre-built models for common IoT use
 %% cases so you can answer questions like which devices are about to fail or
 %% which customers are at risk of abandoning their wearable devices.
 -module(aws_iotanalytics).
@@ -164,7 +164,7 @@ cancel_pipeline_reprocessing(Client, PipelineName, ReprocessingId, Input0, Optio
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a channel.
+%% @doc Used to create a channel.
 %%
 %% A channel collects data from an MQTT topic and archives the raw,
 %% unprocessed messages before publishing the data to a pipeline.
@@ -190,7 +190,7 @@ create_channel(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a dataset.
+%% @doc Used to create a dataset.
 %%
 %% A dataset stores data retrieved from a data store by applying a
 %% `queryAction' (a SQL query) or a `containerAction' (executing a
@@ -220,7 +220,7 @@ create_dataset(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates the content of a data set by applying a `queryAction' (a SQL
+%% @doc Creates the content of a dataset by applying a `queryAction' (a SQL
 %% query) or a `containerAction' (executing a containerized application).
 create_dataset_content(Client, DatasetName, Input) ->
     create_dataset_content(Client, DatasetName, Input, []).
@@ -491,8 +491,7 @@ describe_datastore(Client, DatastoreName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the current settings of the AWS IoT Analytics logging
-%% options.
+%% @doc Retrieves the current settings of the IoT Analytics logging options.
 describe_logging_options(Client)
   when is_map(Client) ->
     describe_logging_options(Client, #{}, #{}).
@@ -538,7 +537,7 @@ describe_pipeline(Client, PipelineName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the contents of a data set as presigned URIs.
+%% @doc Retrieves the contents of a dataset as presigned URIs.
 get_dataset_content(Client, DatasetName)
   when is_map(Client) ->
     get_dataset_content(Client, DatasetName, #{}, #{}).
@@ -593,7 +592,7 @@ list_channels(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists information about data set contents that have been created.
+%% @doc Lists information about dataset contents that have been created.
 list_dataset_contents(Client, DatasetName)
   when is_map(Client) ->
     list_dataset_contents(Client, DatasetName, #{}, #{}).
@@ -623,7 +622,7 @@ list_dataset_contents(Client, DatasetName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves information about data sets.
+%% @doc Retrieves information about datasets.
 list_datasets(Client)
   when is_map(Client) ->
     list_datasets(Client, #{}, #{}).
@@ -734,7 +733,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Sets or updates the AWS IoT Analytics logging options.
+%% @doc Sets or updates the IoT Analytics logging options.
 %%
 %% If you update the value of any `loggingOptions' field, it takes up to one
 %% minute for the change to take effect. Also, if you change the policy
@@ -893,7 +892,7 @@ untag_resource(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the settings of a channel.
+%% @doc Used to update the settings of a channel.
 update_channel(Client, ChannelName, Input) ->
     update_channel(Client, ChannelName, Input, []).
 update_channel(Client, ChannelName, Input0, Options0) ->
@@ -916,7 +915,7 @@ update_channel(Client, ChannelName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the settings of a data set.
+%% @doc Updates the settings of a dataset.
 update_dataset(Client, DatasetName, Input) ->
     update_dataset(Client, DatasetName, Input, []).
 update_dataset(Client, DatasetName, Input0, Options0) ->
@@ -939,7 +938,7 @@ update_dataset(Client, DatasetName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the settings of a data store.
+%% @doc Used to update the settings of a data store.
 update_datastore(Client, DatastoreName, Input) ->
     update_datastore(Client, DatastoreName, Input, []).
 update_datastore(Client, DatastoreName, Input0, Options0) ->
@@ -1024,6 +1023,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iotdeviceadvisor.erl
+++ b/src/aws_iotdeviceadvisor.erl
@@ -37,11 +37,10 @@
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
-         list_test_cases/1,
-         list_test_cases/3,
-         list_test_cases/4,
          start_suite_run/3,
          start_suite_run/4,
+         stop_suite_run/4,
+         stop_suite_run/5,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
@@ -259,41 +258,35 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the test cases in the test suite.
-list_test_cases(Client)
-  when is_map(Client) ->
-    list_test_cases(Client, #{}, #{}).
-
-list_test_cases(Client, QueryMap, HeadersMap)
-  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
-    list_test_cases(Client, QueryMap, HeadersMap, []).
-
-list_test_cases(Client, QueryMap, HeadersMap, Options0)
-  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
-    Path = ["/testCases"],
-    SuccessStatusCode = undefined,
-    Options = [{send_body_as_binary, false},
-               {receive_body_as_binary, false}
-               | Options0],
-
-    Headers = [],
-
-    Query0_ =
-      [
-        {<<"intendedForQualification">>, maps:get(<<"intendedForQualification">>, QueryMap, undefined)},
-        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
-        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
-      ],
-    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
-
-    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
-
 %% @doc Starts a Device Advisor test suite run.
 start_suite_run(Client, SuiteDefinitionId, Input) ->
     start_suite_run(Client, SuiteDefinitionId, Input, []).
 start_suite_run(Client, SuiteDefinitionId, Input0, Options0) ->
     Method = post,
     Path = ["/suiteDefinitions/", aws_util:encode_uri(SuiteDefinitionId), "/suiteRuns"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Stops a Device Advisor test suite run that is currently running.
+stop_suite_run(Client, SuiteDefinitionId, SuiteRunId, Input) ->
+    stop_suite_run(Client, SuiteDefinitionId, SuiteRunId, Input, []).
+stop_suite_run(Client, SuiteDefinitionId, SuiteRunId, Input0, Options0) ->
+    Method = post,
+    Path = ["/suiteDefinitions/", aws_util:encode_uri(SuiteDefinitionId), "/suiteRuns/", aws_util:encode_uri(SuiteRunId), "/stop"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -416,6 +409,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iotfleethub.erl
+++ b/src/aws_iotfleethub.erl
@@ -289,6 +289,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -1,12 +1,13 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Welcome to the AWS IoT SiteWise API Reference.
+%% @doc Welcome to the IoT SiteWise API Reference.
 %%
-%% AWS IoT SiteWise is an AWS service that connects Industrial Internet of
-%% Things (IIoT) devices to the power of the AWS Cloud. For more information,
-%% see the AWS IoT SiteWise User Guide. For information about AWS IoT
-%% SiteWise quotas, see Quotas in the AWS IoT SiteWise User Guide.
+%% IoT SiteWise is an Amazon Web Services service that connects Industrial
+%% Internet of Things (IIoT) devices to the power of the Amazon Web Services
+%% Cloud. For more information, see the IoT SiteWise User Guide. For
+%% information about IoT SiteWise quotas, see Quotas in the IoT SiteWise User
+%% Guide.
 -module(aws_iotsitewise).
 
 -export([associate_assets/3,
@@ -78,6 +79,9 @@
          describe_project/2,
          describe_project/4,
          describe_project/5,
+         describe_storage_configuration/1,
+         describe_storage_configuration/3,
+         describe_storage_configuration/4,
          disassociate_assets/3,
          disassociate_assets/4,
          get_asset_property_aggregates/5,
@@ -89,6 +93,9 @@
          get_asset_property_value_history/1,
          get_asset_property_value_history/3,
          get_asset_property_value_history/4,
+         get_interpolated_asset_property_values/6,
+         get_interpolated_asset_property_values/8,
+         get_interpolated_asset_property_values/9,
          list_access_policies/1,
          list_access_policies/3,
          list_access_policies/4,
@@ -126,6 +133,8 @@
          put_default_encryption_configuration/3,
          put_logging_options/2,
          put_logging_options/3,
+         put_storage_configuration/2,
+         put_storage_configuration/3,
          tag_resource/2,
          tag_resource/3,
          untag_resource/2,
@@ -158,7 +167,7 @@
 %% @doc Associates a child asset with the given parent asset through a
 %% hierarchy defined in the parent asset's model.
 %%
-%% For more information, see Associating assets in the AWS IoT SiteWise User
+%% For more information, see Associating assets in the IoT SiteWise User
 %% Guide.
 associate_assets(Client, AssetId, Input) ->
     associate_assets(Client, AssetId, Input, []).
@@ -182,7 +191,7 @@ associate_assets(Client, AssetId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Associates a group (batch) of assets with an AWS IoT SiteWise Monitor
+%% @doc Associates a group (batch) of assets with an IoT SiteWise Monitor
 %% project.
 batch_associate_project_assets(Client, ProjectId, Input) ->
     batch_associate_project_assets(Client, ProjectId, Input, []).
@@ -206,8 +215,8 @@ batch_associate_project_assets(Client, ProjectId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Disassociates a group (batch) of assets from an AWS IoT SiteWise
-%% Monitor project.
+%% @doc Disassociates a group (batch) of assets from an IoT SiteWise Monitor
+%% project.
 batch_disassociate_project_assets(Client, ProjectId, Input) ->
     batch_disassociate_project_assets(Client, ProjectId, Input, []).
 batch_disassociate_project_assets(Client, ProjectId, Input0, Options0) ->
@@ -230,10 +239,10 @@ batch_disassociate_project_assets(Client, ProjectId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Sends a list of asset property values to AWS IoT SiteWise.
+%% @doc Sends a list of asset property values to IoT SiteWise.
 %%
 %% Each value is a timestamp-quality-value (TQV) data point. For more
-%% information, see Ingesting data using the API in the AWS IoT SiteWise User
+%% information, see Ingesting data using the API in the IoT SiteWise User
 %% Guide.
 %%
 %% To identify an asset property, you must specify one of the following:
@@ -244,20 +253,20 @@ batch_disassociate_project_assets(Client, ProjectId, Input0, Options0) ->
 %% `/company/windfarm/3/turbine/7/temperature'). To define an asset
 %% property's alias, see UpdateAssetProperty.
 %%
-%% </li> </ul> With respect to Unix epoch time, AWS IoT SiteWise accepts only
+%% </li> </ul> With respect to Unix epoch time, IoT SiteWise accepts only
 %% TQVs that have a timestamp of no more than 7 days in the past and no more
-%% than 5 minutes in the future. AWS IoT SiteWise rejects timestamps outside
-%% of the inclusive range of [-7 days, +5 minutes] and returns a
+%% than 10 minutes in the future. IoT SiteWise rejects timestamps outside of
+%% the inclusive range of [-7 days, +10 minutes] and returns a
 %% `TimestampOutOfRangeException' error.
 %%
-%% For each asset property, AWS IoT SiteWise overwrites TQVs with duplicate
+%% For each asset property, IoT SiteWise overwrites TQVs with duplicate
 %% timestamps unless the newer TQV has a different quality. For example, if
 %% you store a TQV `{T1, GOOD, V1}', then storing `{T1, GOOD, V2}' replaces
 %% the existing TQV.
 %%
-%% AWS IoT SiteWise authorizes access to each `BatchPutAssetPropertyValue'
-%% entry individually. For more information, see BatchPutAssetPropertyValue
-%% authorization in the AWS IoT SiteWise User Guide.
+%% IoT SiteWise authorizes access to each `BatchPutAssetPropertyValue' entry
+%% individually. For more information, see BatchPutAssetPropertyValue
+%% authorization in the IoT SiteWise User Guide.
 batch_put_asset_property_value(Client, Input) ->
     batch_put_asset_property_value(Client, Input, []).
 batch_put_asset_property_value(Client, Input0, Options0) ->
@@ -280,9 +289,9 @@ batch_put_asset_property_value(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an access policy that grants the specified identity (AWS SSO
-%% user, AWS SSO group, or IAM user) access to the specified AWS IoT SiteWise
-%% Monitor portal or project resource.
+%% @doc Creates an access policy that grants the specified identity (Amazon
+%% Web Services SSO user, Amazon Web Services SSO group, or IAM user) access
+%% to the specified IoT SiteWise Monitor portal or project resource.
 create_access_policy(Client, Input) ->
     create_access_policy(Client, Input, []).
 create_access_policy(Client, Input0, Options0) ->
@@ -307,8 +316,7 @@ create_access_policy(Client, Input0, Options0) ->
 
 %% @doc Creates an asset from an existing asset model.
 %%
-%% For more information, see Creating assets in the AWS IoT SiteWise User
-%% Guide.
+%% For more information, see Creating assets in the IoT SiteWise User Guide.
 create_asset(Client, Input) ->
     create_asset(Client, Input, []).
 create_asset(Client, Input0, Options0) ->
@@ -338,7 +346,7 @@ create_asset(Client, Input0, Options0) ->
 %% create assets of the same type that have standardized definitions. Each
 %% asset created from a model inherits the asset model's property and
 %% hierarchy definitions. For more information, see Defining asset models in
-%% the AWS IoT SiteWise User Guide.
+%% the IoT SiteWise User Guide.
 create_asset_model(Client, Input) ->
     create_asset_model(Client, Input, []).
 create_asset_model(Client, Input0, Options0) ->
@@ -361,7 +369,7 @@ create_asset_model(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a dashboard in an AWS IoT SiteWise Monitor project.
+%% @doc Creates a dashboard in an IoT SiteWise Monitor project.
 create_dashboard(Client, Input) ->
     create_dashboard(Client, Input, []).
 create_dashboard(Client, Input0, Options0) ->
@@ -385,9 +393,9 @@ create_dashboard(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a gateway, which is a virtual or edge device that delivers
-%% industrial data streams from local servers to AWS IoT SiteWise.
+%% industrial data streams from local servers to IoT SiteWise.
 %%
-%% For more information, see Ingesting data using a gateway in the AWS IoT
+%% For more information, see Ingesting data using a gateway in the IoT
 %% SiteWise User Guide.
 create_gateway(Client, Input) ->
     create_gateway(Client, Input, []).
@@ -413,12 +421,12 @@ create_gateway(Client, Input0, Options0) ->
 
 %% @doc Creates a portal, which can contain projects and dashboards.
 %%
-%% AWS IoT SiteWise Monitor uses AWS SSO or IAM to authenticate portal users
-%% and manage user permissions.
+%% IoT SiteWise Monitor uses Amazon Web Services SSO or IAM to authenticate
+%% portal users and manage user permissions.
 %%
 %% Before you can sign in to a new portal, you must add at least one identity
 %% to that portal. For more information, see Adding or removing portal
-%% administrators in the AWS IoT SiteWise User Guide.
+%% administrators in the IoT SiteWise User Guide.
 create_portal(Client, Input) ->
     create_portal(Client, Input, []).
 create_portal(Client, Input0, Options0) ->
@@ -465,9 +473,9 @@ create_project(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes an access policy that grants the specified identity access to
-%% the specified AWS IoT SiteWise Monitor resource.
+%% the specified IoT SiteWise Monitor resource.
 %%
-%% You can use this operation to revoke access to an AWS IoT SiteWise Monitor
+%% You can use this operation to revoke access to an IoT SiteWise Monitor
 %% resource.
 delete_access_policy(Client, AccessPolicyId, Input) ->
     delete_access_policy(Client, AccessPolicyId, Input, []).
@@ -495,7 +503,7 @@ delete_access_policy(Client, AccessPolicyId, Input0, Options0) ->
 %% @doc Deletes an asset.
 %%
 %% This action can't be undone. For more information, see Deleting assets and
-%% models in the AWS IoT SiteWise User Guide.
+%% models in the IoT SiteWise User Guide.
 %%
 %% You can't delete an asset that's associated to another asset. For more
 %% information, see DisassociateAssets.
@@ -528,8 +536,8 @@ delete_asset(Client, AssetId, Input0, Options0) ->
 %% asset model before you can delete the model. Also, you can't delete an
 %% asset model if a parent asset model exists that contains a property
 %% formula expression that depends on the asset model that you want to
-%% delete. For more information, see Deleting assets and models in the AWS
-%% IoT SiteWise User Guide.
+%% delete. For more information, see Deleting assets and models in the IoT
+%% SiteWise User Guide.
 delete_asset_model(Client, AssetModelId, Input) ->
     delete_asset_model(Client, AssetModelId, Input, []).
 delete_asset_model(Client, AssetModelId, Input0, Options0) ->
@@ -553,7 +561,7 @@ delete_asset_model(Client, AssetModelId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a dashboard from AWS IoT SiteWise Monitor.
+%% @doc Deletes a dashboard from IoT SiteWise Monitor.
 delete_dashboard(Client, DashboardId, Input) ->
     delete_dashboard(Client, DashboardId, Input, []).
 delete_dashboard(Client, DashboardId, Input0, Options0) ->
@@ -577,7 +585,7 @@ delete_dashboard(Client, DashboardId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a gateway from AWS IoT SiteWise.
+%% @doc Deletes a gateway from IoT SiteWise.
 %%
 %% When you delete a gateway, some of the gateway's files remain in your
 %% gateway's file system.
@@ -603,7 +611,7 @@ delete_gateway(Client, GatewayId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a portal from AWS IoT SiteWise Monitor.
+%% @doc Deletes a portal from IoT SiteWise Monitor.
 delete_portal(Client, PortalId, Input) ->
     delete_portal(Client, PortalId, Input, []).
 delete_portal(Client, PortalId, Input0, Options0) ->
@@ -627,7 +635,7 @@ delete_portal(Client, PortalId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a project from AWS IoT SiteWise Monitor.
+%% @doc Deletes a project from IoT SiteWise Monitor.
 delete_project(Client, ProjectId, Input) ->
     delete_project(Client, ProjectId, Input, []).
 delete_project(Client, ProjectId, Input0, Options0) ->
@@ -652,7 +660,7 @@ delete_project(Client, ProjectId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Describes an access policy, which specifies an identity's access to
-%% an AWS IoT SiteWise Monitor portal or project.
+%% an IoT SiteWise Monitor portal or project.
 describe_access_policy(Client, AccessPolicyId)
   when is_map(Client) ->
     describe_access_policy(Client, AccessPolicyId, #{}, #{}).
@@ -776,10 +784,9 @@ describe_dashboard(Client, DashboardId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves information about the default encryption configuration for
-%% the AWS account in the default or specified region.
+%% the Amazon Web Services account in the default or specified Region.
 %%
-%% For more information, see Key management in the AWS IoT SiteWise User
-%% Guide.
+%% For more information, see Key management in the IoT SiteWise User Guide.
 describe_default_encryption_configuration(Client)
   when is_map(Client) ->
     describe_default_encryption_configuration(Client, #{}, #{}).
@@ -829,8 +836,8 @@ describe_gateway(Client, GatewayId, QueryMap, HeadersMap, Options0)
 %%
 %% Each gateway capability defines data sources for a gateway. A capability
 %% configuration can contain multiple data source configurations. If you
-%% define OPC-UA sources for a gateway in the AWS IoT SiteWise console, all
-%% of your OPC-UA sources are stored in one capability configuration. To list
+%% define OPC-UA sources for a gateway in the IoT SiteWise console, all of
+%% your OPC-UA sources are stored in one capability configuration. To list
 %% all capability configurations for a gateway, use DescribeGateway.
 describe_gateway_capability_configuration(Client, CapabilityNamespace, GatewayId)
   when is_map(Client) ->
@@ -854,7 +861,7 @@ describe_gateway_capability_configuration(Client, CapabilityNamespace, GatewayId
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the current AWS IoT SiteWise logging options.
+%% @doc Retrieves the current IoT SiteWise logging options.
 describe_logging_options(Client)
   when is_map(Client) ->
     describe_logging_options(Client, #{}, #{}).
@@ -923,6 +930,30 @@ describe_project(Client, ProjectId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Retrieves information about the storage configuration for IoT
+%% SiteWise.
+describe_storage_configuration(Client)
+  when is_map(Client) ->
+    describe_storage_configuration(Client, #{}, #{}).
+
+describe_storage_configuration(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_storage_configuration(Client, QueryMap, HeadersMap, []).
+
+describe_storage_configuration(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/configuration/account/storage"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Disassociates a child asset from the given parent asset through a
 %% hierarchy defined in the parent asset's model.
 disassociate_assets(Client, AssetId, Input) ->
@@ -949,7 +980,7 @@ disassociate_assets(Client, AssetId, Input0, Options0) ->
 
 %% @doc Gets aggregated values for an asset property.
 %%
-%% For more information, see Querying aggregates in the AWS IoT SiteWise User
+%% For more information, see Querying aggregates in the IoT SiteWise User
 %% Guide.
 %%
 %% To identify an asset property, you must specify one of the following:
@@ -999,8 +1030,8 @@ get_asset_property_aggregates(Client, AggregateTypes, EndDate, Resolution, Start
 
 %% @doc Gets an asset property's current value.
 %%
-%% For more information, see Querying current values in the AWS IoT SiteWise
-%% User Guide.
+%% For more information, see Querying current values in the IoT SiteWise User
+%% Guide.
 %%
 %% To identify an asset property, you must specify one of the following:
 %%
@@ -1041,8 +1072,8 @@ get_asset_property_value(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Gets the history of an asset property's values.
 %%
-%% For more information, see Querying historical values in the AWS IoT
-%% SiteWise User Guide.
+%% For more information, see Querying historical values in the IoT SiteWise
+%% User Guide.
 %%
 %% To identify an asset property, you must specify one of the following:
 %%
@@ -1087,9 +1118,66 @@ get_asset_property_value_history(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of access policies for an identity (an AWS
-%% SSO user, an AWS SSO group, or an IAM user) or an AWS IoT SiteWise Monitor
-%% resource (a portal or project).
+%% @doc Get interpolated values for an asset property for a specified time
+%% interval, during a period of time.
+%%
+%% If your time series is missing data points during the specified time
+%% interval, you can use interpolation to estimate the missing data.
+%%
+%% For example, you can use this operation to return the interpolated
+%% temperature values for a wind turbine every 24 hours over a duration of 7
+%% days.
+%%
+%% To identify an asset property, you must specify one of the following:
+%%
+%% <ul> <li> The `assetId' and `propertyId' of an asset property.
+%%
+%% </li> <li> A `propertyAlias', which is a data stream alias (for example,
+%% `/company/windfarm/3/turbine/7/temperature'). To define an asset
+%% property's alias, see UpdateAssetProperty.
+%%
+%% </li> </ul>
+get_interpolated_asset_property_values(Client, EndTimeInSeconds, IntervalInSeconds, Quality, StartTimeInSeconds, Type)
+  when is_map(Client) ->
+    get_interpolated_asset_property_values(Client, EndTimeInSeconds, IntervalInSeconds, Quality, StartTimeInSeconds, Type, #{}, #{}).
+
+get_interpolated_asset_property_values(Client, EndTimeInSeconds, IntervalInSeconds, Quality, StartTimeInSeconds, Type, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_interpolated_asset_property_values(Client, EndTimeInSeconds, IntervalInSeconds, Quality, StartTimeInSeconds, Type, QueryMap, HeadersMap, []).
+
+get_interpolated_asset_property_values(Client, EndTimeInSeconds, IntervalInSeconds, Quality, StartTimeInSeconds, Type, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/properties/interpolated"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"assetId">>, maps:get(<<"assetId">>, QueryMap, undefined)},
+        {<<"endTimeInSeconds">>, EndTimeInSeconds},
+        {<<"endTimeOffsetInNanos">>, maps:get(<<"endTimeOffsetInNanos">>, QueryMap, undefined)},
+        {<<"intervalInSeconds">>, IntervalInSeconds},
+        {<<"intervalWindowInSeconds">>, maps:get(<<"intervalWindowInSeconds">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"propertyAlias">>, maps:get(<<"propertyAlias">>, QueryMap, undefined)},
+        {<<"propertyId">>, maps:get(<<"propertyId">>, QueryMap, undefined)},
+        {<<"quality">>, Quality},
+        {<<"startTimeInSeconds">>, StartTimeInSeconds},
+        {<<"startTimeOffsetInNanos">>, maps:get(<<"startTimeOffsetInNanos">>, QueryMap, undefined)},
+        {<<"type">>, Type}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves a paginated list of access policies for an identity (an
+%% Amazon Web Services SSO user, an Amazon Web Services SSO group, or an IAM
+%% user) or an IoT SiteWise Monitor resource (a portal or project).
 list_access_policies(Client)
   when is_map(Client) ->
     list_access_policies(Client, #{}, #{}).
@@ -1262,8 +1350,8 @@ list_associated_assets(Client, AssetId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of dashboards for an AWS IoT SiteWise
-%% Monitor project.
+%% @doc Retrieves a paginated list of dashboards for an IoT SiteWise Monitor
+%% project.
 list_dashboards(Client, ProjectId)
   when is_map(Client) ->
     list_dashboards(Client, ProjectId, #{}, #{}).
@@ -1320,7 +1408,7 @@ list_gateways(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of AWS IoT SiteWise Monitor portals.
+%% @doc Retrieves a paginated list of IoT SiteWise Monitor portals.
 list_portals(Client)
   when is_map(Client) ->
     list_portals(Client, #{}, #{}).
@@ -1348,8 +1436,8 @@ list_portals(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of assets associated with an AWS IoT
-%% SiteWise Monitor project.
+%% @doc Retrieves a paginated list of assets associated with an IoT SiteWise
+%% Monitor project.
 list_project_assets(Client, ProjectId)
   when is_map(Client) ->
     list_project_assets(Client, ProjectId, #{}, #{}).
@@ -1377,8 +1465,8 @@ list_project_assets(Client, ProjectId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves a paginated list of projects for an AWS IoT SiteWise
-%% Monitor portal.
+%% @doc Retrieves a paginated list of projects for an IoT SiteWise Monitor
+%% portal.
 list_projects(Client, PortalId)
   when is_map(Client) ->
     list_projects(Client, PortalId, #{}, #{}).
@@ -1407,7 +1495,7 @@ list_projects(Client, PortalId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the list of tags for an AWS IoT SiteWise resource.
+%% @doc Retrieves the list of tags for an IoT SiteWise resource.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -1434,10 +1522,10 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Sets the default encryption configuration for the AWS account.
+%% @doc Sets the default encryption configuration for the Amazon Web Services
+%% account.
 %%
-%% For more information, see Key management in the AWS IoT SiteWise User
-%% Guide.
+%% For more information, see Key management in the IoT SiteWise User Guide.
 put_default_encryption_configuration(Client, Input) ->
     put_default_encryption_configuration(Client, Input, []).
 put_default_encryption_configuration(Client, Input0, Options0) ->
@@ -1460,7 +1548,7 @@ put_default_encryption_configuration(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Sets logging options for AWS IoT SiteWise.
+%% @doc Sets logging options for IoT SiteWise.
 put_logging_options(Client, Input) ->
     put_logging_options(Client, Input, []).
 put_logging_options(Client, Input0, Options0) ->
@@ -1483,7 +1571,30 @@ put_logging_options(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Adds tags to an AWS IoT SiteWise resource.
+%% @doc Configures storage settings for IoT SiteWise.
+put_storage_configuration(Client, Input) ->
+    put_storage_configuration(Client, Input, []).
+put_storage_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/configuration/account/storage"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds tags to an IoT SiteWise resource.
 %%
 %% If a tag already exists for the resource, this operation updates the tag's
 %% value.
@@ -1510,7 +1621,7 @@ tag_resource(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes a tag from an AWS IoT SiteWise resource.
+%% @doc Removes a tag from an IoT SiteWise resource.
 untag_resource(Client, Input) ->
     untag_resource(Client, Input, []).
 untag_resource(Client, Input0, Options0) ->
@@ -1536,7 +1647,7 @@ untag_resource(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates an existing access policy that specifies an identity's access
-%% to an AWS IoT SiteWise Monitor portal or project resource.
+%% to an IoT SiteWise Monitor portal or project resource.
 update_access_policy(Client, AccessPolicyId, Input) ->
     update_access_policy(Client, AccessPolicyId, Input, []).
 update_access_policy(Client, AccessPolicyId, Input0, Options0) ->
@@ -1561,8 +1672,8 @@ update_access_policy(Client, AccessPolicyId, Input0, Options0) ->
 
 %% @doc Updates an asset's name.
 %%
-%% For more information, see Updating assets and models in the AWS IoT
-%% SiteWise User Guide.
+%% For more information, see Updating assets and models in the IoT SiteWise
+%% User Guide.
 update_asset(Client, AssetId, Input) ->
     update_asset(Client, AssetId, Input, []).
 update_asset(Client, AssetId, Input0, Options0) ->
@@ -1590,16 +1701,16 @@ update_asset(Client, AssetId, Input0, Options0) ->
 %%
 %% Each asset created from the model inherits the updated asset model's
 %% property and hierarchy definitions. For more information, see Updating
-%% assets and models in the AWS IoT SiteWise User Guide.
+%% assets and models in the IoT SiteWise User Guide.
 %%
 %% This operation overwrites the existing model with the provided model. To
 %% avoid deleting your asset model's properties or hierarchies, you must
 %% include their IDs and definitions in the updated asset model payload. For
 %% more information, see DescribeAssetModel.
 %%
-%% If you remove a property from an asset model, AWS IoT SiteWise deletes all
+%% If you remove a property from an asset model, IoT SiteWise deletes all
 %% previous data for that property. If you remove a hierarchy definition from
-%% an asset model, AWS IoT SiteWise disassociates every asset associated with
+%% an asset model, IoT SiteWise disassociates every asset associated with
 %% that hierarchy. You can't change the type or data type of an existing
 %% property.
 update_asset_model(Client, AssetModelId, Input) ->
@@ -1652,7 +1763,7 @@ update_asset_property(Client, AssetId, PropertyId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates an AWS IoT SiteWise Monitor dashboard.
+%% @doc Updates an IoT SiteWise Monitor dashboard.
 update_dashboard(Client, DashboardId, Input) ->
     update_dashboard(Client, DashboardId, Input, []).
 update_dashboard(Client, DashboardId, Input0, Options0) ->
@@ -1703,8 +1814,8 @@ update_gateway(Client, GatewayId, Input0, Options0) ->
 %%
 %% Each gateway capability defines data sources for a gateway. A capability
 %% configuration can contain multiple data source configurations. If you
-%% define OPC-UA sources for a gateway in the AWS IoT SiteWise console, all
-%% of your OPC-UA sources are stored in one capability configuration. To list
+%% define OPC-UA sources for a gateway in the IoT SiteWise console, all of
+%% your OPC-UA sources are stored in one capability configuration. To list
 %% all capability configurations for a gateway, use DescribeGateway.
 update_gateway_capability_configuration(Client, GatewayId, Input) ->
     update_gateway_capability_configuration(Client, GatewayId, Input, []).
@@ -1728,7 +1839,7 @@ update_gateway_capability_configuration(Client, GatewayId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates an AWS IoT SiteWise Monitor portal.
+%% @doc Updates an IoT SiteWise Monitor portal.
 update_portal(Client, PortalId, Input) ->
     update_portal(Client, PortalId, Input, []).
 update_portal(Client, PortalId, Input0, Options0) ->
@@ -1751,7 +1862,7 @@ update_portal(Client, PortalId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates an AWS IoT SiteWise Monitor project.
+%% @doc Updates an IoT SiteWise Monitor project.
 update_project(Client, ProjectId, Input) ->
     update_project(Client, ProjectId, Input, []).
 update_project(Client, ProjectId, Input0, Options0) ->
@@ -1809,6 +1920,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -4,168 +4,152 @@
 %% @doc Introduction
 %%
 %% The Amazon Interactive Video Service (IVS) API is REST compatible, using a
-%% standard HTTP API and an AWS SNS event stream for responses.
+%% standard HTTP API and an Amazon Web Services EventBridge event stream for
+%% responses.
 %%
 %% JSON is used for both requests and responses, including errors.
 %%
-%% The API is an AWS regional service, currently in these regions: us-west-2,
-%% us-east-1, and eu-west-1.
+%% The API is an Amazon Web Services regional service. For a list of
+%% supported regions and Amazon IVS HTTPS service endpoints, see the Amazon
+%% IVS page in the Amazon Web Services General Reference.
 %%
 %% All API request parameters and URLs are case sensitive.
 %%
 %% For a summary of notable documentation changes in each release, see
 %% Document History.
 %%
-%% Service Endpoints
-%%
-%% The following are the Amazon IVS service endpoints (all HTTPS):
-%%
-%% Region name: US West (Oregon)
-%%
-%% <ul> <li> Region: `us-west-2'
-%%
-%% </li> <li> Endpoint: `ivs.us-west-2.amazonaws.com'
-%%
-%% </li> </ul> Region name: US East (Virginia)
-%%
-%% <ul> <li> Region: `us-east-1'
-%%
-%% </li> <li> Endpoint: `ivs.us-east-1.amazonaws.com'
-%%
-%% </li> </ul> Region name: EU West (Dublin)
-%%
-%% <ul> <li> Region: `eu-west-1'
-%%
-%% </li> <li> Endpoint: `ivs.eu-west-1.amazonaws.com'
-%%
-%% </li> </ul> Allowed Header Values
-%%
-%% <ul> <li> ` Accept: ' application/json
-%%
-%% </li> <li> ` Accept-Encoding: ' gzip, deflate
-%%
-%% </li> <li> ` Content-Type: 'application/json
-%%
-%% </li> </ul> Resources
-%%
-%% The following resources contain information about your IVS live stream
-%% (see Getting Started with Amazon IVS):
-%%
-%% <ul> <li> Channel — Stores configuration data related to your live stream.
-%% You first create a channel and then use the channel’s stream key to start
-%% your live stream. See the Channel endpoints for more information.
-%%
-%% </li> <li> Stream key — An identifier assigned by Amazon IVS when you
-%% create a channel, which is then used to authorize streaming. See the
-%% StreamKey endpoints for more information. Treat the stream key like a
-%% secret, since it allows anyone to stream to the channel.
-%%
-%% </li> <li> Playback key pair — Video playback may be restricted using
-%% playback-authorization tokens, which use public-key encryption. A playback
-%% key pair is the public-private pair of keys used to sign and validate the
+%% <p> <b>Allowed Header Values</b> </p> <ul> <li> <p> <code> <b>Accept:</b>
+%% </code> application/json</p> </li> <li> <p> <code> <b>Accept-Encoding:</b>
+%% </code> gzip, deflate</p> </li> <li> <p> <code> <b>Content-Type:</b>
+%% </code>application/json</p> </li> </ul> <p> <b>Resources</b> </p> <p>The
+%% following resources contain information about your IVS live stream (see <a
+%% href="https://docs.aws.amazon.com/ivs/latest/userguide/getting-started.html">
+%% Getting Started with Amazon IVS</a>):</p> <ul> <li> <p>Channel — Stores
+%% configuration data related to your live stream. You first create a channel
+%% and then use the channel’s stream key to start your live stream. See the
+%% Channel endpoints for more information. </p> </li> <li> <p>Stream key — An
+%% identifier assigned by Amazon IVS when you create a channel, which is then
+%% used to authorize streaming. See the StreamKey endpoints for more
+%% information. <i> <b>Treat the stream key like a secret, since it allows
+%% anyone to stream to the channel.</b> </i> </p> </li> <li> <p>Playback key
+%% pair — Video playback may be restricted using playback-authorization
+%% tokens, which use public-key encryption. A playback key pair is the
+%% public-private pair of keys used to sign and validate the
 %% playback-authorization token. See the PlaybackKeyPair endpoints for more
-%% information.
-%%
-%% </li> </ul> Tagging
-%%
-%% A tag is a metadata label that you assign to an AWS resource. A tag
-%% comprises a key and a value, both set by you. For example, you might set a
-%% tag as `topic:nature' to label a particular video category. See Tagging
-%% AWS Resources for more information, including restrictions that apply to
-%% tags.
-%%
-%% Tags can help you identify and organize your AWS resources. For example,
-%% you can use the same tag for different resources to indicate that they are
-%% related. You can also use tags to manage access (see Access Tags).
-%%
-%% The Amazon IVS API has these tag-related endpoints: `TagResource',
-%% `UntagResource', and `ListTagsForResource'. The following resources
-%% support tagging: Channels, Stream Keys, and Playback Key Pairs.
-%%
-%% Channel Endpoints
-%%
-%% <ul> <li> `CreateChannel' — Creates a new channel and an associated stream
-%% key to start streaming.
-%%
-%% </li> <li> `GetChannel' — Gets the channel configuration for the specified
-%% channel ARN (Amazon Resource Name).
-%%
-%% </li> <li> `BatchGetChannel' — Performs `GetChannel' on multiple ARNs
-%% simultaneously.
-%%
-%% </li> <li> `ListChannels' — Gets summary information about all channels in
-%% your account, in the AWS region where the API request is processed. This
-%% list can be filtered to match a specified string.
-%%
-%% </li> <li> `UpdateChannel' — Updates a channel's configuration. This does
-%% not affect an ongoing stream of this channel. You must stop and restart
-%% the stream for the changes to take effect.
-%%
-%% </li> <li> `DeleteChannel' — Deletes the specified channel.
-%%
-%% </li> </ul> StreamKey Endpoints
-%%
-%% <ul> <li> `CreateStreamKey' — Creates a stream key, used to initiate a
-%% stream, for the specified channel ARN.
-%%
-%% </li> <li> `GetStreamKey' — Gets stream key information for the specified
-%% ARN.
-%%
-%% </li> <li> `BatchGetStreamKey' — Performs `GetStreamKey' on multiple ARNs
-%% simultaneously.
-%%
-%% </li> <li> `ListStreamKeys' — Gets summary information about stream keys
-%% for the specified channel.
-%%
-%% </li> <li> `DeleteStreamKey' — Deletes the stream key for the specified
-%% ARN, so it can no longer be used to stream.
-%%
-%% </li> </ul> Stream Endpoints
-%%
-%% <ul> <li> `GetStream' — Gets information about the active (live) stream on
-%% a specified channel.
-%%
-%% </li> <li> `ListStreams' — Gets summary information about live streams in
-%% your account, in the AWS region where the API request is processed.
-%%
-%% </li> <li> `StopStream' — Disconnects the incoming RTMPS stream for the
-%% specified channel. Can be used in conjunction with `DeleteStreamKey' to
-%% prevent further streaming to a channel.
-%%
-%% </li> <li> `PutMetadata' — Inserts metadata into an RTMPS stream for the
-%% specified channel. A maximum of 5 requests per second per channel is
-%% allowed, each with a maximum 1KB payload.
-%%
-%% </li> </ul> PlaybackKeyPair Endpoints
-%%
-%% <ul> <li> `ImportPlaybackKeyPair' — Imports the public portion of a new
-%% key pair and returns its `arn' and `fingerprint'. The `privateKey' can
-%% then be used to generate viewer authorization tokens, to grant viewers
-%% access to authorized channels.
-%%
-%% </li> <li> `GetPlaybackKeyPair' — Gets a specified playback authorization
-%% key pair and returns the `arn' and `fingerprint'. The `privateKey' held by
-%% the caller can be used to generate viewer authorization tokens, to grant
-%% viewers access to authorized channels.
-%%
-%% </li> <li> `ListPlaybackKeyPairs' — Gets summary information about
-%% playback key pairs.
-%%
-%% </li> <li> `DeletePlaybackKeyPair' — Deletes a specified authorization key
-%% pair. This invalidates future viewer tokens generated using the key pair’s
-%% `privateKey'.
-%%
-%% </li> </ul> AWS Tags Endpoints
-%%
-%% <ul> <li> `TagResource' — Adds or updates tags for the AWS resource with
-%% the specified ARN.
-%%
-%% </li> <li> `UntagResource' — Removes tags from the resource with the
-%% specified ARN.
-%%
-%% </li> <li> `ListTagsForResource' — Gets information about AWS tags for the
-%% specified ARN.
-%%
+%% information.</p> </li> <li> <p>Recording configuration — Stores
+%% configuration related to recording a live stream and where to store the
+%% recorded content. Multiple channels can reference the same recording
+%% configuration. See the Recording Configuration endpoints for more
+%% information.</p> </li> </ul> <p> <b>Tagging</b> </p> <p>A <i>tag</i> is a
+%% metadata label that you assign to an Amazon Web Services resource. A tag
+%% comprises a <i>key</i> and a <i>value</i>, both set by you. For example,
+%% you might set a tag as <code>topic:nature</code> to label a particular
+%% video category. See <a
+%% href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">Tagging
+%% Amazon Web Services Resources</a> for more information, including
+%% restrictions that apply to tags.</p> <p>Tags can help you identify and
+%% organize your Amazon Web Services resources. For example, you can use the
+%% same tag for different resources to indicate that they are related. You
+%% can also use tags to manage access (see <a
+%% href="https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html">
+%% Access Tags</a>). </p> <p>The Amazon IVS API has these tag-related
+%% endpoints: <a>TagResource</a>, <a>UntagResource</a>, and
+%% <a>ListTagsForResource</a>. The following resources support tagging:
+%% Channels, Stream Keys, Playback Key Pairs, and Recording
+%% Configurations.</p> <p>At most 50 tags can be applied to a resource. </p>
+%% <p> <b>Authentication versus Authorization</b> </p> <p>Note the
+%% differences between these concepts:</p> <ul> <li> <p>
+%% <i>Authentication</i> is about verifying identity. You need to be
+%% authenticated to sign Amazon IVS API requests.</p> </li> <li> <p>
+%% <i>Authorization</i> is about granting permissions. You need to be
+%% authorized to view <a
+%% href="https://docs.aws.amazon.com/ivs/latest/userguide/private-channels.html">Amazon
+%% IVS private channels</a>. (Private channels are channels that are enabled
+%% for "playback authorization.")</p> </li> </ul> <p> <b>Authentication</b>
+%% </p> <p>All Amazon IVS API requests must be authenticated with a
+%% signature. The Amazon Web Services Command-Line Interface (CLI) and Amazon
+%% IVS Player SDKs take care of signing the underlying API calls for you.
+%% However, if your application calls the Amazon IVS API directly, it’s your
+%% responsibility to sign the requests.</p> <p>You generate a signature using
+%% valid Amazon Web Services credentials that have permission to perform the
+%% requested action. For example, you must sign PutMetadata requests with a
+%% signature generated from an IAM user account that has the
+%% <code>ivs:PutMetadata</code> permission.</p> <p>For more information:</p>
+%% <ul> <li> <p>Authentication and generating signatures — See <a
+%% href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
+%% Requests (Amazon Web Services Signature Version 4)</a> in the <i>Amazon
+%% Web Services General Reference</i>.</p> </li> <li> <p>Managing Amazon IVS
+%% permissions — See <a
+%% href="https://docs.aws.amazon.com/ivs/latest/userguide/security-iam.html">Identity
+%% and Access Management</a> on the Security page of the <i>Amazon IVS User
+%% Guide</i>.</p> </li> </ul> <p> <b>Channel Endpoints</b> </p> <ul> <li> <p>
+%% <a>CreateChannel</a> — Creates a new channel and an associated stream key
+%% to start streaming.</p> </li> <li> <p> <a>GetChannel</a> — Gets the
+%% channel configuration for the specified channel ARN (Amazon Resource
+%% Name).</p> </li> <li> <p> <a>BatchGetChannel</a> — Performs
+%% <a>GetChannel</a> on multiple ARNs simultaneously.</p> </li> <li> <p>
+%% <a>ListChannels</a> — Gets summary information about all channels in your
+%% account, in the Amazon Web Services region where the API request is
+%% processed. This list can be filtered to match a specified name or
+%% recording-configuration ARN. Filters are mutually exclusive and cannot be
+%% used together. If you try to use both filters, you will get an error (409
+%% Conflict Exception).</p> </li> <li> <p> <a>UpdateChannel</a> — Updates a
+%% channel's configuration. This does not affect an ongoing stream of this
+%% channel. You must stop and restart the stream for the changes to take
+%% effect.</p> </li> <li> <p> <a>DeleteChannel</a> — Deletes the specified
+%% channel.</p> </li> </ul> <p> <b>StreamKey Endpoints</b> </p> <ul> <li> <p>
+%% <a>CreateStreamKey</a> — Creates a stream key, used to initiate a stream,
+%% for the specified channel ARN.</p> </li> <li> <p> <a>GetStreamKey</a> —
+%% Gets stream key information for the specified ARN.</p> </li> <li> <p>
+%% <a>BatchGetStreamKey</a> — Performs <a>GetStreamKey</a> on multiple ARNs
+%% simultaneously.</p> </li> <li> <p> <a>ListStreamKeys</a> — Gets summary
+%% information about stream keys for the specified channel.</p> </li> <li>
+%% <p> <a>DeleteStreamKey</a> — Deletes the stream key for the specified ARN,
+%% so it can no longer be used to stream.</p> </li> </ul> <p> <b>Stream
+%% Endpoints</b> </p> <ul> <li> <p> <a>GetStream</a> — Gets information about
+%% the active (live) stream on a specified channel.</p> </li> <li> <p>
+%% <a>ListStreams</a> — Gets summary information about live streams in your
+%% account, in the Amazon Web Services region where the API request is
+%% processed.</p> </li> <li> <p> <a>StopStream</a> — Disconnects the incoming
+%% RTMPS stream for the specified channel. Can be used in conjunction with
+%% <a>DeleteStreamKey</a> to prevent further streaming to a channel.</p>
+%% </li> <li> <p> <a>PutMetadata</a> — Inserts metadata into the active
+%% stream of the specified channel. At most 5 requests per second per channel
+%% are allowed, each with a maximum 1 KB payload. (If 5 TPS is not sufficient
+%% for your needs, we recommend batching your data into a single PutMetadata
+%% call.) At most 155 requests per second per account are allowed.</p> </li>
+%% </ul> <p> <b>PlaybackKeyPair Endpoints</b> </p> <p>For more information,
+%% see <a
+%% href="https://docs.aws.amazon.com/ivs/latest/userguide/private-channels.html">Setting
+%% Up Private Channels</a> in the <i>Amazon IVS User Guide</i>.</p> <ul> <li>
+%% <p> <a>ImportPlaybackKeyPair</a> — Imports the public portion of a new key
+%% pair and returns its <code>arn</code> and <code>fingerprint</code>. The
+%% <code>privateKey</code> can then be used to generate viewer authorization
+%% tokens, to grant viewers access to private channels (channels enabled for
+%% playback authorization).</p> </li> <li> <p> <a>GetPlaybackKeyPair</a> —
+%% Gets a specified playback authorization key pair and returns the
+%% <code>arn</code> and <code>fingerprint</code>. The <code>privateKey</code>
+%% held by the caller can be used to generate viewer authorization tokens, to
+%% grant viewers access to private channels.</p> </li> <li> <p>
+%% <a>ListPlaybackKeyPairs</a> — Gets summary information about playback key
+%% pairs.</p> </li> <li> <p> <a>DeletePlaybackKeyPair</a> — Deletes a
+%% specified authorization key pair. This invalidates future viewer tokens
+%% generated using the key pair’s <code>privateKey</code>.</p> </li> </ul>
+%% <p> <b>RecordingConfiguration Endpoints</b> </p> <ul> <li> <p>
+%% <a>CreateRecordingConfiguration</a> — Creates a new recording
+%% configuration, used to enable recording to Amazon S3.</p> </li> <li> <p>
+%% <a>GetRecordingConfiguration</a> — Gets the recording-configuration
+%% metadata for the specified ARN.</p> </li> <li> <p>
+%% <a>ListRecordingConfigurations</a> — Gets summary information about all
+%% recording configurations in your account, in the Amazon Web Services
+%% region where the API request is processed.</p> </li> <li> <p>
+%% <a>DeleteRecordingConfiguration</a> — Deletes the recording configuration
+%% for the specified ARN.</p> </li> </ul> <p> <b>Amazon Web Services Tags
+%% Endpoints</b> </p> <ul> <li> <p> <a>TagResource</a> — Adds or updates tags
+%% for the Amazon Web Services resource with the specified ARN.</p> </li>
+%% <li> <p> <a>UntagResource</a> — Removes tags from the resource with the
+%% specified ARN.</p> </li> <li> <p> <a>ListTagsForResource</a> — Gets
+%% information about Amazon Web Services tags for the specified ARN.</p>
 %% </li> </ul>
 -module(aws_ivs).
 
@@ -175,18 +159,24 @@
          batch_get_stream_key/3,
          create_channel/2,
          create_channel/3,
+         create_recording_configuration/2,
+         create_recording_configuration/3,
          create_stream_key/2,
          create_stream_key/3,
          delete_channel/2,
          delete_channel/3,
          delete_playback_key_pair/2,
          delete_playback_key_pair/3,
+         delete_recording_configuration/2,
+         delete_recording_configuration/3,
          delete_stream_key/2,
          delete_stream_key/3,
          get_channel/2,
          get_channel/3,
          get_playback_key_pair/2,
          get_playback_key_pair/3,
+         get_recording_configuration/2,
+         get_recording_configuration/3,
          get_stream/2,
          get_stream/3,
          get_stream_key/2,
@@ -197,6 +187,8 @@
          list_channels/3,
          list_playback_key_pairs/2,
          list_playback_key_pairs/3,
+         list_recording_configurations/2,
+         list_recording_configurations/3,
          list_stream_keys/2,
          list_stream_keys/3,
          list_streams/2,
@@ -227,7 +219,7 @@ batch_get_channel(Client, Input) ->
 batch_get_channel(Client, Input0, Options0) ->
     Method = post,
     Path = ["/BatchGetChannel"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -250,7 +242,7 @@ batch_get_stream_key(Client, Input) ->
 batch_get_stream_key(Client, Input0, Options0) ->
     Method = post,
     Path = ["/BatchGetStreamKey"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -274,7 +266,43 @@ create_channel(Client, Input) ->
 create_channel(Client, Input0, Options0) ->
     Method = post,
     Path = ["/CreateChannel"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new recording configuration, used to enable recording to
+%% Amazon S3.
+%%
+%% Known issue: In the us-east-1 region, if you use the Amazon Web Services
+%% CLI to create a recording configuration, it returns success even if the S3
+%% bucket is in a different region. In this case, the `state' of the
+%% recording configuration is `CREATE_FAILED' (instead of `ACTIVE'). (In
+%% other regions, the CLI correctly returns failure if the bucket is in a
+%% different region.)
+%%
+%% Workaround: Ensure that your S3 bucket is in the same region as the
+%% recording configuration. If you create a recording configuration in a
+%% different region as your S3 bucket, delete that recording configuration
+%% and create a new one with an S3 bucket from the correct region.
+create_recording_configuration(Client, Input) ->
+    create_recording_configuration(Client, Input, []).
+create_recording_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/CreateRecordingConfiguration"],
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -304,7 +332,7 @@ create_stream_key(Client, Input) ->
 create_stream_key(Client, Input0, Options0) ->
     Method = post,
     Path = ["/CreateStreamKey"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -322,6 +350,12 @@ create_stream_key(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the specified channel and its associated stream keys.
+%%
+%% If you try to delete a live channel, you will get an error (409
+%% ConflictException). To delete a channel that is live, call `StopStream',
+%% wait for the Amazon EventBridge "Stream End" event (to verify that the
+%% stream's state was changed from Live to Offline), then call DeleteChannel.
+%% (See Using EventBridge with Amazon IVS.)
 delete_channel(Client, Input) ->
     delete_channel(Client, Input, []).
 delete_channel(Client, Input0, Options0) ->
@@ -347,13 +381,43 @@ delete_channel(Client, Input0, Options0) ->
 %% @doc Deletes a specified authorization key pair.
 %%
 %% This invalidates future viewer tokens generated using the key pair’s
-%% `privateKey'.
+%% `privateKey'. For more information, see Setting Up Private Channels in the
+%% Amazon IVS User Guide.
 delete_playback_key_pair(Client, Input) ->
     delete_playback_key_pair(Client, Input, []).
 delete_playback_key_pair(Client, Input0, Options0) ->
     Method = post,
     Path = ["/DeletePlaybackKeyPair"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the recording configuration for the specified ARN.
+%%
+%% If you try to delete a recording configuration that is associated with a
+%% channel, you will get an error (409 ConflictException). To avoid this, for
+%% all channels that reference the recording configuration, first use
+%% `UpdateChannel' to set the `recordingConfigurationArn' field to an empty
+%% string, then use DeleteRecordingConfiguration.
+delete_recording_configuration(Client, Input) ->
+    delete_recording_configuration(Client, Input, []).
+delete_recording_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteRecordingConfiguration"],
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -402,7 +466,7 @@ get_channel(Client, Input) ->
 get_channel(Client, Input0, Options0) ->
     Method = post,
     Path = ["/GetChannel"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -423,13 +487,38 @@ get_channel(Client, Input0, Options0) ->
 %% `arn' and `fingerprint'.
 %%
 %% The `privateKey' held by the caller can be used to generate viewer
-%% authorization tokens, to grant viewers access to authorized channels.
+%% authorization tokens, to grant viewers access to private channels. For
+%% more information, see Setting Up Private Channels in the Amazon IVS User
+%% Guide.
 get_playback_key_pair(Client, Input) ->
     get_playback_key_pair(Client, Input, []).
 get_playback_key_pair(Client, Input0, Options0) ->
     Method = post,
     Path = ["/GetPlaybackKeyPair"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets the recording configuration for the specified ARN.
+get_recording_configuration(Client, Input) ->
+    get_recording_configuration(Client, Input, []).
+get_recording_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetRecordingConfiguration"],
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -453,7 +542,7 @@ get_stream(Client, Input) ->
 get_stream(Client, Input0, Options0) ->
     Method = post,
     Path = ["/GetStream"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -476,7 +565,7 @@ get_stream_key(Client, Input) ->
 get_stream_key(Client, Input0, Options0) ->
     Method = post,
     Path = ["/GetStreamKey"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -497,13 +586,14 @@ get_stream_key(Client, Input0, Options0) ->
 %% and `fingerprint'.
 %%
 %% The `privateKey' can then be used to generate viewer authorization tokens,
-%% to grant viewers access to authorized channels.
+%% to grant viewers access to private channels. For more information, see
+%% Setting Up Private Channels in the Amazon IVS User Guide.
 import_playback_key_pair(Client, Input) ->
     import_playback_key_pair(Client, Input, []).
 import_playback_key_pair(Client, Input0, Options0) ->
     Method = post,
     Path = ["/ImportPlaybackKeyPair"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -521,15 +611,18 @@ import_playback_key_pair(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets summary information about all channels in your account, in the
-%% AWS region where the API request is processed.
+%% Amazon Web Services region where the API request is processed.
 %%
-%% This list can be filtered to match a specified string.
+%% This list can be filtered to match a specified name or
+%% recording-configuration ARN. Filters are mutually exclusive and cannot be
+%% used together. If you try to use both filters, you will get an error (409
+%% ConflictException).
 list_channels(Client, Input) ->
     list_channels(Client, Input, []).
 list_channels(Client, Input0, Options0) ->
     Method = post,
     Path = ["/ListChannels"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -547,12 +640,40 @@ list_channels(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets summary information about playback key pairs.
+%%
+%% For more information, see Setting Up Private Channels in the Amazon IVS
+%% User Guide.
 list_playback_key_pairs(Client, Input) ->
     list_playback_key_pairs(Client, Input, []).
 list_playback_key_pairs(Client, Input0, Options0) ->
     Method = post,
     Path = ["/ListPlaybackKeyPairs"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets summary information about all recording configurations in your
+%% account, in the Amazon Web Services region where the API request is
+%% processed.
+list_recording_configurations(Client, Input) ->
+    list_recording_configurations(Client, Input, []).
+list_recording_configurations(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListRecordingConfigurations"],
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -575,7 +696,7 @@ list_stream_keys(Client, Input) ->
 list_stream_keys(Client, Input0, Options0) ->
     Method = post,
     Path = ["/ListStreamKeys"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -593,13 +714,13 @@ list_stream_keys(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets summary information about live streams in your account, in the
-%% AWS region where the API request is processed.
+%% Amazon Web Services region where the API request is processed.
 list_streams(Client, Input) ->
     list_streams(Client, Input, []).
 list_streams(Client, Input0, Options0) ->
     Method = post,
     Path = ["/ListStreams"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -616,7 +737,8 @@ list_streams(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Gets information about AWS tags for the specified ARN.
+%% @doc Gets information about Amazon Web Services tags for the specified
+%% ARN.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -628,7 +750,7 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
 list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -639,16 +761,19 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Inserts metadata into an RTMPS stream for the specified channel.
+%% @doc Inserts metadata into the active stream of the specified channel.
 %%
-%% A maximum of 5 requests per second per channel is allowed, each with a
-%% maximum 1KB payload.
+%% At most 5 requests per second per channel are allowed, each with a maximum
+%% 1 KB payload. (If 5 TPS is not sufficient for your needs, we recommend
+%% batching your data into a single PutMetadata call.) At most 155 requests
+%% per second per account are allowed. Also see Embedding Metadata within a
+%% Video Stream in the Amazon IVS User Guide.
 put_metadata(Client, Input) ->
     put_metadata(Client, Input, []).
 put_metadata(Client, Input0, Options0) ->
     Method = post,
     Path = ["/PutMetadata"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -678,7 +803,7 @@ stop_stream(Client, Input) ->
 stop_stream(Client, Input0, Options0) ->
     Method = post,
     Path = ["/StopStream"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -695,13 +820,14 @@ stop_stream(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Adds or updates tags for the AWS resource with the specified ARN.
+%% @doc Adds or updates tags for the Amazon Web Services resource with the
+%% specified ARN.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
     Method = post,
     Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -724,7 +850,7 @@ untag_resource(Client, ResourceArn, Input) ->
 untag_resource(Client, ResourceArn, Input0, Options0) ->
     Method = delete,
     Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -751,7 +877,7 @@ update_channel(Client, Input) ->
 update_channel(Client, Input0, Options0) ->
     Method = post,
     Path = ["/UpdateChannel"],
-    SuccessStatusCode = undefined,
+    SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
                | Options0],
@@ -803,6 +929,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -77,7 +77,9 @@
          update_configuration/3,
          update_configuration/4,
          update_monitoring/3,
-         update_monitoring/4]).
+         update_monitoring/4,
+         update_security/3,
+         update_security/4]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -835,6 +837,30 @@ update_monitoring(Client, ClusterArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc You can use this operation to update the encrypting and
+%% authentication settings for an existing cluster.
+update_security(Client, ClusterArn, Input) ->
+    update_security(Client, ClusterArn, Input, []).
+update_security(Client, ClusterArn, Input0, Options0) ->
+    Method = patch,
+    Path = ["/v1/clusters/", aws_util:encode_uri(ClusterArn), "/security"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -870,6 +896,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kafkaconnect.erl
+++ b/src/aws_kafkaconnect.erl
@@ -1,0 +1,402 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+
+-module(aws_kafkaconnect).
+
+-export([create_connector/2,
+         create_connector/3,
+         create_custom_plugin/2,
+         create_custom_plugin/3,
+         create_worker_configuration/2,
+         create_worker_configuration/3,
+         delete_connector/3,
+         delete_connector/4,
+         describe_connector/2,
+         describe_connector/4,
+         describe_connector/5,
+         describe_custom_plugin/2,
+         describe_custom_plugin/4,
+         describe_custom_plugin/5,
+         describe_worker_configuration/2,
+         describe_worker_configuration/4,
+         describe_worker_configuration/5,
+         list_connectors/1,
+         list_connectors/3,
+         list_connectors/4,
+         list_custom_plugins/1,
+         list_custom_plugins/3,
+         list_custom_plugins/4,
+         list_worker_configurations/1,
+         list_worker_configurations/3,
+         list_worker_configurations/4,
+         update_connector/3,
+         update_connector/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a connector using the specified properties.
+create_connector(Client, Input) ->
+    create_connector(Client, Input, []).
+create_connector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/connectors"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a custom plugin using the specified properties.
+create_custom_plugin(Client, Input) ->
+    create_custom_plugin(Client, Input, []).
+create_custom_plugin(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/custom-plugins"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a worker configuration using the specified properties.
+create_worker_configuration(Client, Input) ->
+    create_worker_configuration(Client, Input, []).
+create_worker_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/worker-configurations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified connector.
+delete_connector(Client, ConnectorArn, Input) ->
+    delete_connector(Client, ConnectorArn, Input, []).
+delete_connector(Client, ConnectorArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v1/connectors/", aws_util:encode_uri(ConnectorArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"currentVersion">>, <<"currentVersion">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns summary information about the connector.
+describe_connector(Client, ConnectorArn)
+  when is_map(Client) ->
+    describe_connector(Client, ConnectorArn, #{}, #{}).
+
+describe_connector(Client, ConnectorArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_connector(Client, ConnectorArn, QueryMap, HeadersMap, []).
+
+describe_connector(Client, ConnectorArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/connectors/", aws_util:encode_uri(ConnectorArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc A summary description of the custom plugin.
+describe_custom_plugin(Client, CustomPluginArn)
+  when is_map(Client) ->
+    describe_custom_plugin(Client, CustomPluginArn, #{}, #{}).
+
+describe_custom_plugin(Client, CustomPluginArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_custom_plugin(Client, CustomPluginArn, QueryMap, HeadersMap, []).
+
+describe_custom_plugin(Client, CustomPluginArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/custom-plugins/", aws_util:encode_uri(CustomPluginArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a worker configuration.
+describe_worker_configuration(Client, WorkerConfigurationArn)
+  when is_map(Client) ->
+    describe_worker_configuration(Client, WorkerConfigurationArn, #{}, #{}).
+
+describe_worker_configuration(Client, WorkerConfigurationArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_worker_configuration(Client, WorkerConfigurationArn, QueryMap, HeadersMap, []).
+
+describe_worker_configuration(Client, WorkerConfigurationArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/worker-configurations/", aws_util:encode_uri(WorkerConfigurationArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of all the connectors in this account and Region.
+%%
+%% The list is limited to connectors whose name starts with the specified
+%% prefix. The response also includes a description of each of the listed
+%% connectors.
+list_connectors(Client)
+  when is_map(Client) ->
+    list_connectors(Client, #{}, #{}).
+
+list_connectors(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_connectors(Client, QueryMap, HeadersMap, []).
+
+list_connectors(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/connectors"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"connectorNamePrefix">>, maps:get(<<"connectorNamePrefix">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of all of the custom plugins in this account and
+%% Region.
+list_custom_plugins(Client)
+  when is_map(Client) ->
+    list_custom_plugins(Client, #{}, #{}).
+
+list_custom_plugins(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_custom_plugins(Client, QueryMap, HeadersMap, []).
+
+list_custom_plugins(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/custom-plugins"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of all of the worker configurations in this account
+%% and Region.
+list_worker_configurations(Client)
+  when is_map(Client) ->
+    list_worker_configurations(Client, #{}, #{}).
+
+list_worker_configurations(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_worker_configurations(Client, QueryMap, HeadersMap, []).
+
+list_worker_configurations(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/worker-configurations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Updates the specified connector.
+update_connector(Client, ConnectorArn, Input) ->
+    update_connector(Client, ConnectorArn, Input, []).
+update_connector(Client, ConnectorArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/v1/connectors/", aws_util:encode_uri(ConnectorArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"currentVersion">>, <<"currentVersion">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"kafkaconnect">>},
+    Host = build_host(<<"kafkaconnect">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_kendra.erl
+++ b/src/aws_kendra.erl
@@ -6,14 +6,20 @@
 
 -export([batch_delete_document/2,
          batch_delete_document/3,
+         batch_get_document_status/2,
+         batch_get_document_status/3,
          batch_put_document/2,
          batch_put_document/3,
+         clear_query_suggestions/2,
+         clear_query_suggestions/3,
          create_data_source/2,
          create_data_source/3,
          create_faq/2,
          create_faq/3,
          create_index/2,
          create_index/3,
+         create_query_suggestions_block_list/2,
+         create_query_suggestions_block_list/3,
          create_thesaurus/2,
          create_thesaurus/3,
          delete_data_source/2,
@@ -22,6 +28,10 @@
          delete_faq/3,
          delete_index/2,
          delete_index/3,
+         delete_principal_mapping/2,
+         delete_principal_mapping/3,
+         delete_query_suggestions_block_list/2,
+         delete_query_suggestions_block_list/3,
          delete_thesaurus/2,
          delete_thesaurus/3,
          describe_data_source/2,
@@ -30,20 +40,34 @@
          describe_faq/3,
          describe_index/2,
          describe_index/3,
+         describe_principal_mapping/2,
+         describe_principal_mapping/3,
+         describe_query_suggestions_block_list/2,
+         describe_query_suggestions_block_list/3,
+         describe_query_suggestions_config/2,
+         describe_query_suggestions_config/3,
          describe_thesaurus/2,
          describe_thesaurus/3,
+         get_query_suggestions/2,
+         get_query_suggestions/3,
          list_data_source_sync_jobs/2,
          list_data_source_sync_jobs/3,
          list_data_sources/2,
          list_data_sources/3,
          list_faqs/2,
          list_faqs/3,
+         list_groups_older_than_ordering_id/2,
+         list_groups_older_than_ordering_id/3,
          list_indices/2,
          list_indices/3,
+         list_query_suggestions_block_lists/2,
+         list_query_suggestions_block_lists/3,
          list_tags_for_resource/2,
          list_tags_for_resource/3,
          list_thesauri/2,
          list_thesauri/3,
+         put_principal_mapping/2,
+         put_principal_mapping/3,
          query/2,
          query/3,
          start_data_source_sync_job/2,
@@ -60,6 +84,10 @@
          update_data_source/3,
          update_index/2,
          update_index/3,
+         update_query_suggestions_block_list/2,
+         update_query_suggestions_block_list/3,
+         update_query_suggestions_config/2,
+         update_query_suggestions_config/3,
          update_thesaurus/2,
          update_thesaurus/3]).
 
@@ -74,14 +102,32 @@
 %% The documents must have been added with the `BatchPutDocument' operation.
 %%
 %% The documents are deleted asynchronously. You can see the progress of the
-%% deletion by using AWS CloudWatch. Any error messages releated to the
-%% processing of the batch are sent to you CloudWatch log.
+%% deletion by using Amazon Web Services CloudWatch. Any error messages
+%% related to the processing of the batch are sent to you CloudWatch log.
 batch_delete_document(Client, Input)
   when is_map(Client), is_map(Input) ->
     batch_delete_document(Client, Input, []).
 batch_delete_document(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchDeleteDocument">>, Input, Options).
+
+%% @doc Returns the indexing status for one or more documents submitted with
+%% the BatchPutDocument operation.
+%%
+%% When you use the `BatchPutDocument' operation, documents are indexed
+%% asynchronously. You can use the `BatchGetDocumentStatus' operation to get
+%% the current status of a list of documents so that you can determine if
+%% they have been successfully indexed.
+%%
+%% You can also use the `BatchGetDocumentStatus' operation to check the
+%% status of the BatchDeleteDocument operation. When a document is deleted
+%% from the index, Amazon Kendra returns `NOT_FOUND' as the status.
+batch_get_document_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_get_document_status(Client, Input, []).
+batch_get_document_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchGetDocumentStatus">>, Input, Options).
 
 %% @doc Adds one or more documents to an index.
 %%
@@ -92,8 +138,8 @@ batch_delete_document(Client, Input, Options)
 %% documents added to the index.
 %%
 %% The documents are indexed asynchronously. You can see the progress of the
-%% batch using AWS CloudWatch. Any error messages related to processing the
-%% batch are sent to your AWS CloudWatch log.
+%% batch using Amazon Web Services CloudWatch. Any error messages related to
+%% processing the batch are sent to your Amazon Web Services CloudWatch log.
 batch_put_document(Client, Input)
   when is_map(Client), is_map(Input) ->
     batch_put_document(Client, Input, []).
@@ -101,11 +147,26 @@ batch_put_document(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchPutDocument">>, Input, Options).
 
-%% @doc Creates a data source that you use to with an Amazon Kendra index.
+%% @doc Clears existing query suggestions from an index.
+%%
+%% This deletes existing suggestions only, not the queries in the query log.
+%% After you clear suggestions, Amazon Kendra learns new suggestions based on
+%% new queries added to the query log from the time you cleared suggestions.
+%% If you do not see any new suggestions, then please allow Amazon Kendra to
+%% collect enough queries to learn new suggestions.
+clear_query_suggestions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    clear_query_suggestions(Client, Input, []).
+clear_query_suggestions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ClearQuerySuggestions">>, Input, Options).
+
+%% @doc Creates a data source that you want to use with an Amazon Kendra
+%% index.
 %%
 %% You specify a name, data source connector type and description for your
-%% data source. You also specify configuration information such as document
-%% metadata (author, source URI, and so on) and user context information.
+%% data source. You also specify configuration information for the data
+%% source connector.
 %%
 %% `CreateDataSource' is a synchronous operation. The operation returns 200
 %% if the data source was successfully created. Otherwise, an exception is
@@ -129,17 +190,36 @@ create_faq(Client, Input, Options)
 %% @doc Creates a new Amazon Kendra index.
 %%
 %% Index creation is an asynchronous operation. To determine if index
-%% creation has completed, check the `Status' field returned from a call to .
-%% The `Status' field is set to `ACTIVE' when the index is ready to use.
+%% creation has completed, check the `Status' field returned from a call to
+%% `DescribeIndex'. The `Status' field is set to `ACTIVE' when the index is
+%% ready to use.
 %%
-%% Once the index is active you can index your documents using the operation
-%% or using one of the supported data sources.
+%% Once the index is active you can index your documents using the
+%% `BatchPutDocument' operation or using one of the supported data sources.
 create_index(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_index(Client, Input, []).
 create_index(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateIndex">>, Input, Options).
+
+%% @doc Creates a block list to exlcude certain queries from suggestions.
+%%
+%% Any query that contains words or phrases specified in the block list is
+%% blocked or filtered out from being shown as a suggestion.
+%%
+%% You need to provide the file location of your block list text file in your
+%% S3 bucket. In your text file, enter each block word or phrase on a
+%% separate line.
+%%
+%% For information on the current quota limits for block lists, see Quotas
+%% for Amazon Kendra.
+create_query_suggestions_block_list(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_query_suggestions_block_list(Client, Input, []).
+create_query_suggestions_block_list(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateQuerySuggestionsBlockList">>, Input, Options).
 
 %% @doc Creates a thesaurus for an index.
 %%
@@ -155,8 +235,8 @@ create_thesaurus(Client, Input, Options)
 %%
 %% An exception is not thrown if the data source is already being deleted.
 %% While the data source is being deleted, the `Status' field returned by a
-%% call to the operation is set to `DELETING'. For more information, see
-%% Deleting Data Sources.
+%% call to the `DescribeDataSource' operation is set to `DELETING'. For more
+%% information, see Deleting Data Sources.
 delete_data_source(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_data_source(Client, Input, []).
@@ -183,6 +263,39 @@ delete_index(Client, Input)
 delete_index(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteIndex">>, Input, Options).
+
+%% @doc Deletes a group so that all users and sub groups that belong to the
+%% group can no longer access documents only available to that group.
+%%
+%% For example, after deleting the group "Summer Interns", all interns who
+%% belonged to that group no longer see intern-only documents in their search
+%% results.
+%%
+%% If you want to delete or replace users or sub groups of a group, you need
+%% to use the `PutPrincipalMapping' operation. For example, if a user in the
+%% group "Engineering" leaves the engineering team and another user takes
+%% their place, you provide an updated list of users or sub groups that
+%% belong to the "Engineering" group when calling `PutPrincipalMapping'. You
+%% can update your internal list of users or sub groups and input this list
+%% when calling `PutPrincipalMapping'.
+delete_principal_mapping(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_principal_mapping(Client, Input, []).
+delete_principal_mapping(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeletePrincipalMapping">>, Input, Options).
+
+%% @doc Deletes a block list used for query suggestions for an index.
+%%
+%% A deleted block list might not take effect right away. Amazon Kendra needs
+%% to refresh the entire suggestions list to add back the queries that were
+%% previously blocked.
+delete_query_suggestions_block_list(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_query_suggestions_block_list(Client, Input, []).
+delete_query_suggestions_block_list(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteQuerySuggestionsBlockList">>, Input, Options).
 
 %% @doc Deletes an existing Amazon Kendra thesaurus.
 delete_thesaurus(Client, Input)
@@ -216,6 +329,42 @@ describe_index(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeIndex">>, Input, Options).
 
+%% @doc Describes the processing of `PUT' and `DELETE' actions for mapping
+%% users to their groups.
+%%
+%% This includes information on the status of actions currently processing or
+%% yet to be processed, when actions were last updated, when actions were
+%% received by Amazon Kendra, the latest action that should process and apply
+%% after other actions, and useful error messages if an action could not be
+%% processed.
+describe_principal_mapping(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_principal_mapping(Client, Input, []).
+describe_principal_mapping(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribePrincipalMapping">>, Input, Options).
+
+%% @doc Describes a block list used for query suggestions for an index.
+%%
+%% This is used to check the current settings that are applied to a block
+%% list.
+describe_query_suggestions_block_list(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_query_suggestions_block_list(Client, Input, []).
+describe_query_suggestions_block_list(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeQuerySuggestionsBlockList">>, Input, Options).
+
+%% @doc Describes the settings of query suggestions for an index.
+%%
+%% This is used to check the current settings applied to query suggestions.
+describe_query_suggestions_config(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_query_suggestions_config(Client, Input, []).
+describe_query_suggestions_config(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeQuerySuggestionsConfig">>, Input, Options).
+
 %% @doc Describes an existing Amazon Kendra thesaurus.
 describe_thesaurus(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -223,6 +372,14 @@ describe_thesaurus(Client, Input)
 describe_thesaurus(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeThesaurus">>, Input, Options).
+
+%% @doc Fetches the queries that are suggested to your users.
+get_query_suggestions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_query_suggestions(Client, Input, []).
+get_query_suggestions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetQuerySuggestions">>, Input, Options).
 
 %% @doc Gets statistics about synchronizing Amazon Kendra with a data source.
 list_data_source_sync_jobs(Client, Input)
@@ -248,6 +405,15 @@ list_faqs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListFaqs">>, Input, Options).
 
+%% @doc Provides a list of groups that are mapped to users before a given
+%% ordering or timestamp identifier.
+list_groups_older_than_ordering_id(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_groups_older_than_ordering_id(Client, Input, []).
+list_groups_older_than_ordering_id(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListGroupsOlderThanOrderingId">>, Input, Options).
+
 %% @doc Lists the Amazon Kendra indexes that you have created.
 list_indices(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -255,6 +421,17 @@ list_indices(Client, Input)
 list_indices(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListIndices">>, Input, Options).
+
+%% @doc Lists the block lists used for query suggestions for an index.
+%%
+%% For information on the current quota limits for block lists, see Quotas
+%% for Amazon Kendra.
+list_query_suggestions_block_lists(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_query_suggestions_block_lists(Client, Input, []).
+list_query_suggestions_block_lists(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListQuerySuggestionsBlockLists">>, Input, Options).
 
 %% @doc Gets a list of tags associated with a specified resource.
 %%
@@ -273,6 +450,30 @@ list_thesauri(Client, Input)
 list_thesauri(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListThesauri">>, Input, Options).
+
+%% @doc Maps users to their groups so that you only need to provide the user
+%% ID when you issue the query.
+%%
+%% You can also map sub groups to groups. For example, the group "Company
+%% Intellectual Property Teams" includes sub groups "Research" and
+%% "Engineering". These sub groups include their own list of users or people
+%% who work in these teams. Only users who work in research and engineering,
+%% and therefore belong in the intellectual property group, can see
+%% top-secret company documents in their search results.
+%%
+%% You map users to their groups when you want to filter search results for
+%% different users based on their group’s access to documents. For more
+%% information on filtering search results for different users, see Filtering
+%% on user context.
+%%
+%% If more than five `PUT' actions for a group are currently processing, a
+%% validation exception is thrown.
+put_principal_mapping(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_principal_mapping(Client, Input, []).
+put_principal_mapping(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutPrincipalMapping">>, Input, Options).
 
 %% @doc Searches an active index.
 %%
@@ -325,7 +526,7 @@ stop_data_source_sync_job(Client, Input, Options)
     request(Client, <<"StopDataSourceSyncJob">>, Input, Options).
 
 %% @doc Enables you to provide feedback to Amazon Kendra to improve the
-%% performance of the service.
+%% performance of your index.
 submit_feedback(Client, Input)
   when is_map(Client), is_map(Input) ->
     submit_feedback(Client, Input, []).
@@ -368,6 +569,44 @@ update_index(Client, Input)
 update_index(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateIndex">>, Input, Options).
+
+%% @doc Updates a block list used for query suggestions for an index.
+%%
+%% Updates to a block list might not take effect right away. Amazon Kendra
+%% needs to refresh the entire suggestions list to apply any updates to the
+%% block list. Other changes not related to the block list apply immediately.
+%%
+%% If a block list is updating, then you need to wait for the first update to
+%% finish before submitting another update.
+%%
+%% Amazon Kendra supports partial updates, so you only need to provide the
+%% fields you want to update.
+update_query_suggestions_block_list(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_query_suggestions_block_list(Client, Input, []).
+update_query_suggestions_block_list(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateQuerySuggestionsBlockList">>, Input, Options).
+
+%% @doc Updates the settings of query suggestions for an index.
+%%
+%% Amazon Kendra supports partial updates, so you only need to provide the
+%% fields you want to update.
+%%
+%% If an update is currently processing (i.e. 'happening'), you need to wait
+%% for the update to finish before making another update.
+%%
+%% Updates to query suggestions settings might not take effect right away.
+%% The time for your updated settings to take effect depends on the updates
+%% made and the number of search queries in your index.
+%%
+%% You can still enable/disable query suggestions at any time.
+update_query_suggestions_config(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_query_suggestions_config(Client, Input, []).
+update_query_suggestions_config(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateQuerySuggestionsConfig">>, Input, Options).
 
 %% @doc Updates a thesaurus file associated with an index.
 update_thesaurus(Client, Input)

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -660,6 +660,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -141,9 +141,9 @@ get_clip(Client, Input0, Options0) ->
 %% an encrypted session token) for the session's MPEG-DASH manifest (the root
 %% resource needed for streaming with MPEG-DASH).
 %%
-%% Don't share or store this token where an unauthorized entity could access
+%% Don't share or store this token where an unauthorized entity can access
 %% it. The token provides access to the content of the stream. Safeguard the
-%% token with the same measures that you would use with your AWS credentials.
+%% token with the same measures that you use with your AWS credentials.
 %%
 %% The media that is made available through the manifest consists only of the
 %% requested stream, time range, and format. No other media data (such as
@@ -189,23 +189,8 @@ get_clip(Client, Input0, Options0) ->
 %%
 %% Data retrieved with this action is billable. See Pricing for details.
 %%
-%% </li> </ul> </li> </ol> The following restrictions apply to MPEG-DASH
-%% sessions:
-%%
-%% A streaming session URL should not be shared between players. The service
-%% might throttle a session if multiple media players are sharing it. For
-%% connection limits, see Kinesis Video Streams Limits.
-%%
-%% A Kinesis video stream can have a maximum of ten active MPEG-DASH
-%% streaming sessions. If a new session is created when the maximum number of
-%% sessions is already active, the oldest (earliest created) session is
-%% closed. The number of active `GetMedia' connections on a Kinesis video
-%% stream does not count against this limit, and the number of active
-%% MPEG-DASH sessions does not count against the active `GetMedia' connection
-%% limit.
-%%
-%% The maximum limits for active HLS and MPEG-DASH streaming sessions are
-%% independent of each other.
+%% </li> </ul> </li> </ol> For restrictions that apply to MPEG-DASH sessions,
+%% see Kinesis Video Streams Limits.
 %%
 %% You can monitor the amount of data that the media player consumes by
 %% monitoring the `GetMP4MediaFragment.OutgoingBytes' Amazon CloudWatch
@@ -372,21 +357,9 @@ get_dash_streaming_session_url(Client, Input0, Options0) ->
 %% Data retrieved with this action is billable. For more information, see
 %% Kinesis Video Streams pricing.
 %%
-%% </li> </ul> </li> </ol> The following restrictions apply to HLS sessions:
-%%
-%% A streaming session URL should not be shared between players. The service
-%% might throttle a session if multiple media players are sharing it. For
-%% connection limits, see Kinesis Video Streams Limits.
-%%
-%% A Kinesis video stream can have a maximum of ten active HLS streaming
-%% sessions. If a new session is created when the maximum number of sessions
-%% is already active, the oldest (earliest created) session is closed. The
-%% number of active `GetMedia' connections on a Kinesis video stream does not
-%% count against this limit, and the number of active HLS sessions does not
-%% count against the active `GetMedia' connection limit.
-%%
-%% The maximum limits for active HLS and MPEG-DASH streaming sessions are
-%% independent of each other.
+%% </li> </ul> </li> </ol> A streaming session URL must not be shared between
+%% players. The service might throttle a session if multiple media players
+%% are sharing it. For connection limits, see Kinesis Video Streams Limits.
 %%
 %% You can monitor the amount of data that the media player consumes by
 %% monitoring the `GetMP4MediaFragment.OutgoingBytes' Amazon CloudWatch
@@ -444,18 +417,11 @@ get_hls_streaming_session_url(Client, Input0, Options0) ->
 %% send the `GetMediaForFragmentList' requests to this endpoint using the
 %% --endpoint-url parameter.
 %%
-%% The following limits apply when using the `GetMediaForFragmentList' API:
+%% For limits, see Kinesis Video Streams Limits.
 %%
-%% <ul> <li> A client can call `GetMediaForFragmentList' up to five times per
-%% second per stream.
-%%
-%% </li> <li> Kinesis Video Streams sends media data at a rate of up to 25
-%% megabytes per second (or 200 megabits per second) during a
-%% `GetMediaForFragmentList' session.
-%%
-%% </li> </ul> If an error is thrown after invoking a Kinesis Video Streams
-%% archived media API, in addition to the HTTP status code and the response
-%% body, it includes the following pieces of information:
+%% If an error is thrown after invoking a Kinesis Video Streams archived
+%% media API, in addition to the HTTP status code and the response body, it
+%% includes the following pieces of information:
 %%
 %% `x-amz-ErrorType' HTTP header – contains a more specific error type in
 %% addition to what the HTTP status code provides.
@@ -595,6 +561,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -128,6 +128,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -123,6 +123,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_kms.erl
+++ b/src/aws_kms.erl
@@ -1,25 +1,30 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Key Management Service
+%% @doc Key Management Service
 %%
-%% AWS Key Management Service (AWS KMS) is an encryption and key management
-%% web service.
+%% Key Management Service (KMS) is an encryption and key management web
+%% service.
 %%
-%% This guide describes the AWS KMS operations that you can call
-%% programmatically. For general information about AWS KMS, see the AWS Key
+%% This guide describes the KMS operations that you can call
+%% programmatically. For general information about KMS, see the Key
 %% Management Service Developer Guide .
 %%
-%% AWS provides SDKs that consist of libraries and sample code for various
-%% programming languages and platforms (Java, Ruby, .Net, macOS, Android,
-%% etc.). The SDKs provide a convenient way to create programmatic access to
-%% AWS KMS and other AWS services. For example, the SDKs take care of tasks
-%% such as signing requests (see below), managing errors, and retrying
-%% requests automatically. For more information about the AWS SDKs, including
-%% how to download and install them, see Tools for Amazon Web Services.
+%% KMS is replacing the term customer master key (CMK) with KMS key and KMS
+%% key. The concept has not changed. To prevent breaking changes, KMS is
+%% keeping some variations of this term.
 %%
-%% We recommend that you use the AWS SDKs to make programmatic API calls to
-%% AWS KMS.
+%% Amazon Web Services provides SDKs that consist of libraries and sample
+%% code for various programming languages and platforms (Java, Ruby, .Net,
+%% macOS, Android, etc.). The SDKs provide a convenient way to create
+%% programmatic access to KMS and other Amazon Web Services services. For
+%% example, the SDKs take care of tasks such as signing requests (see below),
+%% managing errors, and retrying requests automatically. For more information
+%% about the Amazon Web Services SDKs, including how to download and install
+%% them, see Tools for Amazon Web Services.
+%%
+%% We recommend that you use the Amazon Web Services SDKs to make
+%% programmatic API calls to KMS.
 %%
 %% Clients must support TLS (Transport Layer Security) 1.0. We recommend TLS
 %% 1.2. Clients must also support cipher suites with Perfect Forward Secrecy
@@ -30,22 +35,22 @@
 %% Signing Requests
 %%
 %% Requests must be signed by using an access key ID and a secret access key.
-%% We strongly recommend that you do not use your AWS account (root) access
-%% key ID and secret key for everyday work with AWS KMS. Instead, use the
-%% access key ID and secret access key for an IAM user. You can also use the
-%% AWS Security Token Service to generate temporary security credentials that
-%% you can use to sign requests.
+%% We strongly recommend that you do not use your Amazon Web Services account
+%% (root) access key ID and secret key for everyday work with KMS. Instead,
+%% use the access key ID and secret access key for an IAM user. You can also
+%% use the Amazon Web Services Security Token Service to generate temporary
+%% security credentials that you can use to sign requests.
 %%
-%% All AWS KMS operations require Signature Version 4.
+%% All KMS operations require Signature Version 4.
 %%
 %% Logging API Requests
 %%
-%% AWS KMS supports AWS CloudTrail, a service that logs AWS API calls and
-%% related events for your AWS account and delivers them to an Amazon S3
-%% bucket that you specify. By using the information collected by CloudTrail,
-%% you can determine what requests were made to AWS KMS, who made the
-%% request, when it was made, and so on. To learn more about CloudTrail,
-%% including how to turn it on and find your log files, see the AWS
+%% KMS supports CloudTrail, a service that logs Amazon Web Services API calls
+%% and related events for your Amazon Web Services account and delivers them
+%% to an Amazon S3 bucket that you specify. By using the information
+%% collected by CloudTrail, you can determine what requests were made to KMS,
+%% who made the request, when it was made, and so on. To learn more about
+%% CloudTrail, including how to turn it on and find your log files, see the
 %% CloudTrail User Guide.
 %%
 %% Additional Resources
@@ -53,8 +58,9 @@
 %% For more information about credentials and request signing, see the
 %% following:
 %%
-%% <ul> <li> AWS Security Credentials - This topic provides general
-%% information about the types of credentials used for accessing AWS.
+%% <ul> <li> Amazon Web Services Security Credentials - This topic provides
+%% general information about the types of credentials used to access Amazon
+%% Web Services.
 %%
 %% </li> <li> Temporary Security Credentials - This section of the IAM User
 %% Guide describes how to create and use temporary security credentials.
@@ -153,6 +159,8 @@
          put_key_policy/3,
          re_encrypt/2,
          re_encrypt/3,
+         replicate_key/2,
+         replicate_key/3,
          retire_grant/2,
          retire_grant/3,
          revoke_grant/2,
@@ -171,6 +179,8 @@
          update_custom_key_store/3,
          update_key_description/2,
          update_key_description/3,
+         update_primary_region/2,
+         update_primary_region/3,
          verify/2,
          verify/3]).
 
@@ -180,21 +190,20 @@
 %% API
 %%====================================================================
 
-%% @doc Cancels the deletion of a customer master key (CMK).
+%% @doc Cancels the deletion of a KMS key.
 %%
-%% When this operation succeeds, the key state of the CMK is `Disabled'. To
-%% enable the CMK, use `EnableKey'.
+%% When this operation succeeds, the key state of the KMS key is `Disabled'.
+%% To enable the KMS key, use `EnableKey'.
 %%
-%% For more information about scheduling and canceling deletion of a CMK, see
-%% Deleting Customer Master Keys in the AWS Key Management Service Developer
-%% Guide.
+%% For more information about scheduling and canceling deletion of a KMS key,
+%% see Deleting KMS keys in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:CancelKeyDeletion (key policy)
 %%
@@ -206,19 +215,19 @@ cancel_key_deletion(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CancelKeyDeletion">>, Input, Options).
 
-%% @doc Connects or reconnects a custom key store to its associated AWS
-%% CloudHSM cluster.
+%% @doc Connects or reconnects a custom key store to its associated CloudHSM
+%% cluster.
 %%
-%% The custom key store must be connected before you can create customer
-%% master keys (CMKs) in the key store or use the CMKs it contains. You can
-%% disconnect and reconnect a custom key store at any time.
+%% The custom key store must be connected before you can create KMS keys in
+%% the key store or use the KMS keys it contains. You can disconnect and
+%% reconnect a custom key store at any time.
 %%
-%% To connect a custom key store, its associated AWS CloudHSM cluster must
-%% have at least one active HSM. To get the number of active HSMs in a
-%% cluster, use the DescribeClusters operation. To add HSMs to the cluster,
-%% use the CreateHsm operation. Also, the `kmsuser' crypto user (CU) must not
-%% be logged into the cluster. This prevents AWS KMS from using this account
-%% to log in.
+%% To connect a custom key store, its associated CloudHSM cluster must have
+%% at least one active HSM. To get the number of active HSMs in a cluster,
+%% use the DescribeClusters operation. To add HSMs to the cluster, use the
+%% CreateHsm operation. Also, the `kmsuser' crypto user (CU) must not be
+%% logged into the cluster. This prevents KMS from using this account to log
+%% in.
 %%
 %% The connection process can take an extended amount of time to complete; up
 %% to 20 minutes. This operation starts the connection process, but it does
@@ -228,10 +237,10 @@ cancel_key_deletion(Client, Input, Options)
 %% connected. To get the connection state of the custom key store, use the
 %% `DescribeCustomKeyStores' operation.
 %%
-%% During the connection process, AWS KMS finds the AWS CloudHSM cluster that
-%% is associated with the custom key store, creates the connection
-%% infrastructure, connects to the cluster, logs into the AWS CloudHSM client
-%% as the `kmsuser' CU, and rotates its password.
+%% During the connection process, KMS finds the CloudHSM cluster that is
+%% associated with the custom key store, creates the connection
+%% infrastructure, connects to the cluster, logs into the CloudHSM client as
+%% the `kmsuser' CU, and rotates its password.
 %%
 %% The `ConnectCustomKeyStore' operation might fail for various reasons. To
 %% find the reason, use the `DescribeCustomKeyStores' operation and see the
@@ -244,11 +253,11 @@ cancel_key_deletion(Client, Input, Options)
 %% `ConnectCustomKeyStore' again.
 %%
 %% If you are having trouble connecting or disconnecting a custom key store,
-%% see Troubleshooting a Custom Key Store in the AWS Key Management Service
+%% see Troubleshooting a Custom Key Store in the Key Management Service
 %% Developer Guide.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:ConnectCustomKeyStore (IAM policy)
 %%
@@ -272,43 +281,45 @@ connect_custom_key_store(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ConnectCustomKeyStore">>, Input, Options).
 
-%% @doc Creates a friendly name for a customer master key (CMK).
+%% @doc Creates a friendly name for a KMS key.
 %%
-%% You can use an alias to identify a CMK in the AWS KMS console, in the
+%% Adding, deleting, or updating an alias can allow or deny permission to the
+%% KMS key. For details, see Using ABAC in KMS in the Key Management Service
+%% Developer Guide.
+%%
+%% You can use an alias to identify a KMS key in the KMS console, in the
 %% `DescribeKey' operation and in cryptographic operations, such as `Encrypt'
-%% and `GenerateDataKey'.
+%% and `GenerateDataKey'. You can also change the KMS key that's associated
+%% with the alias (`UpdateAlias') or delete the alias (`DeleteAlias') at any
+%% time. These operations don't affect the underlying KMS key.
 %%
-%% You can also change the CMK that's associated with the alias
-%% (`UpdateAlias') or delete the alias (`DeleteAlias') at any time. These
-%% operations don't affect the underlying CMK.
-%%
-%% You can associate the alias with any customer managed CMK in the same AWS
-%% Region. Each alias is associated with only on CMK at a time, but a CMK can
-%% have multiple aliases. A valid CMK is required. You can't create an alias
-%% without a CMK.
+%% You can associate the alias with any customer managed key in the same
+%% Amazon Web Services Region. Each alias is associated with only one KMS key
+%% at a time, but a KMS key can have multiple aliases. A valid KMS key is
+%% required. You can't create an alias without a KMS key.
 %%
 %% The alias must be unique in the account and Region, but you can have
 %% aliases with the same name in different Regions. For detailed information
-%% about aliases, see Using aliases in the AWS Key Management Service
-%% Developer Guide.
+%% about aliases, see Using aliases in the Key Management Service Developer
+%% Guide.
 %%
 %% This operation does not return a response. To get the alias that you
 %% created, use the `ListAliases' operation.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
 %% Cross-account use: No. You cannot perform this operation on an alias in a
-%% different AWS account.
+%% different Amazon Web Services account.
 %%
 %% Required permissions
 %%
 %% <ul> <li> kms:CreateAlias on the alias (IAM policy).
 %%
-%% </li> <li> kms:CreateAlias on the CMK (key policy).
+%% </li> <li> kms:CreateAlias on the KMS key (key policy).
 %%
-%% </li> </ul> For details, see Controlling access to aliases in the AWS Key
+%% </li> </ul> For details, see Controlling access to aliases in the Key
 %% Management Service Developer Guide.
 %%
 %% Related operations:
@@ -327,31 +338,30 @@ create_alias(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateAlias">>, Input, Options).
 
-%% @doc Creates a custom key store that is associated with an AWS CloudHSM
+%% @doc Creates a custom key store that is associated with an CloudHSM
 %% cluster that you own and manage.
 %%
-%% This operation is part of the Custom Key Store feature feature in AWS KMS,
-%% which combines the convenience and extensive integration of AWS KMS with
-%% the isolation and control of a single-tenant key store.
+%% This operation is part of the Custom Key Store feature feature in KMS,
+%% which combines the convenience and extensive integration of KMS with the
+%% isolation and control of a single-tenant key store.
 %%
 %% Before you create the custom key store, you must assemble the required
-%% elements, including an AWS CloudHSM cluster that fulfills the requirements
-%% for a custom key store. For details about the required elements, see
-%% Assemble the Prerequisites in the AWS Key Management Service Developer
-%% Guide.
+%% elements, including an CloudHSM cluster that fulfills the requirements for
+%% a custom key store. For details about the required elements, see Assemble
+%% the Prerequisites in the Key Management Service Developer Guide.
 %%
 %% When the operation completes successfully, it returns the ID of the new
 %% custom key store. Before you can use your new custom key store, you need
 %% to use the `ConnectCustomKeyStore' operation to connect the new key store
-%% to its AWS CloudHSM cluster. Even if you are not going to use your custom
-%% key store immediately, you might want to connect it to verify that all
+%% to its CloudHSM cluster. Even if you are not going to use your custom key
+%% store immediately, you might want to connect it to verify that all
 %% settings are correct and then disconnect it until you are ready to use it.
 %%
-%% For help with failures, see Troubleshooting a Custom Key Store in the AWS
-%% Key Management Service Developer Guide.
+%% For help with failures, see Troubleshooting a Custom Key Store in the Key
+%% Management Service Developer Guide.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:CreateCustomKeyStore (IAM policy).
 %%
@@ -375,51 +385,45 @@ create_custom_key_store(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateCustomKeyStore">>, Input, Options).
 
-%% @doc Adds a grant to a customer master key (CMK).
+%% @doc Adds a grant to a KMS key.
 %%
-%% The grant allows the grantee principal to use the CMK when the conditions
-%% specified in the grant are met. When setting permissions, grants are an
-%% alternative to key policies.
+%% A grant is a policy instrument that allows Amazon Web Services principals
+%% to use KMS keys in cryptographic operations. It also can allow them to
+%% view a KMS key (`DescribeKey') and create and manage grants. When
+%% authorizing access to a KMS key, grants are considered along with key
+%% policies and IAM policies. Grants are often used for temporary permissions
+%% because you can create one, use its permissions, and delete it without
+%% changing your key policies or IAM policies.
 %%
-%% To create a grant that allows a cryptographic operation only when the
-%% request includes a particular encryption context, use the `Constraints'
-%% parameter. For details, see `GrantConstraints'.
+%% For detailed information about grants, including grant terminology, see
+%% Using grants in the Key Management Service Developer Guide . For examples
+%% of working with grants in several programming languages, see Programming
+%% grants.
 %%
-%% You can create grants on symmetric and asymmetric CMKs. However, if the
-%% grant allows an operation that the CMK does not support, `CreateGrant'
-%% fails with a `ValidationException'.
+%% The `CreateGrant' operation returns a `GrantToken' and a `GrantId'.
 %%
-%% <ul> <li> Grants for symmetric CMKs cannot allow operations that are not
-%% supported for symmetric CMKs, including `Sign', `Verify', and
-%% `GetPublicKey'. (There are limited exceptions to this rule for legacy
-%% operations, but you should not create a grant for an operation that AWS
-%% KMS does not support.)
+%% <ul> <li> When you create, retire, or revoke a grant, there might be a
+%% brief delay, usually less than five minutes, until the grant is available
+%% throughout KMS. This state is known as eventual consistency. Once the
+%% grant has achieved eventual consistency, the grantee principal can use the
+%% permissions in the grant without identifying the grant.
 %%
-%% </li> <li> Grants for asymmetric CMKs cannot allow operations that are not
-%% supported for asymmetric CMKs, including operations that generate data
-%% keys or data key pairs, or operations related to automatic key rotation,
-%% imported key material, or CMKs in custom key stores.
+%% However, to use the permissions in the grant immediately, use the
+%% `GrantToken' that `CreateGrant' returns. For details, see Using a grant
+%% token in the Key Management Service Developer Guide .
 %%
-%% </li> <li> Grants for asymmetric CMKs with a `KeyUsage' of
-%% `ENCRYPT_DECRYPT' cannot allow the `Sign' or `Verify' operations. Grants
-%% for asymmetric CMKs with a `KeyUsage' of `SIGN_VERIFY' cannot allow the
-%% `Encrypt' or `Decrypt' operations.
+%% </li> <li> The `CreateGrant' operation also returns a `GrantId'. You can
+%% use the `GrantId' and a key identifier to identify the grant in the
+%% `RetireGrant' and `RevokeGrant' operations. To find the grant ID, use the
+%% `ListGrants' or `ListRetirableGrants' operations.
 %%
-%% </li> <li> Grants for asymmetric CMKs cannot include an encryption context
-%% grant constraint. An encryption context is not supported on asymmetric
-%% CMKs.
+%% </li> </ul> The KMS key that you use for this operation must be in a
+%% compatible key state. For details, see Key state: Effect on your KMS key
+%% in the Key Management Service Developer Guide.
 %%
-%% </li> </ul> For information about symmetric and asymmetric CMKs, see Using
-%% Symmetric and Asymmetric CMKs in the AWS Key Management Service Developer
-%% Guide. For more information about grants, see Grants in the AWS Key
-%% Management Service Developer Guide .
-%%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
-%%
-%% Cross-account use: Yes. To perform this operation on a CMK in a different
-%% AWS account, specify the key ARN in the value of the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation on a KMS key in a
+%% different Amazon Web Services account, specify the key ARN in the value of
+%% the `KeyId' parameter.
 %%
 %% Required permissions: kms:CreateGrant (key policy)
 %%
@@ -441,71 +445,103 @@ create_grant(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateGrant">>, Input, Options).
 
-%% @doc Creates a unique customer managed customer master key (CMK) in your
-%% AWS account and Region.
+%% @doc Creates a unique customer managed KMS key in your Amazon Web Services
+%% account and Region.
+%%
+%% KMS is replacing the term customer master key (CMK) with KMS key and KMS
+%% key. The concept has not changed. To prevent breaking changes, KMS is
+%% keeping some variations of this term.
 %%
 %% You can use the `CreateKey' operation to create symmetric or asymmetric
-%% CMKs.
+%% KMS keys.
 %%
-%% <ul> <li> Symmetric CMKs contain a 256-bit symmetric key that never leaves
-%% AWS KMS unencrypted. To use the CMK, you must call AWS KMS. You can use a
-%% symmetric CMK to encrypt and decrypt small amounts of data, but they are
-%% typically used to generate data keys and data keys pairs. For details, see
-%% `GenerateDataKey' and `GenerateDataKeyPair'.
+%% <ul> <li> Symmetric KMS keys contain a 256-bit symmetric key that never
+%% leaves KMS unencrypted. To use the KMS key, you must call KMS. You can use
+%% a symmetric KMS key to encrypt and decrypt small amounts of data, but they
+%% are typically used to generate data keys and data keys pairs. For details,
+%% see `GenerateDataKey' and `GenerateDataKeyPair'.
 %%
-%% </li> <li> Asymmetric CMKs can contain an RSA key pair or an Elliptic
-%% Curve (ECC) key pair. The private key in an asymmetric CMK never leaves
-%% AWS KMS unencrypted. However, you can use the `GetPublicKey' operation to
-%% download the public key so it can be used outside of AWS KMS. CMKs with
+%% </li> <li> Asymmetric KMS keys can contain an RSA key pair or an Elliptic
+%% Curve (ECC) key pair. The private key in an asymmetric KMS key never
+%% leaves KMS unencrypted. However, you can use the `GetPublicKey' operation
+%% to download the public key so it can be used outside of KMS. KMS keys with
 %% RSA key pairs can be used to encrypt or decrypt data or sign and verify
-%% messages (but not both). CMKs with ECC key pairs can be used only to sign
-%% and verify messages.
+%% messages (but not both). KMS keys with ECC key pairs can be used only to
+%% sign and verify messages.
 %%
-%% </li> </ul> For information about symmetric and asymmetric CMKs, see Using
-%% Symmetric and Asymmetric CMKs in the AWS Key Management Service Developer
-%% Guide.
+%% </li> </ul> For information about symmetric and asymmetric KMS keys, see
+%% Using Symmetric and Asymmetric KMS keys in the Key Management Service
+%% Developer Guide.
 %%
-%% To create different types of CMKs, use the following guidance:
+%% To create different types of KMS keys, use the following guidance:
 %%
-%% <dl> <dt>Asymmetric CMKs</dt> <dd> To create an asymmetric CMK, use the
-%% `CustomerMasterKeySpec' parameter to specify the type of key material in
-%% the CMK. Then, use the `KeyUsage' parameter to determine whether the CMK
+%% <dl> <dt>Asymmetric KMS keys</dt> <dd> To create an asymmetric KMS key,
+%% use the `KeySpec' parameter to specify the type of key material in the KMS
+%% key. Then, use the `KeyUsage' parameter to determine whether the KMS key
 %% will be used to encrypt and decrypt or sign and verify. You can't change
-%% these properties after the CMK is created.
+%% these properties after the KMS key is created.
 %%
-%% </dd> <dt>Symmetric CMKs</dt> <dd> When creating a symmetric CMK, you
-%% don't need to specify the `CustomerMasterKeySpec' or `KeyUsage'
-%% parameters. The default value for `CustomerMasterKeySpec',
-%% `SYMMETRIC_DEFAULT', and the default value for `KeyUsage',
-%% `ENCRYPT_DECRYPT', are the only valid values for symmetric CMKs.
+%% </dd> <dt>Symmetric KMS keys</dt> <dd> When creating a symmetric KMS key,
+%% you don't need to specify the `KeySpec' or `KeyUsage' parameters. The
+%% default value for `KeySpec', `SYMMETRIC_DEFAULT', and the default value
+%% for `KeyUsage', `ENCRYPT_DECRYPT', are the only valid values for symmetric
+%% KMS keys.
 %%
-%% </dd> <dt>Imported Key Material</dt> <dd> To import your own key material,
-%% begin by creating a symmetric CMK with no key material. To do this, use
-%% the `Origin' parameter of `CreateKey' with a value of `EXTERNAL'. Next,
-%% use `GetParametersForImport' operation to get a public key and import
-%% token, and use the public key to encrypt your key material. Then, use
-%% `ImportKeyMaterial' with your import token to import the key material. For
-%% step-by-step instructions, see Importing Key Material in the AWS Key
-%% Management Service Developer Guide . You cannot import the key material
-%% into an asymmetric CMK.
+%% </dd> <dt>Multi-Region primary keys</dt> <dt>Imported key material</dt>
+%% <dd> To create a multi-Region primary key in the local Amazon Web Services
+%% Region, use the `MultiRegion' parameter with a value of `True'. To create
+%% a multi-Region replica key, that is, a KMS key with the same key ID and
+%% key material as a primary key, but in a different Amazon Web Services
+%% Region, use the `ReplicateKey' operation. To change a replica key to a
+%% primary key, and its primary key to a replica key, use the
+%% `UpdatePrimaryRegion' operation.
 %%
-%% </dd> <dt>Custom Key Stores</dt> <dd> To create a symmetric CMK in a
+%% This operation supports multi-Region keys, an KMS feature that lets you
+%% create multiple interoperable KMS keys in different Amazon Web Services
+%% Regions. Because these KMS keys have the same key ID, key material, and
+%% other metadata, you can use them interchangeably to encrypt data in one
+%% Amazon Web Services Region and decrypt it in a different Amazon Web
+%% Services Region without re-encrypting the data or making a cross-Region
+%% call. For more information about multi-Region keys, see Using multi-Region
+%% keys in the Key Management Service Developer Guide.
+%%
+%% You can create symmetric and asymmetric multi-Region keys and multi-Region
+%% keys with imported key material. You cannot create multi-Region keys in a
+%% custom key store.
+%%
+%% </dd> <dd> To import your own key material, begin by creating a symmetric
+%% KMS key with no key material. To do this, use the `Origin' parameter of
+%% `CreateKey' with a value of `EXTERNAL'. Next, use `GetParametersForImport'
+%% operation to get a public key and import token, and use the public key to
+%% encrypt your key material. Then, use `ImportKeyMaterial' with your import
+%% token to import the key material. For step-by-step instructions, see
+%% Importing Key Material in the Key Management Service Developer Guide . You
+%% cannot import the key material into an asymmetric KMS key.
+%%
+%% To create a multi-Region primary key with imported key material, use the
+%% `Origin' parameter of `CreateKey' with a value of `EXTERNAL' and the
+%% `MultiRegion' parameter with a value of `True'. To create replicas of the
+%% multi-Region primary key, use the `ReplicateKey' operation. For more
+%% information about multi-Region keys, see Using multi-Region keys in the
+%% Key Management Service Developer Guide.
+%%
+%% </dd> <dt>Custom key store</dt> <dd> To create a symmetric KMS key in a
 %% custom key store, use the `CustomKeyStoreId' parameter to specify the
 %% custom key store. You must also use the `Origin' parameter with a value of
-%% `AWS_CLOUDHSM'. The AWS CloudHSM cluster that is associated with the
-%% custom key store must have at least two active HSMs in different
-%% Availability Zones in the AWS Region.
+%% `AWS_CLOUDHSM'. The CloudHSM cluster that is associated with the custom
+%% key store must have at least two active HSMs in different Availability
+%% Zones in the Amazon Web Services Region.
 %%
-%% You cannot create an asymmetric CMK in a custom key store. For information
-%% about custom key stores in AWS KMS see Using Custom Key Stores in the AWS
-%% Key Management Service Developer Guide .
+%% You cannot create an asymmetric KMS key in a custom key store. For
+%% information about custom key stores in KMS see Using Custom Key Stores in
+%% the Key Management Service Developer Guide .
 %%
 %% </dd> </dl> Cross-account use: No. You cannot use this operation to create
-%% a CMK in a different AWS account.
+%% a KMS key in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:CreateKey (IAM policy). To use the `Tags'
 %% parameter, kms:TagResource (IAM policy). For examples and information
-%% about related permissions, see Allow a user to create CMKs in the AWS Key
+%% about related permissions, see Allow a user to create KMS keys in the Key
 %% Management Service Developer Guide.
 %%
 %% Related operations:
@@ -524,8 +560,8 @@ create_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateKey">>, Input, Options).
 
-%% @doc Decrypts ciphertext that was encrypted by a AWS KMS customer master
-%% key (CMK) using any of the following operations:
+%% @doc Decrypts ciphertext that was encrypted by a KMS key using any of the
+%% following operations:
 %%
 %% <ul> <li> `Encrypt'
 %%
@@ -538,46 +574,52 @@ create_key(Client, Input, Options)
 %% </li> <li> `GenerateDataKeyPairWithoutPlaintext'
 %%
 %% </li> </ul> You can use this operation to decrypt ciphertext that was
-%% encrypted under a symmetric or asymmetric CMK.
+%% encrypted under a symmetric or asymmetric KMS key.
 %%
-%% When the CMK is asymmetric, you must specify the CMK and the encryption
-%% algorithm that was used to encrypt the ciphertext. For information about
-%% symmetric and asymmetric CMKs, see Using Symmetric and Asymmetric CMKs in
-%% the AWS Key Management Service Developer Guide.
+%% When the KMS key is asymmetric, you must specify the KMS key and the
+%% encryption algorithm that was used to encrypt the ciphertext. For
+%% information about symmetric and asymmetric KMS keys, see Using Symmetric
+%% and Asymmetric KMS keys in the Key Management Service Developer Guide.
 %%
 %% The Decrypt operation also decrypts ciphertext that was encrypted outside
-%% of AWS KMS by the public key in an AWS KMS asymmetric CMK. However, it
-%% cannot decrypt ciphertext produced by other libraries, such as the AWS
-%% Encryption SDK or Amazon S3 client-side encryption. These libraries return
-%% a ciphertext format that is incompatible with AWS KMS.
+%% of KMS by the public key in an KMS asymmetric KMS key. However, it cannot
+%% decrypt ciphertext produced by other libraries, such as the Amazon Web
+%% Services Encryption SDK or Amazon S3 client-side encryption. These
+%% libraries return a ciphertext format that is incompatible with KMS.
 %%
-%% If the ciphertext was encrypted under a symmetric CMK, the `KeyId'
-%% parameter is optional. AWS KMS can get this information from metadata that
-%% it adds to the symmetric ciphertext blob. This feature adds durability to
+%% If the ciphertext was encrypted under a symmetric KMS key, the `KeyId'
+%% parameter is optional. KMS can get this information from metadata that it
+%% adds to the symmetric ciphertext blob. This feature adds durability to
 %% your implementation by ensuring that authorized users can decrypt
 %% ciphertext decades after it was encrypted, even if they've lost track of
-%% the CMK ID. However, specifying the CMK is always recommended as a best
-%% practice. When you use the `KeyId' parameter to specify a CMK, AWS KMS
-%% only uses the CMK you specify. If the ciphertext was encrypted under a
-%% different CMK, the `Decrypt' operation fails. This practice ensures that
-%% you use the CMK that you intend.
+%% the key ID. However, specifying the KMS key is always recommended as a
+%% best practice. When you use the `KeyId' parameter to specify a KMS key,
+%% KMS only uses the KMS key you specify. If the ciphertext was encrypted
+%% under a different KMS key, the `Decrypt' operation fails. This practice
+%% ensures that you use the KMS key that you intend.
 %%
 %% Whenever possible, use key policies to give users permission to call the
-%% `Decrypt' operation on a particular CMK, instead of using IAM policies.
-%% Otherwise, you might create an IAM user policy that gives the user
-%% `Decrypt' permission on all CMKs. This user could decrypt ciphertext that
-%% was encrypted by CMKs in other accounts if the key policy for the
-%% cross-account CMK permits it. If you must use an IAM policy for `Decrypt'
-%% permissions, limit the user to particular CMKs or particular trusted
-%% accounts. For details, see Best practices for IAM policies in the AWS Key
+%% `Decrypt' operation on a particular KMS key, instead of using IAM
+%% policies. Otherwise, you might create an IAM user policy that gives the
+%% user `Decrypt' permission on all KMS keys. This user could decrypt
+%% ciphertext that was encrypted by KMS keys in other accounts if the key
+%% policy for the cross-account KMS key permits it. If you must use an IAM
+%% policy for `Decrypt' permissions, limit the user to particular KMS keys or
+%% particular trusted accounts. For details, see Best practices for IAM
+%% policies in the Key Management Service Developer Guide.
+%%
+%% Applications in Amazon Web Services Nitro Enclaves can call this operation
+%% by using the Amazon Web Services Nitro Enclaves Development Kit. For
+%% information about the supporting parameters, see How Amazon Web Services
+%% Nitro Enclaves use KMS in the Key Management Service Developer Guide.
+%%
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
 %% Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
-%%
-%% Cross-account use: Yes. You can decrypt a ciphertext using a CMK in a
-%% different AWS account.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:Decrypt (key policy)
 %%
@@ -601,26 +643,30 @@ decrypt(Client, Input, Options)
 
 %% @doc Deletes the specified alias.
 %%
-%% Because an alias is not a property of a CMK, you can delete and change the
-%% aliases of a CMK without affecting the CMK. Also, aliases do not appear in
-%% the response from the `DescribeKey' operation. To get the aliases of all
-%% CMKs, use the `ListAliases' operation.
+%% Adding, deleting, or updating an alias can allow or deny permission to the
+%% KMS key. For details, see Using ABAC in KMS in the Key Management Service
+%% Developer Guide.
 %%
-%% Each CMK can have multiple aliases. To change the alias of a CMK, use
-%% `DeleteAlias' to delete the current alias and `CreateAlias' to create a
-%% new alias. To associate an existing alias with a different customer master
-%% key (CMK), call `UpdateAlias'.
+%% Because an alias is not a property of a KMS key, you can delete and change
+%% the aliases of a KMS key without affecting the KMS key. Also, aliases do
+%% not appear in the response from the `DescribeKey' operation. To get the
+%% aliases of all KMS keys, use the `ListAliases' operation.
+%%
+%% Each KMS key can have multiple aliases. To change the alias of a KMS key,
+%% use `DeleteAlias' to delete the current alias and `CreateAlias' to create
+%% a new alias. To associate an existing alias with a different KMS key, call
+%% `UpdateAlias'.
 %%
 %% Cross-account use: No. You cannot perform this operation on an alias in a
-%% different AWS account.
+%% different Amazon Web Services account.
 %%
 %% Required permissions
 %%
 %% <ul> <li> kms:DeleteAlias on the alias (IAM policy).
 %%
-%% </li> <li> kms:DeleteAlias on the CMK (key policy).
+%% </li> <li> kms:DeleteAlias on the KMS key (key policy).
 %%
-%% </li> </ul> For details, see Controlling access to aliases in the AWS Key
+%% </li> </ul> For details, see Controlling access to aliases in the Key
 %% Management Service Developer Guide.
 %%
 %% Related operations:
@@ -641,37 +687,36 @@ delete_alias(Client, Input, Options)
 
 %% @doc Deletes a custom key store.
 %%
-%% This operation does not delete the AWS CloudHSM cluster that is associated
+%% This operation does not delete the CloudHSM cluster that is associated
 %% with the custom key store, or affect any users or keys in the cluster.
 %%
-%% The custom key store that you delete cannot contain any AWS KMS customer
-%% master keys (CMKs). Before deleting the key store, verify that you will
-%% never need to use any of the CMKs in the key store for any cryptographic
-%% operations. Then, use `ScheduleKeyDeletion' to delete the AWS KMS customer
-%% master keys (CMKs) from the key store. When the scheduled waiting period
-%% expires, the `ScheduleKeyDeletion' operation deletes the CMKs. Then it
-%% makes a best effort to delete the key material from the associated
-%% cluster. However, you might need to manually delete the orphaned key
-%% material from the cluster and its backups.
+%% The custom key store that you delete cannot contain any KMS KMS keys.
+%% Before deleting the key store, verify that you will never need to use any
+%% of the KMS keys in the key store for any cryptographic operations. Then,
+%% use `ScheduleKeyDeletion' to delete the KMS keys from the key store. When
+%% the scheduled waiting period expires, the `ScheduleKeyDeletion' operation
+%% deletes the KMS keys. Then it makes a best effort to delete the key
+%% material from the associated cluster. However, you might need to manually
+%% delete the orphaned key material from the cluster and its backups.
 %%
-%% After all CMKs are deleted from AWS KMS, use `DisconnectCustomKeyStore' to
-%% disconnect the key store from AWS KMS. Then, you can delete the custom key
+%% After all KMS keys are deleted from KMS, use `DisconnectCustomKeyStore' to
+%% disconnect the key store from KMS. Then, you can delete the custom key
 %% store.
 %%
 %% Instead of deleting the custom key store, consider using
-%% `DisconnectCustomKeyStore' to disconnect it from AWS KMS. While the key
-%% store is disconnected, you cannot create or use the CMKs in the key store.
-%% But, you do not need to delete CMKs and you can reconnect a disconnected
-%% custom key store at any time.
+%% `DisconnectCustomKeyStore' to disconnect it from KMS. While the key store
+%% is disconnected, you cannot create or use the KMS keys in the key store.
+%% But, you do not need to delete KMS keys and you can reconnect a
+%% disconnected custom key store at any time.
 %%
 %% If the operation succeeds, it returns a JSON object with no properties.
 %%
-%% This operation is part of the Custom Key Store feature feature in AWS KMS,
-%% which combines the convenience and extensive integration of AWS KMS with
-%% the isolation and control of a single-tenant key store.
+%% This operation is part of the Custom Key Store feature feature in KMS,
+%% which combines the convenience and extensive integration of KMS with the
+%% isolation and control of a single-tenant key store.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:DeleteCustomKeyStore (IAM policy)
 %%
@@ -697,23 +742,23 @@ delete_custom_key_store(Client, Input, Options)
 
 %% @doc Deletes key material that you previously imported.
 %%
-%% This operation makes the specified customer master key (CMK) unusable. For
-%% more information about importing key material into AWS KMS, see Importing
-%% Key Material in the AWS Key Management Service Developer Guide.
+%% This operation makes the specified KMS key unusable. For more information
+%% about importing key material into KMS, see Importing Key Material in the
+%% Key Management Service Developer Guide.
 %%
-%% When the specified CMK is in the `PendingDeletion' state, this operation
-%% does not change the CMK's state. Otherwise, it changes the CMK's state to
-%% `PendingImport'.
+%% When the specified KMS key is in the `PendingDeletion' state, this
+%% operation does not change the KMS key's state. Otherwise, it changes the
+%% KMS key's state to `PendingImport'.
 %%
 %% After you delete key material, you can use `ImportKeyMaterial' to reimport
-%% the same key material into the CMK.
+%% the same key material into the KMS key.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:DeleteImportedKeyMaterial (key policy)
 %%
@@ -731,18 +776,18 @@ delete_imported_key_material(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteImportedKeyMaterial">>, Input, Options).
 
-%% @doc Gets information about custom key stores in the account and region.
+%% @doc Gets information about custom key stores in the account and Region.
 %%
-%% This operation is part of the Custom Key Store feature feature in AWS KMS,
-%% which combines the convenience and extensive integration of AWS KMS with
-%% the isolation and control of a single-tenant key store.
+%% This operation is part of the Custom Key Store feature feature in KMS,
+%% which combines the convenience and extensive integration of KMS with the
+%% isolation and control of a single-tenant key store.
 %%
 %% By default, this operation returns information about all custom key stores
-%% in the account and region. To get only information about a particular
+%% in the account and Region. To get only information about a particular
 %% custom key store, use either the `CustomKeyStoreName' or
 %% `CustomKeyStoreId' parameter (but not both).
 %%
-%% To determine whether the custom key store is connected to its AWS CloudHSM
+%% To determine whether the custom key store is connected to its CloudHSM
 %% cluster, use the `ConnectionState' element in the response. If an attempt
 %% to connect the custom key store failed, the `ConnectionState' value is
 %% `FAILED' and the `ConnectionErrorCode' element in the response indicates
@@ -752,15 +797,15 @@ delete_imported_key_material(Client, Input, Options)
 %% Custom key stores have a `DISCONNECTED' connection state if the key store
 %% has never been connected or you use the `DisconnectCustomKeyStore'
 %% operation to disconnect it. If your custom key store state is `CONNECTED'
-%% but you are having trouble using it, make sure that its associated AWS
+%% but you are having trouble using it, make sure that its associated
 %% CloudHSM cluster is active and contains the minimum number of HSMs
 %% required for the operation, if any.
 %%
 %% For help repairing your custom key store, see the Troubleshooting Custom
-%% Key Stores topic in the AWS Key Management Service Developer Guide.
+%% Key Stores topic in the Key Management Service Developer Guide.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:DescribeCustomKeyStores (IAM policy)
 %%
@@ -784,45 +829,47 @@ describe_custom_key_stores(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeCustomKeyStores">>, Input, Options).
 
-%% @doc Provides detailed information about a customer master key (CMK).
+%% @doc Provides detailed information about a KMS key.
 %%
-%% You can run `DescribeKey' on a customer managed CMK or an AWS managed CMK.
+%% You can run `DescribeKey' on a customer managed key or an Amazon Web
+%% Services managed key.
 %%
 %% This detailed information includes the key ARN, creation date (and
 %% deletion date, if applicable), the key state, and the origin and
-%% expiration date (if any) of the key material. For CMKs in custom key
-%% stores, it includes information about the custom key store, such as the
-%% key store ID and the AWS CloudHSM cluster ID. It includes fields, like
-%% `KeySpec', that help you distinguish symmetric from asymmetric CMKs. It
-%% also provides information that is particularly important to asymmetric
-%% CMKs, such as the key usage (encryption or signing) and the encryption
-%% algorithms or signing algorithms that the CMK supports.
+%% expiration date (if any) of the key material. It includes fields, like
+%% `KeySpec', that help you distinguish symmetric from asymmetric KMS keys.
+%% It also provides information that is particularly important to asymmetric
+%% keys, such as the key usage (encryption or signing) and the encryption
+%% algorithms or signing algorithms that the KMS key supports. For KMS keys
+%% in custom key stores, it includes information about the custom key store,
+%% such as the key store ID and the CloudHSM cluster ID. For multi-Region
+%% keys, it displays the primary key and all related replica keys.
 %%
 %% `DescribeKey' does not return the following information:
 %%
-%% <ul> <li> Aliases associated with the CMK. To get this information, use
-%% `ListAliases'.
+%% <ul> <li> Aliases associated with the KMS key. To get this information,
+%% use `ListAliases'.
 %%
-%% </li> <li> Whether automatic key rotation is enabled on the CMK. To get
-%% this information, use `GetKeyRotationStatus'. Also, some key states
-%% prevent a CMK from being automatically rotated. For details, see How
-%% Automatic Key Rotation Works in AWS Key Management Service Developer
-%% Guide.
+%% </li> <li> Whether automatic key rotation is enabled on the KMS key. To
+%% get this information, use `GetKeyRotationStatus'. Also, some key states
+%% prevent a KMS key from being automatically rotated. For details, see How
+%% Automatic Key Rotation Works in Key Management Service Developer Guide.
 %%
-%% </li> <li> Tags on the CMK. To get this information, use
+%% </li> <li> Tags on the KMS key. To get this information, use
 %% `ListResourceTags'.
 %%
-%% </li> <li> Key policies and grants on the CMK. To get this information,
-%% use `GetKeyPolicy' and `ListGrants'.
+%% </li> <li> Key policies and grants on the KMS key. To get this
+%% information, use `GetKeyPolicy' and `ListGrants'.
 %%
-%% </li> </ul> If you call the `DescribeKey' operation on a predefined AWS
-%% alias, that is, an AWS alias with no key ID, AWS KMS creates an AWS
-%% managed CMK. Then, it associates the alias with the new CMK, and returns
-%% the `KeyId' and `Arn' of the new CMK in the response.
+%% </li> </ul> If you call the `DescribeKey' operation on a predefined Amazon
+%% Web Services alias, that is, an Amazon Web Services alias with no key ID,
+%% KMS creates an Amazon Web Services managed key. Then, it associates the
+%% alias with the new KMS key, and returns the `KeyId' and `Arn' of the new
+%% KMS key in the response.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:DescribeKey (key policy)
 %%
@@ -850,21 +897,21 @@ describe_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeKey">>, Input, Options).
 
-%% @doc Sets the state of a customer master key (CMK) to disabled.
+%% @doc Sets the state of a KMS key to disabled.
 %%
-%% This change temporarily prevents use of the CMK for cryptographic
+%% This change temporarily prevents use of the KMS key for cryptographic
 %% operations.
 %%
-%% For more information about how key state affects the use of a CMK, see How
-%% Key State Affects the Use of a Customer Master Key in the AWS Key
-%% Management Service Developer Guide .
+%% For more information about how key state affects the use of a KMS key, see
+%% Key state: Effect on your KMS key in the Key Management Service Developer
+%% Guide .
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:DisableKey (key policy)
 %%
@@ -877,17 +924,19 @@ disable_key(Client, Input, Options)
     request(Client, <<"DisableKey">>, Input, Options).
 
 %% @doc Disables automatic rotation of the key material for the specified
-%% symmetric customer master key (CMK).
+%% symmetric KMS key.
 %%
-%% You cannot enable automatic rotation of asymmetric CMKs, CMKs with
-%% imported key material, or CMKs in a custom key store.
+%% You cannot enable automatic rotation of asymmetric KMS keys, KMS keys with
+%% imported key material, or KMS keys in a custom key store. To enable or
+%% disable automatic rotation of a set of related multi-Region keys, set the
+%% property on the primary key.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:DisableKeyRotation (key policy)
 %%
@@ -905,18 +954,17 @@ disable_key_rotation(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableKeyRotation">>, Input, Options).
 
-%% @doc Disconnects the custom key store from its associated AWS CloudHSM
+%% @doc Disconnects the custom key store from its associated CloudHSM
 %% cluster.
 %%
 %% While a custom key store is disconnected, you can manage the custom key
-%% store and its customer master keys (CMKs), but you cannot create or use
-%% CMKs in the custom key store. You can reconnect the custom key store at
-%% any time.
+%% store and its KMS keys, but you cannot create or use KMS keys in the
+%% custom key store. You can reconnect the custom key store at any time.
 %%
-%% While a custom key store is disconnected, all attempts to create customer
-%% master keys (CMKs) in the custom key store or to use existing CMKs in
-%% cryptographic operations will fail. This action can prevent users from
-%% storing and accessing sensitive data.
+%% While a custom key store is disconnected, all attempts to create KMS keys
+%% in the custom key store or to use existing KMS keys in cryptographic
+%% operations will fail. This action can prevent users from storing and
+%% accessing sensitive data.
 %%
 %% To find the connection state of a custom key store, use the
 %% `DescribeCustomKeyStores' operation. To reconnect a custom key store, use
@@ -924,12 +972,12 @@ disable_key_rotation(Client, Input, Options)
 %%
 %% If the operation succeeds, it returns a JSON object with no properties.
 %%
-%% This operation is part of the Custom Key Store feature feature in AWS KMS,
-%% which combines the convenience and extensive integration of AWS KMS with
-%% the isolation and control of a single-tenant key store.
+%% This operation is part of the Custom Key Store feature feature in KMS,
+%% which combines the convenience and extensive integration of KMS with the
+%% isolation and control of a single-tenant key store.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:DisconnectCustomKeyStore (IAM policy)
 %%
@@ -953,16 +1001,16 @@ disconnect_custom_key_store(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisconnectCustomKeyStore">>, Input, Options).
 
-%% @doc Sets the key state of a customer master key (CMK) to enabled.
+%% @doc Sets the key state of a KMS key to enabled.
 %%
-%% This allows you to use the CMK for cryptographic operations.
+%% This allows you to use the KMS key for cryptographic operations.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:EnableKey (key policy)
 %%
@@ -975,17 +1023,19 @@ enable_key(Client, Input, Options)
     request(Client, <<"EnableKey">>, Input, Options).
 
 %% @doc Enables automatic rotation of the key material for the specified
-%% symmetric customer master key (CMK).
+%% symmetric KMS key.
 %%
-%% You cannot enable automatic rotation of asymmetric CMKs, CMKs with
-%% imported key material, or CMKs in a custom key store.
+%% You cannot enable automatic rotation of asymmetric KMS keys, KMS keys with
+%% imported key material, or KMS keys in a custom key store. To enable or
+%% disable automatic rotation of a set of related multi-Region keys, set the
+%% property on the primary key.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:EnableKeyRotation (key policy)
 %%
@@ -1003,8 +1053,7 @@ enable_key_rotation(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"EnableKeyRotation">>, Input, Options).
 
-%% @doc Encrypts plaintext into ciphertext by using a customer master key
-%% (CMK).
+%% @doc Encrypts plaintext into ciphertext by using a KMS key.
 %%
 %% The `Encrypt' operation has two primary use cases:
 %%
@@ -1012,49 +1061,49 @@ enable_key_rotation(Client, Input, Options)
 %% personal identifier or database password, or other sensitive information.
 %%
 %% </li> <li> You can use the `Encrypt' operation to move encrypted data from
-%% one AWS Region to another. For example, in Region A, generate a data key
-%% and use the plaintext key to encrypt your data. Then, in Region A, use the
-%% `Encrypt' operation to encrypt the plaintext data key under a CMK in
-%% Region B. Now, you can move the encrypted data and the encrypted data key
-%% to Region B. When necessary, you can decrypt the encrypted data key and
-%% the encrypted data entirely within in Region B.
+%% one Amazon Web Services Region to another. For example, in Region A,
+%% generate a data key and use the plaintext key to encrypt your data. Then,
+%% in Region A, use the `Encrypt' operation to encrypt the plaintext data key
+%% under a KMS key in Region B. Now, you can move the encrypted data and the
+%% encrypted data key to Region B. When necessary, you can decrypt the
+%% encrypted data key and the encrypted data entirely within in Region B.
 %%
 %% </li> </ul> You don't need to use the `Encrypt' operation to encrypt a
 %% data key. The `GenerateDataKey' and `GenerateDataKeyPair' operations
 %% return a plaintext data key and an encrypted copy of that data key.
 %%
-%% When you encrypt data, you must specify a symmetric or asymmetric CMK to
-%% use in the encryption operation. The CMK must have a `KeyUsage' value of
-%% `ENCRYPT_DECRYPT.' To find the `KeyUsage' of a CMK, use the `DescribeKey'
-%% operation.
+%% When you encrypt data, you must specify a symmetric or asymmetric KMS key
+%% to use in the encryption operation. The KMS key must have a `KeyUsage'
+%% value of `ENCRYPT_DECRYPT.' To find the `KeyUsage' of a KMS key, use the
+%% `DescribeKey' operation.
 %%
-%% If you use a symmetric CMK, you can use an encryption context to add
+%% If you use a symmetric KMS key, you can use an encryption context to add
 %% additional security to your encryption operation. If you specify an
 %% `EncryptionContext' when encrypting data, you must specify the same
 %% encryption context (a case-sensitive exact match) when decrypting the
 %% data. Otherwise, the request to decrypt fails with an
 %% `InvalidCiphertextException'. For more information, see Encryption Context
-%% in the AWS Key Management Service Developer Guide.
+%% in the Key Management Service Developer Guide.
 %%
-%% If you specify an asymmetric CMK, you must also specify the encryption
-%% algorithm. The algorithm must be compatible with the CMK type.
+%% If you specify an asymmetric KMS key, you must also specify the encryption
+%% algorithm. The algorithm must be compatible with the KMS key type.
 %%
-%% When you use an asymmetric CMK to encrypt or reencrypt data, be sure to
-%% record the CMK and encryption algorithm that you choose. You will be
-%% required to provide the same CMK and encryption algorithm when you decrypt
-%% the data. If the CMK and algorithm do not match the values used to encrypt
-%% the data, the decrypt operation fails.
+%% When you use an asymmetric KMS key to encrypt or reencrypt data, be sure
+%% to record the KMS key and encryption algorithm that you choose. You will
+%% be required to provide the same KMS key and encryption algorithm when you
+%% decrypt the data. If the KMS key and algorithm do not match the values
+%% used to encrypt the data, the decrypt operation fails.
 %%
-%% You are not required to supply the CMK ID and encryption algorithm when
-%% you decrypt with symmetric CMKs because AWS KMS stores this information in
-%% the ciphertext blob. AWS KMS cannot store metadata in ciphertext generated
+%% You are not required to supply the key ID and encryption algorithm when
+%% you decrypt with symmetric KMS keys because KMS stores this information in
+%% the ciphertext blob. KMS cannot store metadata in ciphertext generated
 %% with asymmetric keys. The standard format for asymmetric key ciphertext
 %% does not include configurable fields.
 %%
 %% The maximum size of the data that you can encrypt varies with the type of
-%% CMK and the encryption algorithm that you choose.
+%% KMS key and the encryption algorithm that you choose.
 %%
-%% <ul> <li> Symmetric CMKs
+%% <ul> <li> Symmetric KMS keys
 %%
 %% <ul> <li> `SYMMETRIC_DEFAULT': 4096 bytes
 %%
@@ -1076,13 +1125,13 @@ enable_key_rotation(Client, Input, Options)
 %%
 %% </li> <li> `RSAES_OAEP_SHA_256': 446 bytes
 %%
-%% </li> </ul> </li> </ul> The CMK that you use for this operation must be in
-%% a compatible key state. For details, see How Key State Affects Use of a
-%% Customer Master Key in the AWS Key Management Service Developer Guide.
+%% </li> </ul> </li> </ul> The KMS key that you use for this operation must
+%% be in a compatible key state. For details, see Key state: Effect on your
+%% KMS key in the Key Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:Encrypt (key policy)
 %%
@@ -1105,19 +1154,19 @@ encrypt(Client, Input, Options)
 %% @doc Generates a unique symmetric data key for client-side encryption.
 %%
 %% This operation returns a plaintext copy of the data key and a copy that is
-%% encrypted under a customer master key (CMK) that you specify. You can use
-%% the plaintext key to encrypt your data outside of AWS KMS and store the
-%% encrypted data key with the encrypted data.
+%% encrypted under a KMS key that you specify. You can use the plaintext key
+%% to encrypt your data outside of KMS and store the encrypted data key with
+%% the encrypted data.
 %%
 %% `GenerateDataKey' returns a unique data key for each request. The bytes in
-%% the plaintext key are not related to the caller or the CMK.
+%% the plaintext key are not related to the caller or the KMS key.
 %%
-%% To generate a data key, specify the symmetric CMK that will be used to
-%% encrypt the data key. You cannot use an asymmetric CMK to generate data
-%% keys. To get the type of your CMK, use the `DescribeKey' operation. You
-%% must also specify the length of the data key. Use either the `KeySpec' or
-%% `NumberOfBytes' parameters (but not both). For 128-bit and 256-bit data
-%% keys, use the `KeySpec' parameter.
+%% To generate a data key, specify the symmetric KMS key that will be used to
+%% encrypt the data key. You cannot use an asymmetric KMS key to generate
+%% data keys. To get the type of your KMS key, use the `DescribeKey'
+%% operation. You must also specify the length of the data key. Use either
+%% the `KeySpec' or `NumberOfBytes' parameters (but not both). For 128-bit
+%% and 256-bit data keys, use the `KeySpec' parameter.
 %%
 %% To get only an encrypted copy of the data key, use
 %% `GenerateDataKeyWithoutPlaintext'. To generate an asymmetric data key
@@ -1130,42 +1179,47 @@ encrypt(Client, Input, Options)
 %% specify the same encryption context (a case-sensitive exact match) when
 %% decrypting the encrypted data key. Otherwise, the request to decrypt fails
 %% with an `InvalidCiphertextException'. For more information, see Encryption
-%% Context in the AWS Key Management Service Developer Guide.
+%% Context in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% Applications in Amazon Web Services Nitro Enclaves can call this operation
+%% by using the Amazon Web Services Nitro Enclaves Development Kit. For
+%% information about the supporting parameters, see How Amazon Web Services
+%% Nitro Enclaves use KMS in the Key Management Service Developer Guide.
+%%
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
 %% How to use your data key
 %%
 %% We recommend that you use the following pattern to encrypt data locally in
 %% your application. You can write your own code or use a client-side
-%% encryption library, such as the AWS Encryption SDK, the Amazon DynamoDB
-%% Encryption Client, or Amazon S3 client-side encryption to do these tasks
-%% for you.
+%% encryption library, such as the Amazon Web Services Encryption SDK, the
+%% Amazon DynamoDB Encryption Client, or Amazon S3 client-side encryption to
+%% do these tasks for you.
 %%
-%% To encrypt data outside of AWS KMS:
+%% To encrypt data outside of KMS:
 %%
 %% <ol> <li> Use the `GenerateDataKey' operation to get a data key.
 %%
 %% </li> <li> Use the plaintext data key (in the `Plaintext' field of the
-%% response) to encrypt your data outside of AWS KMS. Then erase the
-%% plaintext data key from memory.
+%% response) to encrypt your data outside of KMS. Then erase the plaintext
+%% data key from memory.
 %%
 %% </li> <li> Store the encrypted data key (in the `CiphertextBlob' field of
 %% the response) with the encrypted data.
 %%
-%% </li> </ol> To decrypt data outside of AWS KMS:
+%% </li> </ol> To decrypt data outside of KMS:
 %%
 %% <ol> <li> Use the `Decrypt' operation to decrypt the encrypted data key.
 %% The operation returns a plaintext copy of the data key.
 %%
-%% </li> <li> Use the plaintext data key to decrypt data outside of AWS KMS,
-%% then erase the plaintext data key from memory.
+%% </li> <li> Use the plaintext data key to decrypt data outside of KMS, then
+%% erase the plaintext data key from memory.
 %%
-%% </li> </ol> Cross-account use: Yes. To perform this operation with a CMK
-%% in a different AWS account, specify the key ARN or alias ARN in the value
-%% of the `KeyId' parameter.
+%% </li> </ol> Cross-account use: Yes. To perform this operation with a KMS
+%% key in a different Amazon Web Services account, specify the key ARN or
+%% alias ARN in the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GenerateDataKey (key policy)
 %%
@@ -1193,23 +1247,26 @@ generate_data_key(Client, Input, Options)
 %%
 %% The `GenerateDataKeyPair' operation returns a plaintext public key, a
 %% plaintext private key, and a copy of the private key that is encrypted
-%% under the symmetric CMK you specify. You can use the data key pair to
-%% perform asymmetric cryptography outside of AWS KMS.
-%%
-%% `GenerateDataKeyPair' returns a unique data key pair for each request. The
-%% bytes in the keys are not related to the caller or the CMK that is used to
-%% encrypt the private key.
+%% under the symmetric KMS key you specify. You can use the data key pair to
+%% perform asymmetric cryptography and implement digital signatures outside
+%% of KMS.
 %%
 %% You can use the public key that `GenerateDataKeyPair' returns to encrypt
-%% data or verify a signature outside of AWS KMS. Then, store the encrypted
+%% data or verify a signature outside of KMS. Then, store the encrypted
 %% private key with the data. When you are ready to decrypt data or sign a
 %% message, you can use the `Decrypt' operation to decrypt the encrypted
 %% private key.
 %%
-%% To generate a data key pair, you must specify a symmetric customer master
-%% key (CMK) to encrypt the private key in a data key pair. You cannot use an
-%% asymmetric CMK or a CMK in a custom key store. To get the type and origin
-%% of your CMK, use the `DescribeKey' operation.
+%% To generate a data key pair, you must specify a symmetric KMS key to
+%% encrypt the private key in a data key pair. You cannot use an asymmetric
+%% KMS key or a KMS key in a custom key store. To get the type and origin of
+%% your KMS key, use the `DescribeKey' operation.
+%%
+%% Use the `KeyPairSpec' parameter to choose an RSA or Elliptic Curve (ECC)
+%% data key pair. KMS recommends that your use ECC key pairs for signing, and
+%% use RSA key pairs for either encryption or signing, but not both. However,
+%% KMS cannot enforce any restrictions on the use of data key pairs outside
+%% of KMS.
 %%
 %% If you are using the data key pair to encrypt data, or for any operation
 %% where you don't immediately need a private key, consider using the
@@ -1220,20 +1277,26 @@ generate_data_key(Client, Input, Options)
 %% decrypt the data or sign a message, use the `Decrypt' operation to decrypt
 %% the encrypted private key in the data key pair.
 %%
+%% `GenerateDataKeyPair' returns a unique data key pair for each request. The
+%% bytes in the keys are not related to the caller or the KMS key that is
+%% used to encrypt the private key. The public key is a DER-encoded X.509
+%% SubjectPublicKeyInfo, as specified in RFC 5280. The private key is a
+%% DER-encoded PKCS8 PrivateKeyInfo, as specified in RFC 5958.
+%%
 %% You can use the optional encryption context to add additional security to
 %% the encryption operation. If you specify an `EncryptionContext', you must
 %% specify the same encryption context (a case-sensitive exact match) when
 %% decrypting the encrypted data key. Otherwise, the request to decrypt fails
 %% with an `InvalidCiphertextException'. For more information, see Encryption
-%% Context in the AWS Key Management Service Developer Guide.
+%% Context in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GenerateDataKeyPair (key policy)
 %%
@@ -1261,38 +1324,45 @@ generate_data_key_pair(Client, Input, Options)
 %%
 %% The `GenerateDataKeyPairWithoutPlaintext' operation returns a plaintext
 %% public key and a copy of the private key that is encrypted under the
-%% symmetric CMK you specify. Unlike `GenerateDataKeyPair', this operation
-%% does not return a plaintext private key.
-%%
-%% To generate a data key pair, you must specify a symmetric customer master
-%% key (CMK) to encrypt the private key in the data key pair. You cannot use
-%% an asymmetric CMK or a CMK in a custom key store. To get the type and
-%% origin of your CMK, use the `KeySpec' field in the `DescribeKey' response.
+%% symmetric KMS key you specify. Unlike `GenerateDataKeyPair', this
+%% operation does not return a plaintext private key.
 %%
 %% You can use the public key that `GenerateDataKeyPairWithoutPlaintext'
-%% returns to encrypt data or verify a signature outside of AWS KMS. Then,
-%% store the encrypted private key with the data. When you are ready to
-%% decrypt data or sign a message, you can use the `Decrypt' operation to
-%% decrypt the encrypted private key.
+%% returns to encrypt data or verify a signature outside of KMS. Then, store
+%% the encrypted private key with the data. When you are ready to decrypt
+%% data or sign a message, you can use the `Decrypt' operation to decrypt the
+%% encrypted private key.
+%%
+%% To generate a data key pair, you must specify a symmetric KMS key to
+%% encrypt the private key in a data key pair. You cannot use an asymmetric
+%% KMS key or a KMS key in a custom key store. To get the type and origin of
+%% your KMS key, use the `DescribeKey' operation.
+%%
+%% Use the `KeyPairSpec' parameter to choose an RSA or Elliptic Curve (ECC)
+%% data key pair. KMS recommends that your use ECC key pairs for signing, and
+%% use RSA key pairs for either encryption or signing, but not both. However,
+%% KMS cannot enforce any restrictions on the use of data key pairs outside
+%% of KMS.
 %%
 %% `GenerateDataKeyPairWithoutPlaintext' returns a unique data key pair for
-%% each request. The bytes in the key are not related to the caller or CMK
-%% that is used to encrypt the private key.
+%% each request. The bytes in the key are not related to the caller or KMS
+%% key that is used to encrypt the private key. The public key is a
+%% DER-encoded X.509 SubjectPublicKeyInfo, as specified in RFC 5280.
 %%
 %% You can use the optional encryption context to add additional security to
 %% the encryption operation. If you specify an `EncryptionContext', you must
 %% specify the same encryption context (a case-sensitive exact match) when
 %% decrypting the encrypted data key. Otherwise, the request to decrypt fails
 %% with an `InvalidCiphertextException'. For more information, see Encryption
-%% Context in the AWS Key Management Service Developer Guide.
+%% Context in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GenerateDataKeyPairWithoutPlaintext (key policy)
 %%
@@ -1318,10 +1388,9 @@ generate_data_key_pair_without_plaintext(Client, Input, Options)
 
 %% @doc Generates a unique symmetric data key.
 %%
-%% This operation returns a data key that is encrypted under a customer
-%% master key (CMK) that you specify. To request an asymmetric data key pair,
-%% use the `GenerateDataKeyPair' or `GenerateDataKeyPairWithoutPlaintext'
-%% operations.
+%% This operation returns a data key that is encrypted under a KMS key that
+%% you specify. To request an asymmetric data key pair, use the
+%% `GenerateDataKeyPair' or `GenerateDataKeyPairWithoutPlaintext' operations.
 %%
 %% `GenerateDataKeyWithoutPlaintext' is identical to the `GenerateDataKey'
 %% operation except that returns only the encrypted copy of the data key.
@@ -1339,12 +1408,12 @@ generate_data_key_pair_without_plaintext(Client, Input, Options)
 %% creates the containers never sees the plaintext data key.
 %%
 %% `GenerateDataKeyWithoutPlaintext' returns a unique data key for each
-%% request. The bytes in the keys are not related to the caller or CMK that
-%% is used to encrypt the private key.
+%% request. The bytes in the keys are not related to the caller or KMS key
+%% that is used to encrypt the private key.
 %%
-%% To generate a data key, you must specify the symmetric customer master key
-%% (CMK) that is used to encrypt the data key. You cannot use an asymmetric
-%% CMK to generate a data key. To get the type of your CMK, use the
+%% To generate a data key, you must specify the symmetric KMS key that is
+%% used to encrypt the data key. You cannot use an asymmetric KMS key to
+%% generate a data key. To get the type of your KMS key, use the
 %% `DescribeKey' operation.
 %%
 %% If the operation succeeds, you will find the encrypted copy of the data
@@ -1355,15 +1424,15 @@ generate_data_key_pair_without_plaintext(Client, Input, Options)
 %% specify the same encryption context (a case-sensitive exact match) when
 %% decrypting the encrypted data key. Otherwise, the request to decrypt fails
 %% with an `InvalidCiphertextException'. For more information, see Encryption
-%% Context in the AWS Key Management Service Developer Guide.
+%% Context in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GenerateDataKeyWithoutPlaintext (key policy)
 %%
@@ -1389,12 +1458,17 @@ generate_data_key_without_plaintext(Client, Input, Options)
 
 %% @doc Returns a random byte string that is cryptographically secure.
 %%
-%% By default, the random byte string is generated in AWS KMS. To generate
-%% the byte string in the AWS CloudHSM cluster that is associated with a
-%% custom key store, specify the custom key store ID.
+%% By default, the random byte string is generated in KMS. To generate the
+%% byte string in the CloudHSM cluster that is associated with a custom key
+%% store, specify the custom key store ID.
 %%
-%% For more information about entropy and random number generation, see the
-%% AWS Key Management Service Cryptographic Details whitepaper.
+%% Applications in Amazon Web Services Nitro Enclaves can call this operation
+%% by using the Amazon Web Services Nitro Enclaves Development Kit. For
+%% information about the supporting parameters, see How Amazon Web Services
+%% Nitro Enclaves use KMS in the Key Management Service Developer Guide.
+%%
+%% For more information about entropy and random number generation, see Key
+%% Management Service Cryptographic Details.
 %%
 %% Required permissions: kms:GenerateRandom (IAM policy)
 generate_random(Client, Input)
@@ -1404,11 +1478,10 @@ generate_random(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GenerateRandom">>, Input, Options).
 
-%% @doc Gets a key policy attached to the specified customer master key
-%% (CMK).
+%% @doc Gets a key policy attached to the specified KMS key.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:GetKeyPolicy (key policy)
 %%
@@ -1421,27 +1494,29 @@ get_key_policy(Client, Input, Options)
     request(Client, <<"GetKeyPolicy">>, Input, Options).
 
 %% @doc Gets a Boolean value that indicates whether automatic rotation of the
-%% key material is enabled for the specified customer master key (CMK).
+%% key material is enabled for the specified KMS key.
 %%
-%% You cannot enable automatic rotation of asymmetric CMKs, CMKs with
-%% imported key material, or CMKs in a custom key store. The key rotation
-%% status for these CMKs is always `false'.
+%% You cannot enable automatic rotation of asymmetric KMS keys, KMS keys with
+%% imported key material, or KMS keys in a custom key store. To enable or
+%% disable automatic rotation of a set of related multi-Region keys, set the
+%% property on the primary key. The key rotation status for these KMS keys is
+%% always `false'.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
 %% <ul> <li> Disabled: The key rotation status does not change when you
-%% disable a CMK. However, while the CMK is disabled, AWS KMS does not rotate
-%% the backing key.
+%% disable a KMS key. However, while the KMS key is disabled, KMS does not
+%% rotate the key material.
 %%
-%% </li> <li> Pending deletion: While a CMK is pending deletion, its key
-%% rotation status is `false' and AWS KMS does not rotate the backing key. If
+%% </li> <li> Pending deletion: While a KMS key is pending deletion, its key
+%% rotation status is `false' and KMS does not rotate the key material. If
 %% you cancel the deletion, the original key rotation status is restored.
 %%
-%% </li> </ul> Cross-account use: Yes. To perform this operation on a CMK in
-%% a different AWS account, specify the key ARN in the value of the `KeyId'
-%% parameter.
+%% </li> </ul> Cross-account use: Yes. To perform this operation on a KMS key
+%% in a different Amazon Web Services account, specify the key ARN in the
+%% value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GetKeyRotationStatus (key policy)
 %%
@@ -1460,20 +1535,21 @@ get_key_rotation_status(Client, Input, Options)
     request(Client, <<"GetKeyRotationStatus">>, Input, Options).
 
 %% @doc Returns the items you need to import key material into a symmetric,
-%% customer managed customer master key (CMK).
+%% customer managed KMS key.
 %%
-%% For more information about importing key material into AWS KMS, see
-%% Importing Key Material in the AWS Key Management Service Developer Guide.
+%% For more information about importing key material into KMS, see Importing
+%% Key Material in the Key Management Service Developer Guide.
 %%
 %% This operation returns a public key and an import token. Use the public
 %% key to encrypt the symmetric key material. Store the import token to send
 %% with a subsequent `ImportKeyMaterial' request.
 %%
-%% You must specify the key ID of the symmetric CMK into which you will
-%% import key material. This CMK's `Origin' must be `EXTERNAL'. You must also
-%% specify the wrapping algorithm and type of wrapping key (public key) that
-%% you will use to encrypt the key material. You cannot perform this
-%% operation on an asymmetric CMK or on any CMK in a different AWS account.
+%% You must specify the key ID of the symmetric KMS key into which you will
+%% import key material. This KMS key's `Origin' must be `EXTERNAL'. You must
+%% also specify the wrapping algorithm and type of wrapping key (public key)
+%% that you will use to encrypt the key material. You cannot perform this
+%% operation on an asymmetric KMS key or on any KMS key in a different Amazon
+%% Web Services account.
 %%
 %% To import key material, you must use the public key and import token from
 %% the same response. These items are valid for 24 hours. The expiration date
@@ -1481,12 +1557,12 @@ get_key_rotation_status(Client, Input, Options)
 %% an expired token in an `ImportKeyMaterial' request. If your key and token
 %% expire, send another `GetParametersForImport' request.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:GetParametersForImport (key policy)
 %%
@@ -1504,51 +1580,51 @@ get_parameters_for_import(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetParametersForImport">>, Input, Options).
 
-%% @doc Returns the public key of an asymmetric CMK.
+%% @doc Returns the public key of an asymmetric KMS key.
 %%
-%% Unlike the private key of a asymmetric CMK, which never leaves AWS KMS
+%% Unlike the private key of a asymmetric KMS key, which never leaves KMS
 %% unencrypted, callers with `kms:GetPublicKey' permission can download the
-%% public key of an asymmetric CMK. You can share the public key to allow
-%% others to encrypt messages and verify signatures outside of AWS KMS. For
-%% information about symmetric and asymmetric CMKs, see Using Symmetric and
-%% Asymmetric CMKs in the AWS Key Management Service Developer Guide.
+%% public key of an asymmetric KMS key. You can share the public key to allow
+%% others to encrypt messages and verify signatures outside of KMS. For
+%% information about symmetric and asymmetric KMS keys, see Using Symmetric
+%% and Asymmetric KMS keys in the Key Management Service Developer Guide.
 %%
 %% You do not need to download the public key. Instead, you can use the
-%% public key within AWS KMS by calling the `Encrypt', `ReEncrypt', or
-%% `Verify' operations with the identifier of an asymmetric CMK. When you use
-%% the public key within AWS KMS, you benefit from the authentication,
-%% authorization, and logging that are part of every AWS KMS operation. You
-%% also reduce of risk of encrypting data that cannot be decrypted. These
-%% features are not effective outside of AWS KMS. For details, see Special
-%% Considerations for Downloading Public Keys.
+%% public key within KMS by calling the `Encrypt', `ReEncrypt', or `Verify'
+%% operations with the identifier of an asymmetric KMS key. When you use the
+%% public key within KMS, you benefit from the authentication, authorization,
+%% and logging that are part of every KMS operation. You also reduce of risk
+%% of encrypting data that cannot be decrypted. These features are not
+%% effective outside of KMS. For details, see Special Considerations for
+%% Downloading Public Keys.
 %%
-%% To help you use the public key safely outside of AWS KMS, `GetPublicKey'
+%% To help you use the public key safely outside of KMS, `GetPublicKey'
 %% returns important information about the public key in the response,
 %% including:
 %%
-%% <ul> <li> CustomerMasterKeySpec: The type of key material in the public
-%% key, such as `RSA_4096' or `ECC_NIST_P521'.
+%% <ul> <li> KeySpec: The type of key material in the public key, such as
+%% `RSA_4096' or `ECC_NIST_P521'.
 %%
 %% </li> <li> KeyUsage: Whether the key is used for encryption or signing.
 %%
 %% </li> <li> EncryptionAlgorithms or SigningAlgorithms: A list of the
 %% encryption algorithms or the signing algorithms for the key.
 %%
-%% </li> </ul> Although AWS KMS cannot enforce these restrictions on external
+%% </li> </ul> Although KMS cannot enforce these restrictions on external
 %% operations, it is crucial that you use this information to prevent the
 %% public key from being used improperly. For example, you can prevent a
 %% public signing key from being used encrypt data, or prevent a public key
-%% from being used with an encryption algorithm that is not supported by AWS
-%% KMS. You can also avoid errors, such as using the wrong signing algorithm
-%% in a verification operation.
+%% from being used with an encryption algorithm that is not supported by KMS.
+%% You can also avoid errors, such as using the wrong signing algorithm in a
+%% verification operation.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:GetPublicKey (key policy)
 %%
@@ -1560,17 +1636,17 @@ get_public_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetPublicKey">>, Input, Options).
 
-%% @doc Imports key material into an existing symmetric AWS KMS customer
-%% master key (CMK) that was created without key material.
+%% @doc Imports key material into an existing symmetric KMS KMS key that was
+%% created without key material.
 %%
-%% After you successfully import key material into a CMK, you can reimport
-%% the same key material into that CMK, but you cannot import different key
-%% material.
+%% After you successfully import key material into a KMS key, you can
+%% reimport the same key material into that KMS key, but you cannot import
+%% different key material.
 %%
-%% You cannot perform this operation on an asymmetric CMK or on any CMK in a
-%% different AWS account. For more information about creating CMKs with no
-%% key material and then importing key material, see Importing Key Material
-%% in the AWS Key Management Service Developer Guide.
+%% You cannot perform this operation on an asymmetric KMS key or on any KMS
+%% key in a different Amazon Web Services account. For more information about
+%% creating KMS keys with no key material and then importing key material,
+%% see Importing Key Material in the Key Management Service Developer Guide.
 %%
 %% Before using this operation, call `GetParametersForImport'. Its response
 %% includes a public key and an import token. Use the public key to encrypt
@@ -1579,12 +1655,12 @@ get_public_key(Client, Input, Options)
 %%
 %% When calling this operation, you must specify the following values:
 %%
-%% <ul> <li> The key ID or key ARN of a CMK with no key material. Its
+%% <ul> <li> The key ID or key ARN of a KMS key with no key material. Its
 %% `Origin' must be `EXTERNAL'.
 %%
-%% To create a CMK with no key material, call `CreateKey' and set the value
-%% of its `Origin' parameter to `EXTERNAL'. To get the `Origin' of a CMK,
-%% call `DescribeKey'.)
+%% To create a KMS key with no key material, call `CreateKey' and set the
+%% value of its `Origin' parameter to `EXTERNAL'. To get the `Origin' of a
+%% KMS key, call `DescribeKey'.)
 %%
 %% </li> <li> The encrypted key material. To get the public key to encrypt
 %% the key material, call `GetParametersForImport'.
@@ -1594,27 +1670,28 @@ get_public_key(Client, Input, Options)
 %% response.
 %%
 %% </li> <li> Whether the key material expires and if so, when. If you set an
-%% expiration date, AWS KMS deletes the key material from the CMK on the
-%% specified date, and the CMK becomes unusable. To use the CMK again, you
-%% must reimport the same key material. The only way to change an expiration
-%% date is by reimporting the same key material and specifying a new
-%% expiration date.
+%% expiration date, KMS deletes the key material from the KMS key on the
+%% specified date, and the KMS key becomes unusable. To use the KMS key
+%% again, you must reimport the same key material. The only way to change an
+%% expiration date is by reimporting the same key material and specifying a
+%% new expiration date.
 %%
-%% </li> </ul> When this operation is successful, the key state of the CMK
-%% changes from `PendingImport' to `Enabled', and you can use the CMK.
+%% </li> </ul> When this operation is successful, the key state of the KMS
+%% key changes from `PendingImport' to `Enabled', and you can use the KMS
+%% key.
 %%
 %% If this operation fails, use the exception to help determine the problem.
 %% If the error is related to the key material, the import token, or wrapping
 %% key, use `GetParametersForImport' to get a new public key and import token
-%% for the CMK and repeat the import procedure. For help, see How To Import
-%% Key Material in the AWS Key Management Service Developer Guide.
+%% for the KMS key and repeat the import procedure. For help, see How To
+%% Import Key Material in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:ImportKeyMaterial (key policy)
 %%
@@ -1632,31 +1709,33 @@ import_key_material(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ImportKeyMaterial">>, Input, Options).
 
-%% @doc Gets a list of aliases in the caller's AWS account and region.
+%% @doc Gets a list of aliases in the caller's Amazon Web Services account
+%% and region.
 %%
 %% For more information about aliases, see `CreateAlias'.
 %%
 %% By default, the `ListAliases' operation returns all aliases in the account
-%% and region. To get only the aliases associated with a particular customer
-%% master key (CMK), use the `KeyId' parameter.
+%% and region. To get only the aliases associated with a particular KMS key,
+%% use the `KeyId' parameter.
 %%
 %% The `ListAliases' response can include aliases that you created and
-%% associated with your customer managed CMKs, and aliases that AWS created
-%% and associated with AWS managed CMKs in your account. You can recognize
-%% AWS aliases because their names have the format `aws/<service-name>', such
-%% as `aws/dynamodb'.
+%% associated with your customer managed keys, and aliases that Amazon Web
+%% Services created and associated with Amazon Web Services managed keys in
+%% your account. You can recognize Amazon Web Services aliases because their
+%% names have the format `aws/<service-name>', such as `aws/dynamodb'.
 %%
 %% The response might also include aliases that have no `TargetKeyId' field.
-%% These are predefined aliases that AWS has created but has not yet
-%% associated with a CMK. Aliases that AWS creates in your account, including
-%% predefined aliases, do not count against your AWS KMS aliases quota.
+%% These are predefined aliases that Amazon Web Services has created but has
+%% not yet associated with a KMS key. Aliases that Amazon Web Services
+%% creates in your account, including predefined aliases, do not count
+%% against your KMS aliases quota.
 %%
-%% Cross-account use: No. `ListAliases' does not return aliases in other AWS
-%% accounts.
+%% Cross-account use: No. `ListAliases' does not return aliases in other
+%% Amazon Web Services accounts.
 %%
 %% Required permissions: kms:ListAliases (IAM policy)
 %%
-%% For details, see Controlling access to aliases in the AWS Key Management
+%% For details, see Controlling access to aliases in the Key Management
 %% Service Developer Guide.
 %%
 %% Related operations:
@@ -1675,20 +1754,25 @@ list_aliases(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAliases">>, Input, Options).
 
-%% @doc Gets a list of all grants for the specified customer master key
-%% (CMK).
+%% @doc Gets a list of all grants for the specified KMS key.
 %%
-%% You must specify the CMK in all requests. You can filter the grant list by
-%% grant ID or grantee principal.
+%% You must specify the KMS key in all requests. You can filter the grant
+%% list by grant ID or grantee principal.
+%%
+%% For detailed information about grants, including grant terminology, see
+%% Using grants in the Key Management Service Developer Guide . For examples
+%% of working with grants in several programming languages, see Programming
+%% grants.
 %%
 %% The `GranteePrincipal' field in the `ListGrants' response usually contains
 %% the user or role designated as the grantee principal in the grant.
-%% However, when the grantee principal in the grant is an AWS service, the
-%% `GranteePrincipal' field contains the service principal, which might
-%% represent several different grantee principals.
+%% However, when the grantee principal in the grant is an Amazon Web Services
+%% service, the `GranteePrincipal' field contains the service principal,
+%% which might represent several different grantee principals.
 %%
-%% Cross-account use: Yes. To perform this operation on a CMK in a different
-%% AWS account, specify the key ARN in the value of the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation on a KMS key in a
+%% different Amazon Web Services account, specify the key ARN in the value of
+%% the `KeyId' parameter.
 %%
 %% Required permissions: kms:ListGrants (key policy)
 %%
@@ -1710,15 +1794,14 @@ list_grants(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListGrants">>, Input, Options).
 
-%% @doc Gets the names of the key policies that are attached to a customer
-%% master key (CMK).
+%% @doc Gets the names of the key policies that are attached to a KMS key.
 %%
 %% This operation is designed to get policy names that you can use in a
 %% `GetKeyPolicy' operation. However, the only valid policy name is
 %% `default'.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:ListKeyPolicies (key policy)
 %%
@@ -1736,11 +1819,11 @@ list_key_policies(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListKeyPolicies">>, Input, Options).
 
-%% @doc Gets a list of all customer master keys (CMKs) in the caller's AWS
+%% @doc Gets a list of all KMS keys in the caller's Amazon Web Services
 %% account and Region.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:ListKeys (IAM policy)
 %%
@@ -1762,20 +1845,24 @@ list_keys(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListKeys">>, Input, Options).
 
-%% @doc Returns all tags on the specified customer master key (CMK).
+%% @doc Returns all tags on the specified KMS key.
 %%
 %% For general information about tags, including the format and syntax, see
-%% Tagging AWS resources in the Amazon Web Services General Reference. For
-%% information about using tags in AWS KMS, see Tagging keys.
+%% Tagging Amazon Web Services resources in the Amazon Web Services General
+%% Reference. For information about using tags in KMS, see Tagging keys.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:ListResourceTags (key policy)
 %%
 %% Related operations:
 %%
-%% <ul> <li> `TagResource'
+%% <ul> <li> `CreateKey'
+%%
+%% </li> <li> `ReplicateKey'
+%%
+%% </li> <li> `TagResource'
 %%
 %% </li> <li> `UntagResource'
 %%
@@ -1787,23 +1874,28 @@ list_resource_tags(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListResourceTags">>, Input, Options).
 
-%% @doc Returns all grants in which the specified principal is the
-%% `RetiringPrincipal' in the grant.
+%% @doc Returns information about all grants in the Amazon Web Services
+%% account and Region that have the specified retiring principal.
 %%
-%% You can specify any principal in your AWS account. The grants that are
-%% returned include grants for CMKs in your AWS account and other AWS
-%% accounts.
+%% You can specify any principal in your Amazon Web Services account. The
+%% grants that are returned include grants for KMS keys in your Amazon Web
+%% Services account and other Amazon Web Services accounts. You might use
+%% this operation to determine which grants you may retire. To retire a
+%% grant, use the `RetireGrant' operation.
 %%
-%% You might use this operation to determine which grants you may retire. To
-%% retire a grant, use the `RetireGrant' operation.
+%% For detailed information about grants, including grant terminology, see
+%% Using grants in the Key Management Service Developer Guide . For examples
+%% of working with grants in several programming languages, see Programming
+%% grants.
 %%
-%% Cross-account use: You must specify a principal in your AWS account.
-%% However, this operation can return grants in any AWS account. You do not
-%% need `kms:ListRetirableGrants' permission (or any other additional
-%% permission) in any AWS account other than your own.
+%% Cross-account use: You must specify a principal in your Amazon Web
+%% Services account. However, this operation can return grants in any Amazon
+%% Web Services account. You do not need `kms:ListRetirableGrants' permission
+%% (or any other additional permission) in any Amazon Web Services account
+%% other than your own.
 %%
-%% Required permissions: kms:ListRetirableGrants (IAM policy) in your AWS
-%% account.
+%% Required permissions: kms:ListRetirableGrants (IAM policy) in your Amazon
+%% Web Services account.
 %%
 %% Related operations:
 %%
@@ -1823,16 +1915,17 @@ list_retirable_grants(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListRetirableGrants">>, Input, Options).
 
-%% @doc Attaches a key policy to the specified customer master key (CMK).
+%% @doc Attaches a key policy to the specified KMS key.
 %%
-%% For more information about key policies, see Key Policies in the AWS Key
+%% For more information about key policies, see Key Policies in the Key
 %% Management Service Developer Guide. For help writing and formatting a JSON
-%% policy document, see the IAM JSON Policy Reference in the IAM User Guide .
-%% For examples of adding a key policy in multiple programming languages, see
-%% Setting a key policy in the AWS Key Management Service Developer Guide.
+%% policy document, see the IAM JSON Policy Reference in the Identity and
+%% Access Management User Guide . For examples of adding a key policy in
+%% multiple programming languages, see Setting a key policy in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:PutKeyPolicy (key policy)
 %%
@@ -1844,79 +1937,83 @@ put_key_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutKeyPolicy">>, Input, Options).
 
-%% @doc Decrypts ciphertext and then reencrypts it entirely within AWS KMS.
+%% @doc Decrypts ciphertext and then reencrypts it entirely within KMS.
 %%
-%% You can use this operation to change the customer master key (CMK) under
-%% which data is encrypted, such as when you manually rotate a CMK or change
-%% the CMK that protects a ciphertext. You can also use it to reencrypt
-%% ciphertext under the same CMK, such as to change the encryption context of
-%% a ciphertext.
+%% You can use this operation to change the KMS key under which data is
+%% encrypted, such as when you manually rotate a KMS key or change the KMS
+%% key that protects a ciphertext. You can also use it to reencrypt
+%% ciphertext under the same KMS key, such as to change the encryption
+%% context of a ciphertext.
 %%
 %% The `ReEncrypt' operation can decrypt ciphertext that was encrypted by
-%% using an AWS KMS CMK in an AWS KMS operation, such as `Encrypt' or
+%% using an KMS KMS key in an KMS operation, such as `Encrypt' or
 %% `GenerateDataKey'. It can also decrypt ciphertext that was encrypted by
-%% using the public key of an asymmetric CMK outside of AWS KMS. However, it
-%% cannot decrypt ciphertext produced by other libraries, such as the AWS
-%% Encryption SDK or Amazon S3 client-side encryption. These libraries return
-%% a ciphertext format that is incompatible with AWS KMS.
+%% using the public key of an asymmetric KMS key outside of KMS. However, it
+%% cannot decrypt ciphertext produced by other libraries, such as the Amazon
+%% Web Services Encryption SDK or Amazon S3 client-side encryption. These
+%% libraries return a ciphertext format that is incompatible with KMS.
 %%
 %% When you use the `ReEncrypt' operation, you need to provide information
 %% for the decrypt operation and the subsequent encrypt operation.
 %%
-%% <ul> <li> If your ciphertext was encrypted under an asymmetric CMK, you
-%% must use the `SourceKeyId' parameter to identify the CMK that encrypted
-%% the ciphertext. You must also supply the encryption algorithm that was
-%% used. This information is required to decrypt the data.
+%% <ul> <li> If your ciphertext was encrypted under an asymmetric KMS key,
+%% you must use the `SourceKeyId' parameter to identify the KMS key that
+%% encrypted the ciphertext. You must also supply the encryption algorithm
+%% that was used. This information is required to decrypt the data.
 %%
-%% </li> <li> If your ciphertext was encrypted under a symmetric CMK, the
-%% `SourceKeyId' parameter is optional. AWS KMS can get this information from
+%% </li> <li> If your ciphertext was encrypted under a symmetric KMS key, the
+%% `SourceKeyId' parameter is optional. KMS can get this information from
 %% metadata that it adds to the symmetric ciphertext blob. This feature adds
 %% durability to your implementation by ensuring that authorized users can
 %% decrypt ciphertext decades after it was encrypted, even if they've lost
-%% track of the CMK ID. However, specifying the source CMK is always
+%% track of the key ID. However, specifying the source KMS key is always
 %% recommended as a best practice. When you use the `SourceKeyId' parameter
-%% to specify a CMK, AWS KMS uses only the CMK you specify. If the ciphertext
-%% was encrypted under a different CMK, the `ReEncrypt' operation fails. This
-%% practice ensures that you use the CMK that you intend.
+%% to specify a KMS key, KMS uses only the KMS key you specify. If the
+%% ciphertext was encrypted under a different KMS key, the `ReEncrypt'
+%% operation fails. This practice ensures that you use the KMS key that you
+%% intend.
 %%
 %% </li> <li> To reencrypt the data, you must use the `DestinationKeyId'
-%% parameter specify the CMK that re-encrypts the data after it is decrypted.
-%% You can select a symmetric or asymmetric CMK. If the destination CMK is an
-%% asymmetric CMK, you must also provide the encryption algorithm. The
-%% algorithm that you choose must be compatible with the CMK.
+%% parameter specify the KMS key that re-encrypts the data after it is
+%% decrypted. You can select a symmetric or asymmetric KMS key. If the
+%% destination KMS key is an asymmetric KMS key, you must also provide the
+%% encryption algorithm. The algorithm that you choose must be compatible
+%% with the KMS key.
 %%
-%% When you use an asymmetric CMK to encrypt or reencrypt data, be sure to
-%% record the CMK and encryption algorithm that you choose. You will be
-%% required to provide the same CMK and encryption algorithm when you decrypt
-%% the data. If the CMK and algorithm do not match the values used to encrypt
-%% the data, the decrypt operation fails.
+%% When you use an asymmetric KMS key to encrypt or reencrypt data, be sure
+%% to record the KMS key and encryption algorithm that you choose. You will
+%% be required to provide the same KMS key and encryption algorithm when you
+%% decrypt the data. If the KMS key and algorithm do not match the values
+%% used to encrypt the data, the decrypt operation fails.
 %%
-%% You are not required to supply the CMK ID and encryption algorithm when
-%% you decrypt with symmetric CMKs because AWS KMS stores this information in
-%% the ciphertext blob. AWS KMS cannot store metadata in ciphertext generated
+%% You are not required to supply the key ID and encryption algorithm when
+%% you decrypt with symmetric KMS keys because KMS stores this information in
+%% the ciphertext blob. KMS cannot store metadata in ciphertext generated
 %% with asymmetric keys. The standard format for asymmetric key ciphertext
 %% does not include configurable fields.
 %%
-%% </li> </ul> The CMK that you use for this operation must be in a
-%% compatible key state. For details, see How Key State Affects Use of a
-%% Customer Master Key in the AWS Key Management Service Developer Guide.
+%% </li> </ul> The KMS key that you use for this operation must be in a
+%% compatible key state. For details, see Key state: Effect on your KMS key
+%% in the Key Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. The source CMK and destination CMK can be in
-%% different AWS accounts. Either or both CMKs can be in a different account
-%% than the caller.
+%% Cross-account use: Yes. The source KMS key and destination KMS key can be
+%% in different Amazon Web Services accounts. Either or both KMS keys can be
+%% in a different account than the caller. To specify a KMS key in a
+%% different account, you must use its key ARN or alias ARN.
 %%
 %% Required permissions:
 %%
-%% <ul> <li> kms:ReEncryptFrom permission on the source CMK (key policy)
+%% <ul> <li> kms:ReEncryptFrom permission on the source KMS key (key policy)
 %%
-%% </li> <li> kms:ReEncryptTo permission on the destination CMK (key policy)
+%% </li> <li> kms:ReEncryptTo permission on the destination KMS key (key
+%% policy)
 %%
-%% </li> </ul> To permit reencryption from or to a CMK, include the
+%% </li> </ul> To permit reencryption from or to a KMS key, include the
 %% `"kms:ReEncrypt*"' permission in your key policy. This permission is
 %% automatically included in the key policy when you use the console to
-%% create a CMK. But you must include it manually when you create a CMK
-%% programmatically or when you use the `PutKeyPolicy' operation to set a key
-%% policy.
+%% create a KMS key. But you must include it manually when you create a KMS
+%% key programmatically or when you use the `PutKeyPolicy' operation to set a
+%% key policy.
 %%
 %% Related operations:
 %%
@@ -1936,32 +2033,113 @@ re_encrypt(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ReEncrypt">>, Input, Options).
 
-%% @doc Retires a grant.
+%% @doc Replicates a multi-Region key into the specified Region.
 %%
-%% To clean up, you can retire a grant when you're done using it. You should
-%% revoke a grant when you intend to actively deny operations that depend on
-%% it. The following are permitted to call this API:
+%% This operation creates a multi-Region replica key based on a multi-Region
+%% primary key in a different Region of the same Amazon Web Services
+%% partition. You can create multiple replicas of a primary key, but each
+%% must be in a different Region. To create a multi-Region primary key, use
+%% the `CreateKey' operation.
 %%
-%% <ul> <li> The AWS account (root user) under which the grant was created
+%% This operation supports multi-Region keys, an KMS feature that lets you
+%% create multiple interoperable KMS keys in different Amazon Web Services
+%% Regions. Because these KMS keys have the same key ID, key material, and
+%% other metadata, you can use them interchangeably to encrypt data in one
+%% Amazon Web Services Region and decrypt it in a different Amazon Web
+%% Services Region without re-encrypting the data or making a cross-Region
+%% call. For more information about multi-Region keys, see Using multi-Region
+%% keys in the Key Management Service Developer Guide.
 %%
-%% </li> <li> The `RetiringPrincipal', if present in the grant
+%% A replica key is a fully-functional KMS key that can be used independently
+%% of its primary and peer replica keys. A primary key and its replica keys
+%% share properties that make them interoperable. They have the same key ID
+%% and key material. They also have the same key spec, key usage, key
+%% material origin, and automatic key rotation status. KMS automatically
+%% synchronizes these shared properties among related multi-Region keys. All
+%% other properties of a replica key can differ, including its key policy,
+%% tags, aliases, and key state. KMS pricing and quotas for KMS keys apply to
+%% each primary key and replica key.
 %%
-%% </li> <li> The `GranteePrincipal', if `RetireGrant' is an operation
-%% specified in the grant
-%%
-%% </li> </ul> You must identify the grant to retire by its grant token or by
-%% a combination of the grant ID and the Amazon Resource Name (ARN) of the
-%% customer master key (CMK). A grant token is a unique variable-length
-%% base64-encoded string. A grant ID is a 64 character unique identifier of a
-%% grant. The `CreateGrant' operation returns both.
-%%
-%% Cross-account use: Yes. You can retire a grant on a CMK in a different AWS
-%% account.
-%%
-%% Required permissions:: Permission to retire a grant is specified in the
-%% grant. You cannot control access to this operation in a policy. For more
-%% information, see Using grants in the AWS Key Management Service Developer
+%% When this operation completes, the new replica key has a transient key
+%% state of `Creating'. This key state changes to `Enabled' (or
+%% `PendingImport') after a few seconds when the process of creating the new
+%% replica key is complete. While the key state is `Creating', you can manage
+%% key, but you cannot yet use it in cryptographic operations. If you are
+%% creating and using the replica key programmatically, retry on
+%% `KMSInvalidStateException' or call `DescribeKey' to check its `KeyState'
+%% value before using it. For details about the `Creating' key state, see Key
+%% state: Effect on your KMS key in the Key Management Service Developer
 %% Guide.
+%%
+%% The CloudTrail log of a `ReplicateKey' operation records a `ReplicateKey'
+%% operation in the primary key's Region and a `CreateKey' operation in the
+%% replica key's Region.
+%%
+%% If you replicate a multi-Region primary key with imported key material,
+%% the replica key is created with no key material. You must import the same
+%% key material that you imported into the primary key. For details, see
+%% Importing key material into multi-Region keys in the Key Management
+%% Service Developer Guide.
+%%
+%% To convert a replica key to a primary key, use the `UpdatePrimaryRegion'
+%% operation.
+%%
+%% `ReplicateKey' uses different default values for the `KeyPolicy' and
+%% `Tags' parameters than those used in the KMS console. For details, see the
+%% parameter descriptions.
+%%
+%% Cross-account use: No. You cannot use this operation to create a replica
+%% key in a different Amazon Web Services account.
+%%
+%% Required permissions:
+%%
+%% <ul> <li> `kms:ReplicateKey' on the primary key (in the primary key's
+%% Region). Include this permission in the primary key's key policy.
+%%
+%% </li> <li> `kms:CreateKey' in an IAM policy in the replica Region.
+%%
+%% </li> <li> To use the `Tags' parameter, `kms:TagResource' in an IAM policy
+%% in the replica Region.
+%%
+%% </li> </ul> Related operations
+%%
+%% <ul> <li> `CreateKey'
+%%
+%% </li> <li> `UpdatePrimaryRegion'
+%%
+%% </li> </ul>
+replicate_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    replicate_key(Client, Input, []).
+replicate_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ReplicateKey">>, Input, Options).
+
+%% @doc Deletes a grant.
+%%
+%% Typically, you retire a grant when you no longer need its permissions. To
+%% identify the grant to retire, use a grant token, or both the grant ID and
+%% a key identifier (key ID or key ARN) of the KMS key. The `CreateGrant'
+%% operation returns both values.
+%%
+%% This operation can be called by the retiring principal for a grant, by the
+%% grantee principal if the grant allows the `RetireGrant' operation, and by
+%% the Amazon Web Services account (root user) in which the grant is created.
+%% It can also be called by principals to whom permission for retiring a
+%% grant is delegated. For details, see Retiring and revoking grants in the
+%% Key Management Service Developer Guide.
+%%
+%% For detailed information about grants, including grant terminology, see
+%% Using grants in the Key Management Service Developer Guide . For examples
+%% of working with grants in several programming languages, see Programming
+%% grants.
+%%
+%% Cross-account use: Yes. You can retire a grant on a KMS key in a different
+%% Amazon Web Services account.
+%%
+%% Required permissions::Permission to retire a grant is determined primarily
+%% by the grant. For details, see Retiring and revoking grants in the Key
+%% Management Service Developer Guide.
 %%
 %% Related operations:
 %%
@@ -1981,15 +2159,27 @@ retire_grant(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RetireGrant">>, Input, Options).
 
-%% @doc Revokes the specified grant for the specified customer master key
-%% (CMK).
+%% @doc Deletes the specified grant.
 %%
-%% You can revoke a grant to actively deny operations that depend on it.
+%% You revoke a grant to terminate the permissions that the grant allows. For
+%% more information, see Retiring and revoking grants in the Key Management
+%% Service Developer Guide .
 %%
-%% Cross-account use: Yes. To perform this operation on a CMK in a different
-%% AWS account, specify the key ARN in the value of the `KeyId' parameter.
+%% When you create, retire, or revoke a grant, there might be a brief delay,
+%% usually less than five minutes, until the grant is available throughout
+%% KMS. This state is known as eventual consistency. For details, see
+%% Eventual consistency in the Key Management Service Developer Guide .
 %%
-%% Required permissions: kms:RevokeGrant (key policy)
+%% For detailed information about grants, including grant terminology, see
+%% Using grants in the Key Management Service Developer Guide . For examples
+%% of working with grants in several programming languages, see Programming
+%% grants.
+%%
+%% Cross-account use: Yes. To perform this operation on a KMS key in a
+%% different Amazon Web Services account, specify the key ARN in the value of
+%% the `KeyId' parameter.
+%%
+%% Required permissions: kms:RevokeGrant (key policy).
 %%
 %% Related operations:
 %%
@@ -2009,36 +2199,48 @@ revoke_grant(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RevokeGrant">>, Input, Options).
 
-%% @doc Schedules the deletion of a customer master key (CMK).
+%% @doc Schedules the deletion of a KMS key.
 %%
-%% You may provide a waiting period, specified in days, before deletion
-%% occurs. If you do not provide a waiting period, the default period of 30
-%% days is used. When this operation is successful, the key state of the CMK
-%% changes to `PendingDeletion'. Before the waiting period ends, you can use
-%% `CancelKeyDeletion' to cancel the deletion of the CMK. After the waiting
-%% period ends, AWS KMS deletes the CMK and all AWS KMS data associated with
-%% it, including all aliases that refer to it.
+%% By default, KMS applies a waiting period of 30 days, but you can specify a
+%% waiting period of 7-30 days. When this operation is successful, the key
+%% state of the KMS key changes to `PendingDeletion' and the key can't be
+%% used in any cryptographic operations. It remains in this state for the
+%% duration of the waiting period. Before the waiting period ends, you can
+%% use `CancelKeyDeletion' to cancel the deletion of the KMS key. After the
+%% waiting period ends, KMS deletes the KMS key, its key material, and all
+%% KMS data associated with it, including all aliases that refer to it.
 %%
-%% Deleting a CMK is a destructive and potentially dangerous operation. When
-%% a CMK is deleted, all data that was encrypted under the CMK is
-%% unrecoverable. To prevent the use of a CMK without deleting it, use
-%% `DisableKey'.
+%% Deleting a KMS key is a destructive and potentially dangerous operation.
+%% When a KMS key is deleted, all data that was encrypted under the KMS key
+%% is unrecoverable. (The only exception is a multi-Region replica key.) To
+%% prevent the use of a KMS key without deleting it, use `DisableKey'.
 %%
-%% If you schedule deletion of a CMK from a custom key store, when the
-%% waiting period expires, `ScheduleKeyDeletion' deletes the CMK from AWS
-%% KMS. Then AWS KMS makes a best effort to delete the key material from the
-%% associated AWS CloudHSM cluster. However, you might need to manually
-%% delete the orphaned key material from the cluster and its backups.
+%% If you schedule deletion of a KMS key from a custom key store, when the
+%% waiting period expires, `ScheduleKeyDeletion' deletes the KMS key from
+%% KMS. Then KMS makes a best effort to delete the key material from the
+%% associated CloudHSM cluster. However, you might need to manually delete
+%% the orphaned key material from the cluster and its backups.
 %%
-%% For more information about scheduling a CMK for deletion, see Deleting
-%% Customer Master Keys in the AWS Key Management Service Developer Guide.
+%% You can schedule the deletion of a multi-Region primary key and its
+%% replica keys at any time. However, KMS will not delete a multi-Region
+%% primary key with existing replica keys. If you schedule the deletion of a
+%% primary key with replicas, its key state changes to
+%% `PendingReplicaDeletion' and it cannot be replicated or used in
+%% cryptographic operations. This status can continue indefinitely. When the
+%% last of its replicas keys is deleted (not just scheduled), the key state
+%% of the primary key changes to `PendingDeletion' and its waiting period
+%% (`PendingWindowInDays') begins. For details, see Deleting multi-Region
+%% keys in the Key Management Service Developer Guide.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% For more information about scheduling a KMS key for deletion, see Deleting
+%% KMS keys in the Key Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
+%%
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:ScheduleKeyDeletion (key policy)
 %%
@@ -2057,26 +2259,26 @@ schedule_key_deletion(Client, Input, Options)
     request(Client, <<"ScheduleKeyDeletion">>, Input, Options).
 
 %% @doc Creates a digital signature for a message or message digest by using
-%% the private key in an asymmetric CMK.
+%% the private key in an asymmetric KMS key.
 %%
 %% To verify the signature, use the `Verify' operation, or use the public key
-%% in the same asymmetric CMK outside of AWS KMS. For information about
-%% symmetric and asymmetric CMKs, see Using Symmetric and Asymmetric CMKs in
-%% the AWS Key Management Service Developer Guide.
+%% in the same asymmetric KMS key outside of KMS. For information about
+%% symmetric and asymmetric KMS keys, see Using Symmetric and Asymmetric KMS
+%% keys in the Key Management Service Developer Guide.
 %%
 %% Digital signatures are generated and verified by using asymmetric key
-%% pair, such as an RSA or ECC pair that is represented by an asymmetric
-%% customer master key (CMK). The key owner (or an authorized user) uses
-%% their private key to sign a message. Anyone with the public key can verify
-%% that the message was signed with that particular private key and that the
-%% message hasn't changed since it was signed.
+%% pair, such as an RSA or ECC pair that is represented by an asymmetric KMS
+%% key. The key owner (or an authorized user) uses their private key to sign
+%% a message. Anyone with the public key can verify that the message was
+%% signed with that particular private key and that the message hasn't
+%% changed since it was signed.
 %%
 %% To use the `Sign' operation, provide the following information:
 %%
-%% <ul> <li> Use the `KeyId' parameter to identify an asymmetric CMK with a
-%% `KeyUsage' value of `SIGN_VERIFY'. To get the `KeyUsage' value of a CMK,
-%% use the `DescribeKey' operation. The caller must have `kms:Sign'
-%% permission on the CMK.
+%% <ul> <li> Use the `KeyId' parameter to identify an asymmetric KMS key with
+%% a `KeyUsage' value of `SIGN_VERIFY'. To get the `KeyUsage' value of a KMS
+%% key, use the `DescribeKey' operation. The caller must have `kms:Sign'
+%% permission on the KMS key.
 %%
 %% </li> <li> Use the `Message' parameter to specify the message or message
 %% digest to sign. You can submit messages of up to 4096 bytes. To sign a
@@ -2084,22 +2286,22 @@ schedule_key_deletion(Client, Input, Options)
 %% the hash digest in the `Message' parameter. To indicate whether the
 %% message is a full message or a digest, use the `MessageType' parameter.
 %%
-%% </li> <li> Choose a signing algorithm that is compatible with the CMK.
+%% </li> <li> Choose a signing algorithm that is compatible with the KMS key.
 %%
-%% </li> </ul> When signing a message, be sure to record the CMK and the
+%% </li> </ul> When signing a message, be sure to record the KMS key and the
 %% signing algorithm. This information is required to verify the signature.
 %%
 %% To verify the signature that this operation generates, use the `Verify'
 %% operation. Or use the `GetPublicKey' operation to download the public key
-%% and then use the public key to verify the signature outside of AWS KMS.
+%% and then use the public key to verify the signature outside of KMS.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:Sign (key policy)
 %%
@@ -2111,35 +2313,47 @@ sign(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"Sign">>, Input, Options).
 
-%% @doc Adds or edits tags on a customer managed CMK.
+%% @doc Adds or edits tags on a customer managed key.
+%%
+%% Tagging or untagging a KMS key can allow or deny permission to the KMS
+%% key. For details, see Using ABAC in KMS in the Key Management Service
+%% Developer Guide.
 %%
 %% Each tag consists of a tag key and a tag value, both of which are
-%% case-sensitive strings. The tag value can be an empty (null) string.
+%% case-sensitive strings. The tag value can be an empty (null) string. To
+%% add a tag, specify a new tag key and a tag value. To edit a tag, specify
+%% an existing tag key and a new tag value.
 %%
-%% To add a tag, specify a new tag key and a tag value. To edit a tag,
-%% specify an existing tag key and a new tag value.
+%% You can use this operation to tag a customer managed key, but you cannot
+%% tag an Amazon Web Services managed key, an Amazon Web Services owned key,
+%% a custom key store, or an alias.
 %%
-%% You can use this operation to tag a customer managed CMK, but you cannot
-%% tag an AWS managed CMK, an AWS owned CMK, or an alias.
+%% You can also add tags to a KMS key while creating it (`CreateKey') or
+%% replicating it (`ReplicateKey').
 %%
-%% For general information about tags, including the format and syntax, see
-%% Tagging AWS resources in the Amazon Web Services General Reference. For
-%% information about using tags in AWS KMS, see Tagging keys.
+%% For information about using tags in KMS, see Tagging keys. For general
+%% information about tags, including the format and syntax, see Tagging
+%% Amazon Web Services resources in the Amazon Web Services General
+%% Reference.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:TagResource (key policy)
 %%
 %% Related operations
 %%
-%% <ul> <li> `UntagResource'
+%% <ul> <li> `CreateKey'
 %%
 %% </li> <li> `ListResourceTags'
+%%
+%% </li> <li> `ReplicateKey'
+%%
+%% </li> <li> `UntagResource'
 %%
 %% </li> </ul>
 tag_resource(Client, Input)
@@ -2149,33 +2363,42 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Deletes tags from a customer managed CMK.
+%% @doc Deletes tags from a customer managed key.
 %%
-%% To delete a tag, specify the tag key and the CMK.
+%% To delete a tag, specify the tag key and the KMS key.
+%%
+%% Tagging or untagging a KMS key can allow or deny permission to the KMS
+%% key. For details, see Using ABAC in KMS in the Key Management Service
+%% Developer Guide.
 %%
 %% When it succeeds, the `UntagResource' operation doesn't return any output.
-%% Also, if the specified tag key isn't found on the CMK, it doesn't throw an
-%% exception or return a response. To confirm that the operation worked, use
-%% the `ListResourceTags' operation.
+%% Also, if the specified tag key isn't found on the KMS key, it doesn't
+%% throw an exception or return a response. To confirm that the operation
+%% worked, use the `ListResourceTags' operation.
 %%
-%% For general information about tags, including the format and syntax, see
-%% Tagging AWS resources in the Amazon Web Services General Reference. For
-%% information about using tags in AWS KMS, see Tagging keys.
+%% For information about using tags in KMS, see Tagging keys. For general
+%% information about tags, including the format and syntax, see Tagging
+%% Amazon Web Services resources in the Amazon Web Services General
+%% Reference.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:UntagResource (key policy)
 %%
 %% Related operations
 %%
-%% <ul> <li> `TagResource'
+%% <ul> <li> `CreateKey'
 %%
 %% </li> <li> `ListResourceTags'
+%%
+%% </li> <li> `ReplicateKey'
+%%
+%% </li> <li> `TagResource'
 %%
 %% </li> </ul>
 untag_resource(Client, Input)
@@ -2185,17 +2408,20 @@ untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
 
-%% @doc Associates an existing AWS KMS alias with a different customer master
-%% key (CMK).
+%% @doc Associates an existing KMS alias with a different KMS key.
 %%
-%% Each alias is associated with only one CMK at a time, although a CMK can
-%% have multiple aliases. The alias and the CMK must be in the same AWS
-%% account and region.
+%% Each alias is associated with only one KMS key at a time, although a KMS
+%% key can have multiple aliases. The alias and the KMS key must be in the
+%% same Amazon Web Services account and Region.
 %%
-%% The current and new CMK must be the same type (both symmetric or both
+%% Adding, deleting, or updating an alias can allow or deny permission to the
+%% KMS key. For details, see Using ABAC in KMS in the Key Management Service
+%% Developer Guide.
+%%
+%% The current and new KMS key must be the same type (both symmetric or both
 %% asymmetric), and they must have the same key usage (`ENCRYPT_DECRYPT' or
 %% `SIGN_VERIFY'). This restriction prevents errors in code that uses
-%% aliases. If you must assign an alias to a different type of CMK, use
+%% aliases. If you must assign an alias to a different type of KMS key, use
 %% `DeleteAlias' to delete the old alias and `CreateAlias' to create a new
 %% alias.
 %%
@@ -2203,27 +2429,28 @@ untag_resource(Client, Input, Options)
 %% name, use `DeleteAlias' to delete the old alias and `CreateAlias' to
 %% create a new alias.
 %%
-%% Because an alias is not a property of a CMK, you can create, update, and
-%% delete the aliases of a CMK without affecting the CMK. Also, aliases do
-%% not appear in the response from the `DescribeKey' operation. To get the
-%% aliases of all CMKs in the account, use the `ListAliases' operation.
+%% Because an alias is not a property of a KMS key, you can create, update,
+%% and delete the aliases of a KMS key without affecting the KMS key. Also,
+%% aliases do not appear in the response from the `DescribeKey' operation. To
+%% get the aliases of all KMS keys in the account, use the `ListAliases'
+%% operation.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions
 %%
 %% <ul> <li> kms:UpdateAlias on the alias (IAM policy).
 %%
-%% </li> <li> kms:UpdateAlias on the current CMK (key policy).
+%% </li> <li> kms:UpdateAlias on the current KMS key (key policy).
 %%
-%% </li> <li> kms:UpdateAlias on the new CMK (key policy).
+%% </li> <li> kms:UpdateAlias on the new KMS key (key policy).
 %%
-%% </li> </ul> For details, see Controlling access to aliases in the AWS Key
+%% </li> </ul> For details, see Controlling access to aliases in the Key
 %% Management Service Developer Guide.
 %%
 %% Related operations:
@@ -2254,34 +2481,35 @@ update_alias(Client, Input, Options)
 %% To find the connection state of a custom key store, use the
 %% `DescribeCustomKeyStores' operation.
 %%
-%% Use the parameters of `UpdateCustomKeyStore' to edit your keystore
+%% The `CustomKeyStoreId' parameter is required in all commands. Use the
+%% other parameters of `UpdateCustomKeyStore' to edit your key store
 %% settings.
 %%
-%% <ul> <li> Use the NewCustomKeyStoreName parameter to change the friendly
+%% <ul> <li> Use the `NewCustomKeyStoreName' parameter to change the friendly
 %% name of the custom key store to the value that you specify.
 %%
-%% </li> <li> Use the KeyStorePassword parameter tell AWS KMS the current
-%% password of the `kmsuser' crypto user (CU) in the associated AWS CloudHSM
+%% </li> <li> Use the `KeyStorePassword' parameter tell KMS the current
+%% password of the `kmsuser' crypto user (CU) in the associated CloudHSM
 %% cluster. You can use this parameter to fix connection failures that occur
-%% when AWS KMS cannot log into the associated cluster because the `kmsuser'
-%% password has changed. This value does not change the password in the AWS
+%% when KMS cannot log into the associated cluster because the `kmsuser'
+%% password has changed. This value does not change the password in the
 %% CloudHSM cluster.
 %%
-%% </li> <li> Use the CloudHsmClusterId parameter to associate the custom key
-%% store with a different, but related, AWS CloudHSM cluster. You can use
-%% this parameter to repair a custom key store if its AWS CloudHSM cluster
+%% </li> <li> Use the `CloudHsmClusterId' parameter to associate the custom
+%% key store with a different, but related, CloudHSM cluster. You can use
+%% this parameter to repair a custom key store if its CloudHSM cluster
 %% becomes corrupted or is deleted, or when you need to create or restore a
 %% cluster from a backup.
 %%
 %% </li> </ul> If the operation succeeds, it returns a JSON object with no
 %% properties.
 %%
-%% This operation is part of the Custom Key Store feature feature in AWS KMS,
-%% which combines the convenience and extensive integration of AWS KMS with
-%% the isolation and control of a single-tenant key store.
+%% This operation is part of the Custom Key Store feature feature in KMS,
+%% which combines the convenience and extensive integration of KMS with the
+%% isolation and control of a single-tenant key store.
 %%
 %% Cross-account use: No. You cannot perform this operation on a custom key
-%% store in a different AWS account.
+%% store in a different Amazon Web Services account.
 %%
 %% Required permissions: kms:UpdateCustomKeyStore (IAM policy)
 %%
@@ -2305,16 +2533,16 @@ update_custom_key_store(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateCustomKeyStore">>, Input, Options).
 
-%% @doc Updates the description of a customer master key (CMK).
+%% @doc Updates the description of a KMS key.
 %%
-%% To see the description of a CMK, use `DescribeKey'.
+%% To see the description of a KMS key, use `DescribeKey'.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: No. You cannot perform this operation on a CMK in a
-%% different AWS account.
+%% Cross-account use: No. You cannot perform this operation on a KMS key in a
+%% different Amazon Web Services account.
 %%
 %% Required permissions: kms:UpdateKeyDescription (key policy)
 %%
@@ -2332,42 +2560,118 @@ update_key_description(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateKeyDescription">>, Input, Options).
 
+%% @doc Changes the primary key of a multi-Region key.
+%%
+%% This operation changes the replica key in the specified Region to a
+%% primary key and changes the former primary key to a replica key. For
+%% example, suppose you have a primary key in `us-east-1' and a replica key
+%% in `eu-west-2'. If you run `UpdatePrimaryRegion' with a `PrimaryRegion'
+%% value of `eu-west-2', the primary key is now the key in `eu-west-2', and
+%% the key in `us-east-1' becomes a replica key. For details, see Updating
+%% the primary Region in the Key Management Service Developer Guide.
+%%
+%% This operation supports multi-Region keys, an KMS feature that lets you
+%% create multiple interoperable KMS keys in different Amazon Web Services
+%% Regions. Because these KMS keys have the same key ID, key material, and
+%% other metadata, you can use them interchangeably to encrypt data in one
+%% Amazon Web Services Region and decrypt it in a different Amazon Web
+%% Services Region without re-encrypting the data or making a cross-Region
+%% call. For more information about multi-Region keys, see Using multi-Region
+%% keys in the Key Management Service Developer Guide.
+%%
+%% The primary key of a multi-Region key is the source for properties that
+%% are always shared by primary and replica keys, including the key material,
+%% key ID, key spec, key usage, key material origin, and automatic key
+%% rotation. It's the only key that can be replicated. You cannot delete the
+%% primary key until all replica keys are deleted.
+%%
+%% The key ID and primary Region that you specify uniquely identify the
+%% replica key that will become the primary key. The primary Region must
+%% already have a replica key. This operation does not create a KMS key in
+%% the specified Region. To find the replica keys, use the `DescribeKey'
+%% operation on the primary key or any replica key. To create a replica key,
+%% use the `ReplicateKey' operation.
+%%
+%% You can run this operation while using the affected multi-Region keys in
+%% cryptographic operations. This operation should not delay, interrupt, or
+%% cause failures in cryptographic operations.
+%%
+%% Even after this operation completes, the process of updating the primary
+%% Region might still be in progress for a few more seconds. Operations such
+%% as `DescribeKey' might display both the old and new primary keys as
+%% replicas. The old and new primary keys have a transient key state of
+%% `Updating'. The original key state is restored when the update is
+%% complete. While the key state is `Updating', you can use the keys in
+%% cryptographic operations, but you cannot replicate the new primary key or
+%% perform certain management operations, such as enabling or disabling these
+%% keys. For details about the `Updating' key state, see Key state: Effect on
+%% your KMS key in the Key Management Service Developer Guide.
+%%
+%% This operation does not return any output. To verify that primary key is
+%% changed, use the `DescribeKey' operation.
+%%
+%% Cross-account use: No. You cannot use this operation in a different Amazon
+%% Web Services account.
+%%
+%% Required permissions:
+%%
+%% <ul> <li> `kms:UpdatePrimaryRegion' on the current primary key (in the
+%% primary key's Region). Include this permission primary key's key policy.
+%%
+%% </li> <li> `kms:UpdatePrimaryRegion' on the current replica key (in the
+%% replica key's Region). Include this permission in the replica key's key
+%% policy.
+%%
+%% </li> </ul> Related operations
+%%
+%% <ul> <li> `CreateKey'
+%%
+%% </li> <li> `ReplicateKey'
+%%
+%% </li> </ul>
+update_primary_region(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_primary_region(Client, Input, []).
+update_primary_region(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdatePrimaryRegion">>, Input, Options).
+
 %% @doc Verifies a digital signature that was generated by the `Sign'
 %% operation.
 %%
 %% Verification confirms that an authorized user signed the message with the
-%% specified CMK and signing algorithm, and the message hasn't changed since
-%% it was signed. If the signature is verified, the value of the
+%% specified KMS key and signing algorithm, and the message hasn't changed
+%% since it was signed. If the signature is verified, the value of the
 %% `SignatureValid' field in the response is `True'. If the signature
 %% verification fails, the `Verify' operation fails with an
 %% `KMSInvalidSignatureException' exception.
 %%
 %% A digital signature is generated by using the private key in an asymmetric
-%% CMK. The signature is verified by using the public key in the same
-%% asymmetric CMK. For information about symmetric and asymmetric CMKs, see
-%% Using Symmetric and Asymmetric CMKs in the AWS Key Management Service
-%% Developer Guide.
+%% KMS key. The signature is verified by using the public key in the same
+%% asymmetric KMS key. For information about symmetric and asymmetric KMS
+%% keys, see Using Symmetric and Asymmetric KMS keys in the Key Management
+%% Service Developer Guide.
 %%
 %% To verify a digital signature, you can use the `Verify' operation. Specify
-%% the same asymmetric CMK, message, and signing algorithm that were used to
-%% produce the signature.
+%% the same asymmetric KMS key, message, and signing algorithm that were used
+%% to produce the signature.
 %%
 %% You can also verify the digital signature by using the public key of the
-%% CMK outside of AWS KMS. Use the `GetPublicKey' operation to download the
-%% public key in the asymmetric CMK and then use the public key to verify the
-%% signature outside of AWS KMS. The advantage of using the `Verify'
-%% operation is that it is performed within AWS KMS. As a result, it's easy
-%% to call, the operation is performed within the FIPS boundary, it is logged
-%% in AWS CloudTrail, and you can use key policy and IAM policy to determine
-%% who is authorized to use the CMK to verify signatures.
+%% KMS key outside of KMS. Use the `GetPublicKey' operation to download the
+%% public key in the asymmetric KMS key and then use the public key to verify
+%% the signature outside of KMS. The advantage of using the `Verify'
+%% operation is that it is performed within KMS. As a result, it's easy to
+%% call, the operation is performed within the FIPS boundary, it is logged in
+%% CloudTrail, and you can use key policy and IAM policy to determine who is
+%% authorized to use the KMS key to verify signatures.
 %%
-%% The CMK that you use for this operation must be in a compatible key state.
-%% For details, see How Key State Affects Use of a Customer Master Key in the
-%% AWS Key Management Service Developer Guide.
+%% The KMS key that you use for this operation must be in a compatible key
+%% state. For details, see Key state: Effect on your KMS key in the Key
+%% Management Service Developer Guide.
 %%
-%% Cross-account use: Yes. To perform this operation with a CMK in a
-%% different AWS account, specify the key ARN or alias ARN in the value of
-%% the `KeyId' parameter.
+%% Cross-account use: Yes. To perform this operation with a KMS key in a
+%% different Amazon Web Services account, specify the key ARN or alias ARN in
+%% the value of the `KeyId' parameter.
 %%
 %% Required permissions: kms:Verify (key policy)
 %%

--- a/src/aws_lakeformation.erl
+++ b/src/aws_lakeformation.erl
@@ -6,10 +6,16 @@
 %% Defines the public endpoint for the AWS Lake Formation service.
 -module(aws_lakeformation).
 
--export([batch_grant_permissions/2,
+-export([add_l_f_tags_to_resource/2,
+         add_l_f_tags_to_resource/3,
+         batch_grant_permissions/2,
          batch_grant_permissions/3,
          batch_revoke_permissions/2,
          batch_revoke_permissions/3,
+         create_l_f_tag/2,
+         create_l_f_tag/3,
+         delete_l_f_tag/2,
+         delete_l_f_tag/3,
          deregister_resource/2,
          deregister_resource/3,
          describe_resource/2,
@@ -18,8 +24,14 @@
          get_data_lake_settings/3,
          get_effective_permissions_for_path/2,
          get_effective_permissions_for_path/3,
+         get_l_f_tag/2,
+         get_l_f_tag/3,
+         get_resource_l_f_tags/2,
+         get_resource_l_f_tags/3,
          grant_permissions/2,
          grant_permissions/3,
+         list_l_f_tags/2,
+         list_l_f_tags/3,
          list_permissions/2,
          list_permissions/3,
          list_resources/2,
@@ -28,8 +40,16 @@
          put_data_lake_settings/3,
          register_resource/2,
          register_resource/3,
+         remove_l_f_tags_from_resource/2,
+         remove_l_f_tags_from_resource/3,
          revoke_permissions/2,
          revoke_permissions/3,
+         search_databases_by_l_f_tags/2,
+         search_databases_by_l_f_tags/3,
+         search_tables_by_l_f_tags/2,
+         search_tables_by_l_f_tags/3,
+         update_l_f_tag/2,
+         update_l_f_tag/3,
          update_resource/2,
          update_resource/3]).
 
@@ -38,6 +58,14 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Attaches one or more tags to an existing resource.
+add_l_f_tags_to_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    add_l_f_tags_to_resource(Client, Input, []).
+add_l_f_tags_to_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AddLFTagsToResource">>, Input, Options).
 
 %% @doc Batch operation to grant permissions to the principal.
 batch_grant_permissions(Client, Input)
@@ -54,6 +82,29 @@ batch_revoke_permissions(Client, Input)
 batch_revoke_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"BatchRevokePermissions">>, Input, Options).
+
+%% @doc Creates a tag with the specified name and values.
+create_l_f_tag(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_l_f_tag(Client, Input, []).
+create_l_f_tag(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateLFTag">>, Input, Options).
+
+%% @doc Deletes the specified tag key name.
+%%
+%% If the attribute key does not exist or the tag does not exist, then the
+%% operation will not do anything. If the attribute key exists, then the
+%% operation checks if any resources are tagged with this attribute key, if
+%% yes, the API throws a 400 Exception with the message "Delete not allowed"
+%% as the tag key is still attached with resources. You can consider
+%% untagging resources with this tag key.
+delete_l_f_tag(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_l_f_tag(Client, Input, []).
+delete_l_f_tag(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteLFTag">>, Input, Options).
 
 %% @doc Deregisters the resource as managed by the Data Catalog.
 %%
@@ -96,6 +147,22 @@ get_effective_permissions_for_path(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetEffectivePermissionsForPath">>, Input, Options).
 
+%% @doc Returns a tag definition.
+get_l_f_tag(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_l_f_tag(Client, Input, []).
+get_l_f_tag(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetLFTag">>, Input, Options).
+
+%% @doc Returns the tags applied to a resource.
+get_resource_l_f_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_resource_l_f_tags(Client, Input, []).
+get_resource_l_f_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetResourceLFTags">>, Input, Options).
+
 %% @doc Grants permissions to the principal to access metadata in the Data
 %% Catalog and data organized in underlying data storage such as Amazon S3.
 %%
@@ -107,6 +174,14 @@ grant_permissions(Client, Input)
 grant_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GrantPermissions">>, Input, Options).
+
+%% @doc Lists tags that the requester has permission to view.
+list_l_f_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_l_f_tags(Client, Input, []).
+list_l_f_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListLFTags">>, Input, Options).
 
 %% @doc Returns a list of the principal permissions on the resource, filtered
 %% by the permissions of the caller.
@@ -178,6 +253,18 @@ register_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RegisterResource">>, Input, Options).
 
+%% @doc Removes a tag from the resource.
+%%
+%% Only database, table, or tableWithColumns resource are allowed. To tag
+%% columns, use the column inclusion list in `tableWithColumns' to specify
+%% column input.
+remove_l_f_tags_from_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    remove_l_f_tags_from_resource(Client, Input, []).
+remove_l_f_tags_from_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RemoveLFTagsFromResource">>, Input, Options).
+
 %% @doc Revokes permissions to the principal to access metadata in the Data
 %% Catalog and data organized in underlying data storage such as Amazon S3.
 revoke_permissions(Client, Input)
@@ -186,6 +273,49 @@ revoke_permissions(Client, Input)
 revoke_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RevokePermissions">>, Input, Options).
+
+%% @doc This operation allows a search on `DATABASE' resources by
+%% `TagCondition'.
+%%
+%% This operation is used by admins who want to grant user permissions on
+%% certain `TagConditions'. Before making a grant, the admin can use
+%% `SearchDatabasesByTags' to find all resources where the given
+%% `TagConditions' are valid to verify whether the returned resources can be
+%% shared.
+search_databases_by_l_f_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    search_databases_by_l_f_tags(Client, Input, []).
+search_databases_by_l_f_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SearchDatabasesByLFTags">>, Input, Options).
+
+%% @doc This operation allows a search on `TABLE' resources by `LFTag's.
+%%
+%% This will be used by admins who want to grant user permissions on certain
+%% LFTags. Before making a grant, the admin can use `SearchTablesByLFTags' to
+%% find all resources where the given `LFTag's are valid to verify whether
+%% the returned resources can be shared.
+search_tables_by_l_f_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    search_tables_by_l_f_tags(Client, Input, []).
+search_tables_by_l_f_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SearchTablesByLFTags">>, Input, Options).
+
+%% @doc Updates the list of possible values for the specified tag key.
+%%
+%% If the tag does not exist, the operation throws an
+%% EntityNotFoundException. The values in the delete key values will be
+%% deleted from list of possible values. If any value in the delete key
+%% values is attached to a resource, then API errors out with a 400 Exception
+%% - "Update not allowed". Untag the attribute before deleting the tag key's
+%% value.
+update_l_f_tag(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_l_f_tag(Client, Input, []).
+update_l_f_tag(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateLFTag">>, Input, Options).
 
 %% @doc Updates the data access role used for vending access to the given
 %% (registered) resource in AWS Lake Formation.

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -1,16 +1,15 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Lambda
+%% @doc Lambda
 %%
 %% Overview
 %%
-%% This is the AWS Lambda API Reference.
+%% This is the Lambda API Reference.
 %%
-%% The AWS Lambda Developer Guide provides additional information. For the
-%% service overview, see What is AWS Lambda, and for information about how
-%% the service works, see AWS Lambda: How it Works in the AWS Lambda
-%% Developer Guide.
+%% The Lambda Developer Guide provides additional information. For the
+%% service overview, see What is Lambda, and for information about how the
+%% service works, see Lambda: How it Works in the Lambda Developer Guide.
 -module(aws_lambda).
 
 -export([add_layer_version_permission/4,
@@ -161,12 +160,12 @@
 %% API
 %%====================================================================
 
-%% @doc Adds permissions to the resource-based policy of a version of an AWS
+%% @doc Adds permissions to the resource-based policy of a version of an
 %% Lambda layer.
 %%
 %% Use this action to grant layer usage permission to other accounts. You can
-%% grant permission to a single account, all AWS accounts, or all accounts in
-%% an organization.
+%% grant permission to a single account, all accounts in an organization, or
+%% all Amazon Web Services accounts.
 %%
 %% To revoke permission, call `RemoveLayerVersionPermission' with the
 %% statement ID that you specified when you added it.
@@ -193,21 +192,23 @@ add_layer_version_permission(Client, LayerName, VersionNumber, Input0, Options0)
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Grants an AWS service or another account permission to use a
-%% function.
+%% @doc Grants an Amazon Web Services service or another account permission
+%% to use a function.
 %%
 %% You can apply the policy at the function level, or specify a qualifier to
 %% restrict access to a single version or alias. If you use a qualifier, the
 %% invoker must use the full Amazon Resource Name (ARN) of that version or
-%% alias to invoke the function.
+%% alias to invoke the function. Note: Lambda does not support adding
+%% policies to version $LATEST.
 %%
 %% To grant permission to another account, specify the account ID as the
-%% `Principal'. For AWS services, the principal is a domain-style identifier
-%% defined by the service, like `s3.amazonaws.com' or `sns.amazonaws.com'.
-%% For AWS services, you can also specify the ARN of the associated resource
-%% as the `SourceArn'. If you grant permission to a service principal without
-%% specifying the source, other accounts could potentially configure
-%% resources in their account to invoke your Lambda function.
+%% `Principal'. For Amazon Web Services services, the principal is a
+%% domain-style identifier defined by the service, like `s3.amazonaws.com' or
+%% `sns.amazonaws.com'. For Amazon Web Services services, you can also
+%% specify the ARN of the associated resource as the `SourceArn'. If you
+%% grant permission to a service principal without specifying the source,
+%% other accounts could potentially configure resources in their account to
+%% invoke your Lambda function.
 %%
 %% This action adds a statement to a resource-based permissions policy for
 %% the function. For more information about function policies, see Lambda
@@ -292,23 +293,23 @@ create_code_signing_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a mapping between an event source and an AWS Lambda function.
+%% @doc Creates a mapping between an event source and an Lambda function.
 %%
 %% Lambda reads items from the event source and triggers the function.
 %%
 %% For details about each event source type, see the following topics.
 %%
-%% <ul> <li> Using AWS Lambda with Amazon DynamoDB
+%% <ul> <li> Configuring a Dynamo DB stream as an event source
 %%
-%% </li> <li> Using AWS Lambda with Amazon Kinesis
+%% </li> <li> Configuring a Kinesis stream as an event source
 %%
-%% </li> <li> Using AWS Lambda with Amazon SQS
+%% </li> <li> Configuring an Amazon SQS queue as an event source
 %%
-%% </li> <li> Using AWS Lambda with Amazon MQ
+%% </li> <li> Configuring an MQ broker as an event source
 %%
-%% </li> <li> Using AWS Lambda with Amazon MSK
+%% </li> <li> Configuring MSK as an event source
 %%
-%% </li> <li> Using AWS Lambda with Self-Managed Apache Kafka
+%% </li> <li> Configuring Self-Managed Apache Kafka as an event source
 %%
 %% </li> </ul> The following error handling options are only available for
 %% stream sources (DynamoDB and Kinesis):
@@ -358,8 +359,20 @@ create_event_source_mapping(Client, Input0, Options0) ->
 %% To create a function, you need a deployment package and an execution role.
 %% The deployment package is a .zip file archive or container image that
 %% contains your function code. The execution role grants the function
-%% permission to use AWS services, such as Amazon CloudWatch Logs for log
-%% streaming and AWS X-Ray for request tracing.
+%% permission to use Amazon Web Services services, such as Amazon CloudWatch
+%% Logs for log streaming and X-Ray for request tracing.
+%%
+%% You set the package type to `Image' if the deployment package is a
+%% container image. For a container image, the code property must include the
+%% URI of a container image in the Amazon ECR registry. You do not need to
+%% specify the handler and runtime properties.
+%%
+%% You set the package type to `Zip' if the deployment package is a .zip file
+%% archive. For a .zip file archive, the code property specifies the location
+%% of the .zip file. You must also specify the handler and runtime
+%% properties. The code in the deployment package must be compatible with the
+%% target instruction set architecture of the function (`x86-64' or `arm64').
+%% If you do not specify the architecture, the default value is `x86-64'.
 %%
 %% When you create a function, Lambda provisions an instance of the function
 %% and its supporting resources. If your function connects to a VPC, this
@@ -391,15 +404,16 @@ create_event_source_mapping(Client, Input0, Options0) ->
 %% includes set set of signing profiles, which define the trusted publishers
 %% for this function.
 %%
-%% If another account or an AWS service invokes your function, use
-%% `AddPermission' to grant permission by creating a resource-based IAM
-%% policy. You can grant permissions at the function level, on a version, or
-%% on an alias.
+%% If another account or an Amazon Web Services service invokes your
+%% function, use `AddPermission' to grant permission by creating a
+%% resource-based IAM policy. You can grant permissions at the function
+%% level, on a version, or on an alias.
 %%
 %% To invoke your function directly, use `Invoke'. To invoke your function in
-%% response to events in other AWS services, create an event source mapping
-%% (`CreateEventSourceMapping'), or configure a function trigger in the other
-%% service. For more information, see Invoking Functions.
+%% response to events in other Amazon Web Services services, create an event
+%% source mapping (`CreateEventSourceMapping'), or configure a function
+%% trigger in the other service. For more information, see Invoking
+%% Functions.
 create_function(Client, Input) ->
     create_function(Client, Input, []).
 create_function(Client, Input0, Options0) ->
@@ -506,9 +520,9 @@ delete_event_source_mapping(Client, UUID, Input0, Options0) ->
 %% Otherwise, all versions and aliases are deleted.
 %%
 %% To delete Lambda event source mappings that invoke a function, use
-%% `DeleteEventSourceMapping'. For AWS services and resources that invoke
-%% your function directly, delete the trigger in the service where you
-%% originally configured it.
+%% `DeleteEventSourceMapping'. For Amazon Web Services services and resources
+%% that invoke your function directly, delete the trigger in the service
+%% where you originally configured it.
 delete_function(Client, FunctionName, Input) ->
     delete_function(Client, FunctionName, Input, []).
 delete_function(Client, FunctionName, Input0, Options0) ->
@@ -606,7 +620,7 @@ delete_function_event_invoke_config(Client, FunctionName, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes a version of an AWS Lambda layer.
+%% @doc Deletes a version of an Lambda layer.
 %%
 %% Deleted versions can no longer be viewed or added to functions. To avoid
 %% breaking functions, a copy of the version remains in Lambda until no
@@ -657,8 +671,8 @@ delete_provisioned_concurrency_config(Client, FunctionName, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Retrieves details about your account's limits and usage in an AWS
-%% Region.
+%% @doc Retrieves details about your account's limits and usage in an Amazon
+%% Web Services Region.
 get_account_settings(Client)
   when is_map(Client) ->
     get_account_settings(Client, #{}, #{}).
@@ -898,8 +912,8 @@ get_function_event_invoke_config(Client, FunctionName, QueryMap, HeadersMap, Opt
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns information about a version of an AWS Lambda layer, with a
-%% link to download the layer archive that's valid for 10 minutes.
+%% @doc Returns information about a version of an Lambda layer, with a link
+%% to download the layer archive that's valid for 10 minutes.
 get_layer_version(Client, LayerName, VersionNumber)
   when is_map(Client) ->
     get_layer_version(Client, LayerName, VersionNumber, #{}, #{}).
@@ -922,8 +936,8 @@ get_layer_version(Client, LayerName, VersionNumber, QueryMap, HeadersMap, Option
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns information about a version of an AWS Lambda layer, with a
-%% link to download the layer archive that's valid for 10 minutes.
+%% @doc Returns information about a version of an Lambda layer, with a link
+%% to download the layer archive that's valid for 10 minutes.
 get_layer_version_by_arn(Client, Arn)
   when is_map(Client) ->
     get_layer_version_by_arn(Client, Arn, #{}, #{}).
@@ -950,7 +964,7 @@ get_layer_version_by_arn(Client, Arn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the permission policy for a version of an AWS Lambda layer.
+%% @doc Returns the permission policy for a version of an Lambda layer.
 %%
 %% For more information, see `AddLayerVersionPermission'.
 get_layer_version_policy(Client, LayerName, VersionNumber)
@@ -1271,8 +1285,12 @@ list_function_event_invoke_configs(Client, FunctionName, QueryMap, HeadersMap, O
 %% Lambda returns up to 50 functions per call.
 %%
 %% Set `FunctionVersion' to `ALL' to include all published versions of each
-%% function in addition to the unpublished version. To get more information
-%% about a function or version, use `GetFunction'.
+%% function in addition to the unpublished version.
+%%
+%% The `ListFunctions' action returns a subset of the `FunctionConfiguration'
+%% fields. To get the additional fields (State, StateReasonCode, StateReason,
+%% LastUpdateStatus, LastUpdateStatusReason, LastUpdateStatusReasonCode) for
+%% a function or version, use `GetFunction'.
 list_functions(Client)
   when is_map(Client) ->
     list_functions(Client, #{}, #{}).
@@ -1333,11 +1351,12 @@ list_functions_by_code_signing_config(Client, CodeSigningConfigArn, QueryMap, He
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists the versions of an AWS Lambda layer.
+%% @doc Lists the versions of an Lambda layer.
 %%
 %% Versions that have been deleted aren't listed. Specify a runtime
 %% identifier to list only versions that indicate that they're compatible
-%% with that runtime.
+%% with that runtime. Specify a compatible architecture to include only layer
+%% versions that are compatible with that architecture.
 list_layer_versions(Client, LayerName)
   when is_map(Client) ->
     list_layer_versions(Client, LayerName, #{}, #{}).
@@ -1358,6 +1377,7 @@ list_layer_versions(Client, LayerName, QueryMap, HeadersMap, Options0)
 
     Query0_ =
       [
+        {<<"CompatibleArchitecture">>, maps:get(<<"CompatibleArchitecture">>, QueryMap, undefined)},
         {<<"CompatibleRuntime">>, maps:get(<<"CompatibleRuntime">>, QueryMap, undefined)},
         {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
         {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)}
@@ -1366,11 +1386,13 @@ list_layer_versions(Client, LayerName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists AWS Lambda layers and shows information about the latest
-%% version of each.
+%% @doc Lists Lambda layers and shows information about the latest version of
+%% each.
 %%
 %% Specify a runtime identifier to list only layers that indicate that
-%% they're compatible with that runtime.
+%% they're compatible with that runtime. Specify a compatible architecture to
+%% include only layers that are compatible with that instruction set
+%% architecture.
 list_layers(Client)
   when is_map(Client) ->
     list_layers(Client, #{}, #{}).
@@ -1391,6 +1413,7 @@ list_layers(Client, QueryMap, HeadersMap, Options0)
 
     Query0_ =
       [
+        {<<"CompatibleArchitecture">>, maps:get(<<"CompatibleArchitecture">>, QueryMap, undefined)},
         {<<"CompatibleRuntime">>, maps:get(<<"CompatibleRuntime">>, QueryMap, undefined)},
         {<<"Marker">>, maps:get(<<"Marker">>, QueryMap, undefined)},
         {<<"MaxItems">>, maps:get(<<"MaxItems">>, QueryMap, undefined)}
@@ -1484,7 +1507,7 @@ list_versions_by_function(Client, FunctionName, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Creates an AWS Lambda layer from a ZIP archive.
+%% @doc Creates an Lambda layer from a ZIP archive.
 %%
 %% Each time you call `PublishLayerVersion' with the same layer name, a new
 %% version is created.
@@ -1519,8 +1542,8 @@ publish_layer_version(Client, LayerName, Input0, Options0) ->
 %% Use versions to create a snapshot of your function code and configuration
 %% that doesn't change.
 %%
-%% AWS Lambda doesn't publish a version if the function's configuration and
-%% code haven't changed since the last version. Use `UpdateFunctionCode' or
+%% Lambda doesn't publish a version if the function's configuration and code
+%% haven't changed since the last version. Use `UpdateFunctionCode' or
 %% `UpdateFunctionConfiguration' to update the function before publishing a
 %% version.
 %%
@@ -1679,7 +1702,7 @@ put_provisioned_concurrency_config(Client, FunctionName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Removes a statement from the permissions policy for a version of an
-%% AWS Lambda layer.
+%% Lambda layer.
 %%
 %% For more information, see `AddLayerVersionPermission'.
 remove_layer_version_permission(Client, LayerName, StatementId, VersionNumber, Input) ->
@@ -1705,8 +1728,8 @@ remove_layer_version_permission(Client, LayerName, StatementId, VersionNumber, I
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Revokes function-use permission from an AWS service or another
-%% account.
+%% @doc Revokes function-use permission from an Amazon Web Services service
+%% or another account.
 %%
 %% You can get the ID of the statement from the output of `GetPolicy'.
 remove_permission(Client, FunctionName, StatementId, Input) ->
@@ -1831,8 +1854,8 @@ update_code_signing_config(Client, CodeSigningConfigArn, Input0, Options0) ->
 
 %% @doc Updates an event source mapping.
 %%
-%% You can change the function that AWS Lambda invokes, or pause invocation
-%% and resume later from the same location.
+%% You can change the function that Lambda invokes, or pause invocation and
+%% resume later from the same location.
 %%
 %% The following error handling options are only available for stream sources
 %% (DynamoDB and Kinesis):
@@ -1927,7 +1950,8 @@ update_function_code(Client, FunctionName, Input0, Options0) ->
 %% version, only the unpublished version.
 %%
 %% To configure function concurrency, use `PutFunctionConcurrency'. To grant
-%% invoke permissions to an account or AWS service, use `AddPermission'.
+%% invoke permissions to an account or Amazon Web Services service, use
+%% `AddPermission'.
 update_function_configuration(Client, FunctionName, Input) ->
     update_function_configuration(Client, FunctionName, Input, []).
 update_function_configuration(Client, FunctionName, Input0, Options0) ->
@@ -2013,6 +2037,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_lex_models_v2.erl
+++ b/src/aws_lex_models_v2.erl
@@ -14,12 +14,20 @@
          create_bot_locale/5,
          create_bot_version/3,
          create_bot_version/4,
+         create_export/2,
+         create_export/3,
          create_intent/5,
          create_intent/6,
+         create_resource_policy/3,
+         create_resource_policy/4,
+         create_resource_policy_statement/3,
+         create_resource_policy_statement/4,
          create_slot/6,
          create_slot/7,
          create_slot_type/5,
          create_slot_type/6,
+         create_upload_url/2,
+         create_upload_url/3,
          delete_bot/3,
          delete_bot/4,
          delete_bot_alias/4,
@@ -28,12 +36,22 @@
          delete_bot_locale/6,
          delete_bot_version/4,
          delete_bot_version/5,
+         delete_export/3,
+         delete_export/4,
+         delete_import/3,
+         delete_import/4,
          delete_intent/6,
          delete_intent/7,
+         delete_resource_policy/3,
+         delete_resource_policy/4,
+         delete_resource_policy_statement/4,
+         delete_resource_policy_statement/5,
          delete_slot/7,
          delete_slot/8,
          delete_slot_type/6,
          delete_slot_type/7,
+         delete_utterances/3,
+         delete_utterances/4,
          describe_bot/2,
          describe_bot/4,
          describe_bot/5,
@@ -46,15 +64,26 @@
          describe_bot_version/3,
          describe_bot_version/5,
          describe_bot_version/6,
+         describe_export/2,
+         describe_export/4,
+         describe_export/5,
+         describe_import/2,
+         describe_import/4,
+         describe_import/5,
          describe_intent/5,
          describe_intent/7,
          describe_intent/8,
+         describe_resource_policy/2,
+         describe_resource_policy/4,
+         describe_resource_policy/5,
          describe_slot/6,
          describe_slot/8,
          describe_slot/9,
          describe_slot_type/5,
          describe_slot_type/7,
          describe_slot_type/8,
+         list_aggregated_utterances/3,
+         list_aggregated_utterances/4,
          list_bot_aliases/3,
          list_bot_aliases/4,
          list_bot_locales/4,
@@ -67,6 +96,10 @@
          list_built_in_intents/4,
          list_built_in_slot_types/3,
          list_built_in_slot_types/4,
+         list_exports/2,
+         list_exports/3,
+         list_imports/2,
+         list_imports/3,
          list_intents/5,
          list_intents/6,
          list_slot_types/5,
@@ -76,6 +109,8 @@
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
+         start_import/2,
+         start_import/3,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
@@ -86,8 +121,12 @@
          update_bot_alias/5,
          update_bot_locale/5,
          update_bot_locale/6,
+         update_export/3,
+         update_export/4,
          update_intent/6,
          update_intent/7,
+         update_resource_policy/3,
+         update_resource_policy/4,
          update_slot/7,
          update_slot/8,
          update_slot_type/6,
@@ -235,6 +274,40 @@ create_bot_version(Client, BotId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates a zip archive containing the contents of a bot or a bot
+%% locale.
+%%
+%% The archive contains a directory structure that contains JSON files that
+%% define the bot.
+%%
+%% You can create an archive that contains the complete definition of a bot,
+%% or you can specify that the archive contain only the definition of a
+%% single bot locale.
+%%
+%% For more information about exporting bots, and about the structure of the
+%% export archive, see Importing and exporting bots
+create_export(Client, Input) ->
+    create_export(Client, Input, []).
+create_export(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/exports/"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates an intent.
 %%
 %% To define the interaction between the user and your bot, you define one or
@@ -289,6 +362,59 @@ create_intent(Client, BotId, BotVersion, LocaleId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates a new resource policy with the specified policy statements.
+create_resource_policy(Client, ResourceArn, Input) ->
+    create_resource_policy(Client, ResourceArn, Input, []).
+create_resource_policy(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds a new resource policy statement to a bot or bot alias.
+%%
+%% If a resource policy exists, the statement is added to the current
+%% resource policy. If a policy doesn't exist, a new policy is created.
+%%
+%% You can't create a resource policy statement that allows cross-account
+%% access.
+create_resource_policy_statement(Client, ResourceArn, Input) ->
+    create_resource_policy_statement(Client, ResourceArn, Input, []).
+create_resource_policy_statement(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/statements/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"expectedRevisionId">>, <<"expectedRevisionId">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a slot in an intent.
 %%
 %% A slot is a variable needed to fulfill an intent. For example, an
@@ -326,6 +452,30 @@ create_slot_type(Client, BotId, BotVersion, LocaleId, Input) ->
 create_slot_type(Client, BotId, BotVersion, LocaleId, Input0, Options0) ->
     Method = put,
     Path = ["/bots/", aws_util:encode_uri(BotId), "/botversions/", aws_util:encode_uri(BotVersion), "/botlocales/", aws_util:encode_uri(LocaleId), "/slottypes/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets a pre-signed S3 write URL that you use to upload the zip archive
+%% when importing a bot or a bot locale.
+create_upload_url(Client, Input) ->
+    create_upload_url(Client, Input, []).
+create_upload_url(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/createuploadurl/"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -453,6 +603,54 @@ delete_bot_version(Client, BotId, BotVersion, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Removes a previous export and the associated files stored in an S3
+%% bucket.
+delete_export(Client, ExportId, Input) ->
+    delete_export(Client, ExportId, Input, []).
+delete_export(Client, ExportId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/exports/", aws_util:encode_uri(ExportId), "/"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a previous import and the associated file stored in an S3
+%% bucket.
+delete_import(Client, ImportId, Input) ->
+    delete_import(Client, ImportId, Input, []).
+delete_import(Client, ImportId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/imports/", aws_util:encode_uri(ImportId), "/"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Removes the specified intent.
 %%
 %% Deleting an intent also deletes the slots associated with the intent.
@@ -476,6 +674,62 @@ delete_intent(Client, BotId, BotVersion, IntentId, LocaleId, Input0, Options0) -
     Query_ = [],
     Input = Input2,
 
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes an existing policy from a bot or bot alias.
+%%
+%% If the resource doesn't have a policy attached, Amazon Lex returns an
+%% exception.
+delete_resource_policy(Client, ResourceArn, Input) ->
+    delete_resource_policy(Client, ResourceArn, Input, []).
+delete_resource_policy(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"expectedRevisionId">>, <<"expectedRevisionId">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a policy statement from a resource policy.
+%%
+%% If you delete the last statement from a policy, the policy is deleted. If
+%% you specify a statement ID that doesn't exist in the policy, or if the bot
+%% or bot alias doesn't have a policy attached, Amazon Lex returns an
+%% exception.
+delete_resource_policy_statement(Client, ResourceArn, StatementId, Input) ->
+    delete_resource_policy_statement(Client, ResourceArn, StatementId, Input, []).
+delete_resource_policy_statement(Client, ResourceArn, StatementId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/statements/", aws_util:encode_uri(StatementId), "/"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"expectedRevisionId">>, <<"expectedRevisionId">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the specified slot from an intent.
@@ -525,6 +779,42 @@ delete_slot_type(Client, BotId, BotVersion, LocaleId, SlotTypeId, Input0, Option
 
     QueryMapping = [
                      {<<"skipResourceInUseCheck">>, <<"skipResourceInUseCheck">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes stored utterances.
+%%
+%% Amazon Lex stores the utterances that users send to your bot. Utterances
+%% are stored for 15 days for use with the operation, and then stored
+%% indefinitely for use in improving the ability of your bot to respond to
+%% user input..
+%%
+%% Use the `DeleteUtterances' operation to manually delete utterances for a
+%% specific session. When you use the `DeleteUtterances' operation,
+%% utterances stored for improving your bot's ability to respond to user
+%% input are deleted immediately. Utterances stored for use with the
+%% `ListAggregatedUtterances' operation are deleted after 15 days.
+delete_utterances(Client, BotId, Input) ->
+    delete_utterances(Client, BotId, Input, []).
+delete_utterances(Client, BotId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/bots/", aws_util:encode_uri(BotId), "/utterances/"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"localeId">>, <<"localeId">>},
+                     {<<"sessionId">>, <<"sessionId">>}
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
@@ -621,6 +911,52 @@ describe_bot_version(Client, BotId, BotVersion, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets information about a specific export.
+describe_export(Client, ExportId)
+  when is_map(Client) ->
+    describe_export(Client, ExportId, #{}, #{}).
+
+describe_export(Client, ExportId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_export(Client, ExportId, QueryMap, HeadersMap, []).
+
+describe_export(Client, ExportId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/exports/", aws_util:encode_uri(ExportId), "/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about a specific import.
+describe_import(Client, ImportId)
+  when is_map(Client) ->
+    describe_import(Client, ImportId, #{}, #{}).
+
+describe_import(Client, ImportId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_import(Client, ImportId, QueryMap, HeadersMap, []).
+
+describe_import(Client, ImportId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/imports/", aws_util:encode_uri(ImportId), "/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns metadata about an intent.
 describe_intent(Client, BotId, BotVersion, IntentId, LocaleId)
   when is_map(Client) ->
@@ -633,6 +969,29 @@ describe_intent(Client, BotId, BotVersion, IntentId, LocaleId, QueryMap, Headers
 describe_intent(Client, BotId, BotVersion, IntentId, LocaleId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/bots/", aws_util:encode_uri(BotId), "/botversions/", aws_util:encode_uri(BotVersion), "/botlocales/", aws_util:encode_uri(LocaleId), "/intents/", aws_util:encode_uri(IntentId), "/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the resource policy and policy revision for a bot or bot alias.
+describe_resource_policy(Client, ResourceArn)
+  when is_map(Client) ->
+    describe_resource_policy(Client, ResourceArn, #{}, #{}).
+
+describe_resource_policy(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_resource_policy(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+describe_resource_policy(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -689,6 +1048,52 @@ describe_slot_type(Client, BotId, BotVersion, LocaleId, SlotTypeId, QueryMap, He
     Query_ = [],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Provides a list of utterances that users have sent to the bot.
+%%
+%% Utterances are aggregated by the text of the utterance. For example, all
+%% instances where customers used the phrase "I want to order pizza" are
+%% aggregated into the same line in the response.
+%%
+%% You can see both detected utterances and missed utterances. A detected
+%% utterance is where the bot properly recognized the utterance and activated
+%% the associated intent. A missed utterance was not recognized by the bot
+%% and didn't activate an intent.
+%%
+%% Utterances can be aggregated for a bot alias or for a bot version, but not
+%% both at the same time.
+%%
+%% Utterances statistics are not generated under the following conditions:
+%%
+%% <ul> <li> The `childDirected' field was set to true when the bot was
+%% created.
+%%
+%% </li> <li> You are using slot obfuscation with one or more slots.
+%%
+%% </li> <li> You opted out of participating in improving Amazon Lex.
+%%
+%% </li> </ul>
+list_aggregated_utterances(Client, BotId, Input) ->
+    list_aggregated_utterances(Client, BotId, Input, []).
+list_aggregated_utterances(Client, BotId, Input0, Options0) ->
+    Method = post,
+    Path = ["/bots/", aws_util:encode_uri(BotId), "/aggregatedutterances/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets a list of aliases for the specified bot.
 list_bot_aliases(Client, BotId, Input) ->
@@ -842,6 +1247,56 @@ list_built_in_slot_types(Client, LocaleId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Lists the exports for a bot or bot locale.
+%%
+%% Exports are kept in the list for 7 days.
+list_exports(Client, Input) ->
+    list_exports(Client, Input, []).
+list_exports(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/exports/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the imports for a bot or bot locale.
+%%
+%% Imports are kept in the list for 7 days.
+list_imports(Client, Input) ->
+    list_imports(Client, Input, []).
+list_imports(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/imports/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Get a list of intents that meet the specified criteria.
 list_intents(Client, BotId, BotVersion, LocaleId, Input) ->
     list_intents(Client, BotId, BotVersion, LocaleId, Input, []).
@@ -936,6 +1391,30 @@ list_tags_for_resource(Client, ResourceARN, QueryMap, HeadersMap, Options0)
     Query_ = [],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Starts importing a bot or bot locale from a zip archive that you
+%% uploaded to an S3 bucket.
+start_import(Client, Input) ->
+    start_import(Client, Input, []).
+start_import(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/imports/"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Adds the specified tags to the specified resource.
 %%
@@ -1056,6 +1535,34 @@ update_bot_locale(Client, BotId, BotVersion, LocaleId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates the password used to protect an export zip archive.
+%%
+%% The password is not required. If you don't supply a password, Amazon Lex
+%% generates a zip file that is not protected by a password. This is the
+%% archive that is available at the pre-signed S3 URL provided by the
+%% operation.
+update_export(Client, ExportId, Input) ->
+    update_export(Client, ExportId, Input, []).
+update_export(Client, ExportId, Input0, Options0) ->
+    Method = put,
+    Path = ["/exports/", aws_util:encode_uri(ExportId), "/"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates the settings for an intent.
 update_intent(Client, BotId, BotVersion, IntentId, LocaleId, Input) ->
     update_intent(Client, BotId, BotVersion, IntentId, LocaleId, Input, []).
@@ -1077,6 +1584,33 @@ update_intent(Client, BotId, BotVersion, IntentId, LocaleId, Input0, Options0) -
     Query_ = [],
     Input = Input2,
 
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Replaces the existing resource policy for a bot or bot alias with a
+%% new one.
+%%
+%% If the policy doesn't exist, Amazon Lex returns an exception.
+update_resource_policy(Client, ResourceArn, Input) ->
+    update_resource_policy(Client, ResourceArn, Input, []).
+update_resource_policy(Client, ResourceArn, Input0, Options0) ->
+    Method = put,
+    Path = ["/policy/", aws_util:encode_uri(ResourceArn), "/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"expectedRevisionId">>, <<"expectedRevisionId">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Updates the settings for a slot.
@@ -1160,6 +1694,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -177,6 +177,8 @@ post_content(Client, BotAlias, BotName, UserId, Input0, Options0) ->
             {<<"x-amz-lex-bot-version">>, <<"botVersion">>},
             {<<"Content-Type">>, <<"contentType">>},
             {<<"x-amz-lex-dialog-state">>, <<"dialogState">>},
+            {<<"x-amz-lex-encoded-input-transcript">>, <<"encodedInputTranscript">>},
+            {<<"x-amz-lex-encoded-message">>, <<"encodedMessage">>},
             {<<"x-amz-lex-input-transcript">>, <<"inputTranscript">>},
             {<<"x-amz-lex-intent-name">>, <<"intentName">>},
             {<<"x-amz-lex-message">>, <<"message">>},
@@ -311,6 +313,7 @@ put_session(Client, BotAlias, BotName, UserId, Input0, Options0) ->
             {<<"x-amz-lex-active-contexts">>, <<"activeContexts">>},
             {<<"Content-Type">>, <<"contentType">>},
             {<<"x-amz-lex-dialog-state">>, <<"dialogState">>},
+            {<<"x-amz-lex-encoded-message">>, <<"encodedMessage">>},
             {<<"x-amz-lex-intent-name">>, <<"intentName">>},
             {<<"x-amz-lex-message">>, <<"message">>},
             {<<"x-amz-lex-message-format">>, <<"messageFormat">>},
@@ -366,6 +369,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_lex_runtime_v2.erl
+++ b/src/aws_lex_runtime_v2.erl
@@ -66,9 +66,9 @@ delete_session(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0)
 %% For example, you can use this operation to retrieve session information
 %% for a user that has left a long-running session in use.
 %%
-%% If the bot, alias, or session identifier doesn't exist, Amazon Lex returns
-%% a `BadRequestException'. If the locale doesn't exist or is not enabled for
-%% the alias, you receive a `BadRequestException'.
+%% If the bot, alias, or session identifier doesn't exist, Amazon Lex V2
+%% returns a `BadRequestException'. If the locale doesn't exist or is not
+%% enabled for the alias, you receive a `BadRequestException'.
 get_session(Client, BotAliasId, BotId, LocaleId, SessionId)
   when is_map(Client) ->
     get_session(Client, BotAliasId, BotId, LocaleId, SessionId, #{}, #{}).
@@ -92,7 +92,7 @@ get_session(Client, BotAliasId, BotId, LocaleId, SessionId, QueryMap, HeadersMap
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Creates a new session or modifies an existing session with an Amazon
-%% Lex bot.
+%% Lex V2 bot.
 %%
 %% Use this operation to enable your application to set the state of the bot.
 put_session(Client, BotAliasId, BotId, LocaleId, SessionId, Input) ->
@@ -139,14 +139,33 @@ put_session(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0) ->
         Result
     end.
 
-%% @doc Sends user input to Amazon Lex.
+%% @doc Sends user input to Amazon Lex V2.
 %%
-%% Client applications use this API to send requests to Amazon Lex at
-%% runtime. Amazon Lex then interprets the user input using the machine
+%% Client applications use this API to send requests to Amazon Lex V2 at
+%% runtime. Amazon Lex V2 then interprets the user input using the machine
 %% learning model that it build for the bot.
 %%
-%% In response, Amazon Lex returns the next message to convey to the user and
-%% an optional response card to display.
+%% In response, Amazon Lex V2 returns the next message to convey to the user
+%% and an optional response card to display.
+%%
+%% If the optional post-fulfillment response is specified, the messages are
+%% returned as follows. For more information, see
+%% PostFulfillmentStatusSpecification.
+%%
+%% <ul> <li> Success message - Returned if the Lambda function completes
+%% successfully and the intent state is fulfilled or ready fulfillment if the
+%% message is present.
+%%
+%% </li> <li> Failed message - The failed message is returned if the Lambda
+%% function throws an exception or if the Lambda function returns a failed
+%% intent state without a message.
+%%
+%% </li> <li> Timeout message - If you don't configure a timeout message and
+%% a timeout, and the Lambda function doesn't return within 30 seconds, the
+%% timeout message is returned. If you configure a timeout, the timeout
+%% message is returned when the period times out.
+%%
+%% </li> </ul> For more information, see Completion message.
 recognize_text(Client, BotAliasId, BotId, LocaleId, SessionId, Input) ->
     recognize_text(Client, BotAliasId, BotId, LocaleId, SessionId, Input, []).
 recognize_text(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0) ->
@@ -169,11 +188,55 @@ recognize_text(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0)
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Sends user input to Amazon Lex.
+%% @doc Sends user input to Amazon Lex V2.
 %%
 %% You can send text or speech. Clients use this API to send text and audio
-%% requests to Amazon Lex at runtime. Amazon Lex interprets the user input
-%% using the machine learning model built for the bot.
+%% requests to Amazon Lex V2 at runtime. Amazon Lex V2 interprets the user
+%% input using the machine learning model built for the bot.
+%%
+%% The following request fields must be compressed with gzip and then base64
+%% encoded before you send them to Amazon Lex V2.
+%%
+%% <ul> <li> requestAttributes
+%%
+%% </li> <li> sessionState
+%%
+%% </li> </ul> The following response fields are compressed using gzip and
+%% then base64 encoded by Amazon Lex V2. Before you can use these fields, you
+%% must decode and decompress them.
+%%
+%% <ul> <li> inputTranscript
+%%
+%% </li> <li> interpretations
+%%
+%% </li> <li> messages
+%%
+%% </li> <li> requestAttributes
+%%
+%% </li> <li> sessionState
+%%
+%% </li> </ul> The example contains a Java application that compresses and
+%% encodes a Java object to send to Amazon Lex V2, and a second that decodes
+%% and decompresses a response from Amazon Lex V2.
+%%
+%% If the optional post-fulfillment response is specified, the messages are
+%% returned as follows. For more information, see
+%% PostFulfillmentStatusSpecification.
+%%
+%% <ul> <li> Success message - Returned if the Lambda function completes
+%% successfully and the intent state is fulfilled or ready fulfillment if the
+%% message is present.
+%%
+%% </li> <li> Failed message - The failed message is returned if the Lambda
+%% function throws an exception or if the Lambda function returns a failed
+%% intent state without a message.
+%%
+%% </li> <li> Timeout message - If you don't configure a timeout message and
+%% a timeout, and the Lambda function doesn't return within 30 seconds, the
+%% timeout message is returned. If you configure a timeout, the timeout
+%% message is returned when the period times out.
+%%
+%% </li> </ul> For more information, see Completion message.
 recognize_utterance(Client, BotAliasId, BotId, LocaleId, SessionId, Input) ->
     recognize_utterance(Client, BotAliasId, BotId, LocaleId, SessionId, Input, []).
 recognize_utterance(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0) ->
@@ -228,8 +291,47 @@ recognize_utterance(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Opti
 %% audio, text, or DTMF input in real time.
 %%
 %% After your application starts a conversation, users send input to Amazon
-%% Lex as a stream of events. Amazon Lex processes the incoming events and
-%% responds with streaming text or audio events.
+%% Lex V2 as a stream of events. Amazon Lex V2 processes the incoming events
+%% and responds with streaming text or audio events.
+%%
+%% Audio input must be in the following format: `audio/lpcm sample-rate=8000
+%% sample-size-bits=16 channel-count=1; is-big-endian=false'.
+%%
+%% If the optional post-fulfillment response is specified, the messages are
+%% returned as follows. For more information, see
+%% PostFulfillmentStatusSpecification.
+%%
+%% <ul> <li> Success message - Returned if the Lambda function completes
+%% successfully and the intent state is fulfilled or ready fulfillment if the
+%% message is present.
+%%
+%% </li> <li> Failed message - The failed message is returned if the Lambda
+%% function throws an exception or if the Lambda function returns a failed
+%% intent state without a message.
+%%
+%% </li> <li> Timeout message - If you don't configure a timeout message and
+%% a timeout, and the Lambda function doesn't return within 30 seconds, the
+%% timeout message is returned. If you configure a timeout, the timeout
+%% message is returned when the period times out.
+%%
+%% </li> </ul> For more information, see Completion message.
+%%
+%% If the optional update message is configured, it is played at the
+%% specified frequency while the Lambda function is running and the update
+%% message state is active. If the fulfillment update message is not active,
+%% the Lambda function runs with a 30 second timeout.
+%%
+%% For more information, see Update message
+%%
+%% The `StartConversation' operation is supported only in the following SDKs:
+%%
+%% <ul> <li> AWS SDK for C++
+%%
+%% </li> <li> AWS SDK for Java V2
+%%
+%% </li> <li> AWS SDK for Ruby V3
+%%
+%% </li> </ul>
 start_conversation(Client, BotAliasId, BotId, LocaleId, SessionId, Input) ->
     start_conversation(Client, BotAliasId, BotId, LocaleId, SessionId, Input, []).
 start_conversation(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Options0) ->
@@ -289,6 +391,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_license_manager.erl
+++ b/src/aws_license_manager.erl
@@ -1,10 +1,9 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS License Manager
-%%
-%% AWS License Manager makes it easier to manage licenses from software
-%% vendors across multiple AWS accounts and on-premises servers.
+%% @doc License Manager makes it easier to manage licenses from software
+%% vendors across multiple Amazon Web Services accounts and on-premises
+%% servers.
 -module(aws_license_manager).
 
 -export([accept_grant/2,
@@ -23,6 +22,10 @@
          create_license/3,
          create_license_configuration/2,
          create_license_configuration/3,
+         create_license_conversion_task_for_resource/2,
+         create_license_conversion_task_for_resource/3,
+         create_license_manager_report_generator/2,
+         create_license_manager_report_generator/3,
          create_license_version/2,
          create_license_version/3,
          create_token/2,
@@ -33,6 +36,8 @@
          delete_license/3,
          delete_license_configuration/2,
          delete_license_configuration/3,
+         delete_license_manager_report_generator/2,
+         delete_license_manager_report_generator/3,
          delete_token/2,
          delete_token/3,
          extend_license_consumption/2,
@@ -45,6 +50,10 @@
          get_license/3,
          get_license_configuration/2,
          get_license_configuration/3,
+         get_license_conversion_task/2,
+         get_license_conversion_task/3,
+         get_license_manager_report_generator/2,
+         get_license_manager_report_generator/3,
          get_license_usage/2,
          get_license_usage/3,
          get_service_settings/2,
@@ -57,6 +66,10 @@
          list_failures_for_license_configuration_operations/3,
          list_license_configurations/2,
          list_license_configurations/3,
+         list_license_conversion_tasks/2,
+         list_license_conversion_tasks/3,
+         list_license_manager_report_generators/2,
+         list_license_manager_report_generators/3,
          list_license_specifications_for_resource/2,
          list_license_specifications_for_resource/3,
          list_license_versions/2,
@@ -83,6 +96,8 @@
          untag_resource/3,
          update_license_configuration/2,
          update_license_configuration/3,
+         update_license_manager_report_generator/2,
+         update_license_manager_report_generator/3,
          update_license_specifications_for_resource/2,
          update_license_specifications_for_resource/3,
          update_service_settings/2,
@@ -130,7 +145,8 @@ checkout_license(Client, Input, Options)
 
 %% @doc Creates a grant for the specified license.
 %%
-%% A grant shares the use of license entitlements with specific AWS accounts.
+%% A grant shares the use of license entitlements with specific Amazon Web
+%% Services accounts.
 create_grant(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_grant(Client, Input, []).
@@ -168,6 +184,22 @@ create_license_configuration(Client, Input)
 create_license_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateLicenseConfiguration">>, Input, Options).
+
+%% @doc Creates a new license conversion task.
+create_license_conversion_task_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_license_conversion_task_for_resource(Client, Input, []).
+create_license_conversion_task_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateLicenseConversionTaskForResource">>, Input, Options).
+
+%% @doc Creates a report generator.
+create_license_manager_report_generator(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_license_manager_report_generator(Client, Input, []).
+create_license_manager_report_generator(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateLicenseManagerReportGenerator">>, Input, Options).
 
 %% @doc Creates a new version of the specified license.
 create_license_version(Client, Input)
@@ -214,6 +246,18 @@ delete_license_configuration(Client, Input)
 delete_license_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteLicenseConfiguration">>, Input, Options).
+
+%% @doc Deletes the specified report generator.
+%%
+%% This action deletes the report generator, which stops it from generating
+%% future reports. The action cannot be reversed. It has no effect on the
+%% previous reports from this generator.
+delete_license_manager_report_generator(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_license_manager_report_generator(Client, Input, []).
+delete_license_manager_report_generator(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteLicenseManagerReportGenerator">>, Input, Options).
 
 %% @doc Deletes the specified token.
 %%
@@ -267,6 +311,22 @@ get_license_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetLicenseConfiguration">>, Input, Options).
 
+%% @doc Gets information about the specified license type conversion task.
+get_license_conversion_task(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_license_conversion_task(Client, Input, []).
+get_license_conversion_task(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetLicenseConversionTask">>, Input, Options).
+
+%% @doc Gets information about the specified report generator.
+get_license_manager_report_generator(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_license_manager_report_generator(Client, Input, []).
+get_license_manager_report_generator(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetLicenseManagerReportGenerator">>, Input, Options).
+
 %% @doc Gets detailed information about the usage of the specified license.
 get_license_usage(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -319,6 +379,22 @@ list_license_configurations(Client, Input)
 list_license_configurations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListLicenseConfigurations">>, Input, Options).
+
+%% @doc Lists the license type conversion tasks for your account.
+list_license_conversion_tasks(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_license_conversion_tasks(Client, Input, []).
+list_license_conversion_tasks(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListLicenseConversionTasks">>, Input, Options).
+
+%% @doc Lists the report generators for your account.
+list_license_manager_report_generators(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_license_manager_report_generators(Client, Input, []).
+list_license_manager_report_generators(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListLicenseManagerReportGenerators">>, Input, Options).
 
 %% @doc Describes the license configurations for the specified resource.
 list_license_specifications_for_resource(Client, Input)
@@ -429,11 +505,22 @@ update_license_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateLicenseConfiguration">>, Input, Options).
 
+%% @doc Updates a report generator.
+%%
+%% After you make changes to a report generator, it starts generating new
+%% reports within 60 minutes of being updated.
+update_license_manager_report_generator(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_license_manager_report_generator(Client, Input, []).
+update_license_manager_report_generator(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateLicenseManagerReportGenerator">>, Input, Options).
+
 %% @doc Adds or removes the specified license configurations for the
-%% specified AWS resource.
+%% specified Amazon Web Services resource.
 %%
 %% You can update the license specifications of AMIs, instances, and hosts.
-%% You cannot update the license specifications for launch templates and AWS
+%% You cannot update the license specifications for launch templates and
 %% CloudFormation templates, as they send license configurations to the
 %% operation that creates the resource.
 update_license_specifications_for_resource(Client, Input)

--- a/src/aws_lightsail.erl
+++ b/src/aws_lightsail.erl
@@ -6,16 +6,16 @@
 %% applications.
 %%
 %% It includes everything you need to launch your project quickly - instances
-%% (virtual private servers), container services, managed databases,
-%% SSD-based block storage, static IP addresses, load balancers, content
-%% delivery network (CDN) distributions, DNS management of registered
+%% (virtual private servers), container services, storage buckets, managed
+%% databases, SSD-based block storage, static IP addresses, load balancers,
+%% content delivery network (CDN) distributions, DNS management of registered
 %% domains, and resource snapshots (backups) - for a low, predictable monthly
 %% price.
 %%
 %% You can manage your Lightsail resources using the Lightsail console,
 %% Lightsail API, AWS Command Line Interface (AWS CLI), or SDKs. For more
-%% information about Lightsail concepts and tasks, see the Lightsail Dev
-%% Guide.
+%% information about Lightsail concepts and tasks, see the Amazon Lightsail
+%% Developer Guide.
 %%
 %% This API Reference provides detailed information about the actions, data
 %% types, parameters, and errors of the Lightsail service. For more
@@ -40,6 +40,10 @@
          close_instance_public_ports/3,
          copy_snapshot/2,
          copy_snapshot/3,
+         create_bucket/2,
+         create_bucket/3,
+         create_bucket_access_key/2,
+         create_bucket_access_key/3,
          create_certificate/2,
          create_certificate/3,
          create_cloud_formation_stack/2,
@@ -86,6 +90,10 @@
          delete_alarm/3,
          delete_auto_snapshot/2,
          delete_auto_snapshot/3,
+         delete_bucket/2,
+         delete_bucket/3,
+         delete_bucket_access_key/2,
+         delete_bucket_access_key/3,
          delete_certificate/2,
          delete_certificate/3,
          delete_contact_method/2,
@@ -144,6 +152,14 @@
          get_auto_snapshots/3,
          get_blueprints/2,
          get_blueprints/3,
+         get_bucket_access_keys/2,
+         get_bucket_access_keys/3,
+         get_bucket_bundles/2,
+         get_bucket_bundles/3,
+         get_bucket_metric_data/2,
+         get_bucket_metric_data/3,
+         get_buckets/2,
+         get_buckets/3,
          get_bundles/2,
          get_bundles/3,
          get_certificates/2,
@@ -278,6 +294,8 @@
          send_contact_method_verification/3,
          set_ip_address_type/2,
          set_ip_address_type/3,
+         set_resource_access_for_bucket/2,
+         set_resource_access_for_bucket/3,
          start_instance/2,
          start_instance/3,
          start_relational_database/2,
@@ -294,6 +312,10 @@
          unpeer_vpc/3,
          untag_resource/2,
          untag_resource/3,
+         update_bucket/2,
+         update_bucket/3,
+         update_bucket_bundle/2,
+         update_bucket_bundle/3,
          update_container_service/2,
          update_container_service/3,
          update_distribution/2,
@@ -349,7 +371,7 @@ attach_certificate_to_distribution(Client, Input, Options)
 %%
 %% The `attach disk' operation supports tag-based access control via resource
 %% tags applied to the resource identified by `disk name'. For more
-%% information, see the Lightsail Dev Guide.
+%% information, see the Amazon Lightsail Developer Guide.
 attach_disk(Client, Input)
   when is_map(Client), is_map(Input) ->
     attach_disk(Client, Input, []).
@@ -364,7 +386,8 @@ attach_disk(Client, Input, Options)
 %%
 %% The `attach instances to load balancer' operation supports tag-based
 %% access control via resource tags applied to the resource identified by
-%% `load balancer name'. For more information, see the Lightsail Dev Guide.
+%% `load balancer name'. For more information, see the Lightsail Developer
+%% Guide.
 attach_instances_to_load_balancer(Client, Input)
   when is_map(Client), is_map(Input) ->
     attach_instances_to_load_balancer(Client, Input, []).
@@ -385,7 +408,8 @@ attach_instances_to_load_balancer(Client, Input, Options)
 %%
 %% The `AttachLoadBalancerTlsCertificate' operation supports tag-based access
 %% control via resource tags applied to the resource identified by `load
-%% balancer name'. For more information, see the Lightsail Dev Guide.
+%% balancer name'. For more information, see the Amazon Lightsail Developer
+%% Guide.
 attach_load_balancer_tls_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     attach_load_balancer_tls_certificate(Client, Input, []).
@@ -405,7 +429,7 @@ attach_static_ip(Client, Input, Options)
 %%
 %% The `CloseInstancePublicPorts' action supports tag-based access control
 %% via resource tags applied to the resource identified by `instanceName'.
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 close_instance_public_ports(Client, Input)
   when is_map(Client), is_map(Input) ->
     close_instance_public_ports(Client, Input, []).
@@ -432,6 +456,43 @@ copy_snapshot(Client, Input)
 copy_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CopySnapshot">>, Input, Options).
+
+%% @doc Creates an Amazon Lightsail bucket.
+%%
+%% A bucket is a cloud storage resource available in the Lightsail object
+%% storage service. Use buckets to store objects such as data and its
+%% descriptive metadata. For more information about buckets, see Buckets in
+%% Amazon Lightsail in the Amazon Lightsail Developer Guide.
+create_bucket(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_bucket(Client, Input, []).
+create_bucket(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBucket">>, Input, Options).
+
+%% @doc Creates a new access key for the specified Amazon Lightsail bucket.
+%%
+%% Access keys consist of an access key ID and corresponding secret access
+%% key.
+%%
+%% Access keys grant full programmatic access to the specified bucket and its
+%% objects. You can have a maximum of two access keys per bucket. Use the
+%% `GetBucketAccessKeys' action to get a list of current access keys for a
+%% specific bucket. For more information about access keys, see Creating
+%% access keys for a bucket in Amazon Lightsail in the Amazon Lightsail
+%% Developer Guide.
+%%
+%% The `secretAccessKey' value is returned only in response to the
+%% `CreateBucketAccessKey' action. You can get a secret access key only when
+%% you first create an access key; you cannot get the secret access key
+%% later. If you lose the secret access key, you must create a new access
+%% key.
+create_bucket_access_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_bucket_access_key(Client, Input, []).
+create_bucket_access_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBucketAccessKey">>, Input, Options).
 
 %% @doc Creates an SSL/TLS certificate for an Amazon Lightsail content
 %% delivery network (CDN) distribution and a container service.
@@ -510,7 +571,7 @@ create_container_service(Client, Input, Options)
 %% You can deploy containers to your container service using container images
 %% from a public registry like Docker Hub, or from your local machine. For
 %% more information, see Creating container images for your Amazon Lightsail
-%% container services in the Lightsail Dev Guide.
+%% container services in the Amazon Lightsail Developer Guide.
 create_container_service_deployment(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_container_service_deployment(Client, Input, []).
@@ -539,7 +600,8 @@ create_container_service_deployment(Client, Input, Options)
 %% This action is not required if you install and use the Lightsail Control
 %% (lightsailctl) plugin to push container images to your Lightsail container
 %% service. For more information, see Pushing and managing container images
-%% on your Amazon Lightsail container services in the Lightsail Dev Guide.
+%% on your Amazon Lightsail container services in the Amazon Lightsail
+%% Developer Guide.
 create_container_service_registry_login(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_container_service_registry_login(Client, Input, []).
@@ -551,7 +613,7 @@ create_container_service_registry_login(Client, Input, Options)
 %% Lightsail instance in the same Availability Zone (e.g., `us-east-2a').
 %%
 %% The `create disk' operation supports tag-based access control via request
-%% tags. For more information, see the Lightsail Dev Guide.
+%% tags. For more information, see the Amazon Lightsail Developer Guide.
 create_disk(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_disk(Client, Input, []).
@@ -567,8 +629,8 @@ create_disk(Client, Input, Options)
 %%
 %% The `create disk from snapshot' operation supports tag-based access
 %% control via request tags and resource tags applied to the resource
-%% identified by `disk snapshot name'. For more information, see the
-%% Lightsail Dev Guide.
+%% identified by `disk snapshot name'. For more information, see the Amazon
+%% Lightsail Developer Guide.
 create_disk_from_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_disk_from_snapshot(Client, Input, []).
@@ -603,7 +665,8 @@ create_disk_from_snapshot(Client, Input, Options)
 %% running instance to access the data on the disk.
 %%
 %% The `create disk snapshot' operation supports tag-based access control via
-%% request tags. For more information, see the Lightsail Dev Guide.
+%% request tags. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_disk_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_disk_snapshot(Client, Input, []).
@@ -629,7 +692,8 @@ create_distribution(Client, Input, Options)
 %% example.com).
 %%
 %% The `create domain' operation supports tag-based access control via
-%% request tags. For more information, see the Lightsail Dev Guide.
+%% request tags. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_domain(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_domain(Client, Input, []).
@@ -644,7 +708,7 @@ create_domain(Client, Input, Options)
 %%
 %% The `create domain entry' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `domain name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 create_domain_entry(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_domain_entry(Client, Input, []).
@@ -658,7 +722,8 @@ create_domain_entry(Client, Input, Options)
 %% snapshot.
 %%
 %% The `create instance snapshot' operation supports tag-based access control
-%% via request tags. For more information, see the Lightsail Dev Guide.
+%% via request tags. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_instance_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_instance_snapshot(Client, Input, []).
@@ -669,7 +734,7 @@ create_instance_snapshot(Client, Input, Options)
 %% @doc Creates one or more Amazon Lightsail instances.
 %%
 %% The `create instances' operation supports tag-based access control via
-%% request tags. For more information, see the Lightsail Dev Guide.
+%% request tags. For more information, see the Lightsail Developer Guide.
 create_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_instances(Client, Input, []).
@@ -683,7 +748,7 @@ create_instances(Client, Input, Options)
 %% The `create instances from snapshot' operation supports tag-based access
 %% control via request tags and resource tags applied to the resource
 %% identified by `instance snapshot name'. For more information, see the
-%% Lightsail Dev Guide.
+%% Amazon Lightsail Developer Guide.
 create_instances_from_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_instances_from_snapshot(Client, Input, []).
@@ -694,7 +759,8 @@ create_instances_from_snapshot(Client, Input, Options)
 %% @doc Creates an SSH key pair.
 %%
 %% The `create key pair' operation supports tag-based access control via
-%% request tags. For more information, see the Lightsail Dev Guide.
+%% request tags. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_key_pair(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_key_pair(Client, Input, []).
@@ -713,7 +779,8 @@ create_key_pair(Client, Input, Options)
 %% `UpdateLoadBalancerAttribute' operation.
 %%
 %% The `create load balancer' operation supports tag-based access control via
-%% request tags. For more information, see the Lightsail Dev Guide.
+%% request tags. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_load_balancer(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_load_balancer(Client, Input, []).
@@ -727,7 +794,8 @@ create_load_balancer(Client, Input, Options)
 %%
 %% The `CreateLoadBalancerTlsCertificate' operation supports tag-based access
 %% control via resource tags applied to the resource identified by `load
-%% balancer name'. For more information, see the Lightsail Dev Guide.
+%% balancer name'. For more information, see the Amazon Lightsail Developer
+%% Guide.
 create_load_balancer_tls_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_load_balancer_tls_certificate(Client, Input, []).
@@ -738,8 +806,8 @@ create_load_balancer_tls_certificate(Client, Input, Options)
 %% @doc Creates a new database in Amazon Lightsail.
 %%
 %% The `create relational database' operation supports tag-based access
-%% control via request tags. For more information, see the Lightsail Dev
-%% Guide.
+%% control via request tags. For more information, see the Amazon Lightsail
+%% Developer Guide.
 create_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_relational_database(Client, Input, []).
@@ -757,7 +825,7 @@ create_relational_database(Client, Input, Options)
 %% The `create relational database from snapshot' operation supports
 %% tag-based access control via request tags and resource tags applied to the
 %% resource identified by relationalDatabaseSnapshotName. For more
-%% information, see the Lightsail Dev Guide.
+%% information, see the Amazon Lightsail Developer Guide.
 create_relational_database_from_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_relational_database_from_snapshot(Client, Input, []).
@@ -771,8 +839,8 @@ create_relational_database_from_snapshot(Client, Input, Options)
 %% save data before deleting a database.
 %%
 %% The `create relational database snapshot' operation supports tag-based
-%% access control via request tags. For more information, see the Lightsail
-%% Dev Guide.
+%% access control via request tags. For more information, see the Amazon
+%% Lightsail Developer Guide.
 create_relational_database_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_relational_database_snapshot(Client, Input, []).
@@ -795,13 +863,38 @@ delete_alarm(Client, Input, Options)
 
 %% @doc Deletes an automatic snapshot of an instance or disk.
 %%
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 delete_auto_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_auto_snapshot(Client, Input, []).
 delete_auto_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAutoSnapshot">>, Input, Options).
+
+%% @doc Deletes a Amazon Lightsail bucket.
+%%
+%% When you delete your bucket, the bucket name is released and can be reused
+%% for a new bucket in your account or another AWS account.
+delete_bucket(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_bucket(Client, Input, []).
+delete_bucket(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBucket">>, Input, Options).
+
+%% @doc Deletes an access key for the specified Amazon Lightsail bucket.
+%%
+%% We recommend that you delete an access key if the secret access key is
+%% compromised.
+%%
+%% For more information about access keys, see Creating access keys for a
+%% bucket in Amazon Lightsail in the Amazon Lightsail Developer Guide.
+delete_bucket_access_key(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_bucket_access_key(Client, Input, []).
+delete_bucket_access_key(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBucketAccessKey">>, Input, Options).
 
 %% @doc Deletes an SSL/TLS certificate for your Amazon Lightsail content
 %% delivery network (CDN) distribution.
@@ -857,7 +950,7 @@ delete_container_service(Client, Input, Options)
 %%
 %% The `delete disk' operation supports tag-based access control via resource
 %% tags applied to the resource identified by `disk name'. For more
-%% information, see the Lightsail Dev Guide.
+%% information, see the Amazon Lightsail Developer Guide.
 delete_disk(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_disk(Client, Input, []).
@@ -876,7 +969,7 @@ delete_disk(Client, Input, Options)
 %%
 %% The `delete disk snapshot' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `disk snapshot name'.
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 delete_disk_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_disk_snapshot(Client, Input, []).
@@ -897,7 +990,7 @@ delete_distribution(Client, Input, Options)
 %%
 %% The `delete domain' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `domain name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 delete_domain(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_domain(Client, Input, []).
@@ -909,7 +1002,7 @@ delete_domain(Client, Input, Options)
 %%
 %% The `delete domain entry' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `domain name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 delete_domain_entry(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_domain_entry(Client, Input, []).
@@ -921,7 +1014,7 @@ delete_domain_entry(Client, Input, Options)
 %%
 %% The `delete instance' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `instance name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 delete_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_instance(Client, Input, []).
@@ -934,7 +1027,7 @@ delete_instance(Client, Input, Options)
 %%
 %% The `delete instance snapshot' operation supports tag-based access control
 %% via resource tags applied to the resource identified by `instance snapshot
-%% name'. For more information, see the Lightsail Dev Guide.
+%% name'. For more information, see the Amazon Lightsail Developer Guide.
 delete_instance_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_instance_snapshot(Client, Input, []).
@@ -946,7 +1039,7 @@ delete_instance_snapshot(Client, Input, Options)
 %%
 %% The `delete key pair' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `key pair name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 delete_key_pair(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_key_pair(Client, Input, []).
@@ -980,7 +1073,7 @@ delete_known_host_keys(Client, Input, Options)
 %%
 %% The `delete load balancer' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `load balancer name'.
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 delete_load_balancer(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_load_balancer(Client, Input, []).
@@ -993,7 +1086,8 @@ delete_load_balancer(Client, Input, Options)
 %%
 %% The `DeleteLoadBalancerTlsCertificate' operation supports tag-based access
 %% control via resource tags applied to the resource identified by `load
-%% balancer name'. For more information, see the Lightsail Dev Guide.
+%% balancer name'. For more information, see the Amazon Lightsail Developer
+%% Guide.
 delete_load_balancer_tls_certificate(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_load_balancer_tls_certificate(Client, Input, []).
@@ -1005,7 +1099,8 @@ delete_load_balancer_tls_certificate(Client, Input, Options)
 %%
 %% The `delete relational database' operation supports tag-based access
 %% control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 delete_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_relational_database(Client, Input, []).
@@ -1017,7 +1112,8 @@ delete_relational_database(Client, Input, Options)
 %%
 %% The `delete relational database snapshot' operation supports tag-based
 %% access control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 delete_relational_database_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_relational_database_snapshot(Client, Input, []).
@@ -1044,7 +1140,7 @@ detach_certificate_from_distribution(Client, Input, Options)
 %%
 %% The `detach disk' operation supports tag-based access control via resource
 %% tags applied to the resource identified by `disk name'. For more
-%% information, see the Lightsail Dev Guide.
+%% information, see the Amazon Lightsail Developer Guide.
 detach_disk(Client, Input)
   when is_map(Client), is_map(Input) ->
     detach_disk(Client, Input, []).
@@ -1059,7 +1155,8 @@ detach_disk(Client, Input, Options)
 %%
 %% The `detach instances from load balancer' operation supports tag-based
 %% access control via resource tags applied to the resource identified by
-%% `load balancer name'. For more information, see the Lightsail Dev Guide.
+%% `load balancer name'. For more information, see the Amazon Lightsail
+%% Developer Guide.
 detach_instances_from_load_balancer(Client, Input)
   when is_map(Client), is_map(Input) ->
     detach_instances_from_load_balancer(Client, Input, []).
@@ -1078,7 +1175,7 @@ detach_static_ip(Client, Input, Options)
 
 %% @doc Disables an add-on for an Amazon Lightsail resource.
 %%
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 disable_add_on(Client, Input)
   when is_map(Client), is_map(Input) ->
     disable_add_on(Client, Input, []).
@@ -1096,7 +1193,7 @@ download_default_key_pair(Client, Input, Options)
 
 %% @doc Enables or modifies an add-on for an Amazon Lightsail resource.
 %%
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 enable_add_on(Client, Input)
   when is_map(Client), is_map(Input) ->
     enable_add_on(Client, Input, []).
@@ -1119,7 +1216,7 @@ enable_add_on(Client, Input, Options)
 %%
 %% The `export snapshot' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `source snapshot
-%% name'. For more information, see the Lightsail Dev Guide.
+%% name'. For more information, see the Amazon Lightsail Developer Guide.
 %%
 %% Use the `get instance snapshots' or `get disk snapshots' operations to get
 %% a list of snapshots that you can export to Amazon EC2.
@@ -1157,7 +1254,7 @@ get_alarms(Client, Input, Options)
 
 %% @doc Returns the available automatic snapshots for an instance or disk.
 %%
-%% For more information, see the Lightsail Dev Guide.
+%% For more information, see the Amazon Lightsail Developer Guide.
 get_auto_snapshots(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_auto_snapshots(Client, Input, []).
@@ -1183,6 +1280,57 @@ get_blueprints(Client, Input)
 get_blueprints(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetBlueprints">>, Input, Options).
+
+%% @doc Returns the existing access key IDs for the specified Amazon
+%% Lightsail bucket.
+%%
+%% This action does not return the secret access key value of an access key.
+%% You can get a secret access key only when you create it from the response
+%% of the `CreateBucketAccessKey' action. If you lose the secret access key,
+%% you must create a new access key.
+get_bucket_access_keys(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_bucket_access_keys(Client, Input, []).
+get_bucket_access_keys(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBucketAccessKeys">>, Input, Options).
+
+%% @doc Returns the bundles that you can apply to a Amazon Lightsail bucket.
+%%
+%% The bucket bundle specifies the monthly cost, storage quota, and data
+%% transfer quota for a bucket.
+%%
+%% Use the `UpdateBucketBundle' action to update the bundle for a bucket.
+get_bucket_bundles(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_bucket_bundles(Client, Input, []).
+get_bucket_bundles(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBucketBundles">>, Input, Options).
+
+%% @doc Returns the data points of a specific metric for an Amazon Lightsail
+%% bucket.
+%%
+%% Metrics report the utilization of a bucket. View and collect metric data
+%% regularly to monitor the number of objects stored in a bucket (including
+%% object versions) and the storage space used by those objects.
+get_bucket_metric_data(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_bucket_metric_data(Client, Input, []).
+get_bucket_metric_data(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBucketMetricData">>, Input, Options).
+
+%% @doc Returns information about one or more Amazon Lightsail buckets.
+%%
+%% For more information about buckets, see Buckets in Amazon Lightsail in the
+%% Amazon Lightsail Developer Guide..
+get_buckets(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_buckets(Client, Input, []).
+get_buckets(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBuckets">>, Input, Options).
 
 %% @doc Returns the list of bundles that are available for purchase.
 %%
@@ -1364,7 +1512,7 @@ get_disks(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetDisks">>, Input, Options).
 
-%% @doc Returns the list bundles that can be applied to you Amazon Lightsail
+%% @doc Returns the bundles that can be applied to your Amazon Lightsail
 %% content delivery network (CDN) distributions.
 %%
 %% A distribution bundle specifies the monthly network transfer quota and
@@ -1423,12 +1571,11 @@ get_domains(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetDomains">>, Input, Options).
 
-%% @doc Returns the export snapshot record created as a result of the `export
-%% snapshot' operation.
+%% @doc Returns all export snapshot records created as a result of the
+%% `export snapshot' operation.
 %%
 %% An export snapshot record can be used to create a new Amazon EC2 instance
-%% and its related resources with the `create cloud formation stack'
-%% operation.
+%% and its related resources with the `CreateCloudFormationStack' action.
 get_export_snapshot_records(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_export_snapshot_records(Client, Input, []).
@@ -1450,7 +1597,7 @@ get_instance(Client, Input, Options)
 %%
 %% The `get instance access details' operation supports tag-based access
 %% control via resource tags applied to the resource identified by `instance
-%% name'. For more information, see the Lightsail Dev Guide.
+%% name'. For more information, see the Amazon Lightsail Developer Guide.
 get_instance_access_details(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_instance_access_details(Client, Input, []).
@@ -1743,7 +1890,7 @@ get_relational_databases(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetRelationalDatabases">>, Input, Options).
 
-%% @doc Returns information about a specific static IP.
+%% @doc Returns information about an Amazon Lightsail static IP.
 get_static_ip(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_static_ip(Client, Input, []).
@@ -1782,7 +1929,7 @@ is_vpc_peered(Client, Input, Options)
 %%
 %% The `OpenInstancePublicPorts' action supports tag-based access control via
 %% resource tags applied to the resource identified by `instanceName'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 open_instance_public_ports(Client, Input)
   when is_map(Client), is_map(Input) ->
     open_instance_public_ports(Client, Input, []).
@@ -1790,7 +1937,7 @@ open_instance_public_ports(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"OpenInstancePublicPorts">>, Input, Options).
 
-%% @doc Tries to peer the Lightsail VPC with the user's default VPC.
+%% @doc Peers the Lightsail VPC with the user's default VPC.
 peer_vpc(Client, Input)
   when is_map(Client), is_map(Input) ->
     peer_vpc(Client, Input, []).
@@ -1833,7 +1980,7 @@ put_alarm(Client, Input, Options)
 %%
 %% The `PutInstancePublicPorts' action supports tag-based access control via
 %% resource tags applied to the resource identified by `instanceName'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 put_instance_public_ports(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_instance_public_ports(Client, Input, []).
@@ -1845,7 +1992,7 @@ put_instance_public_ports(Client, Input, Options)
 %%
 %% The `reboot instance' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `instance name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 reboot_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     reboot_instance(Client, Input, []).
@@ -1857,7 +2004,8 @@ reboot_instance(Client, Input, Options)
 %%
 %% The `reboot relational database' operation supports tag-based access
 %% control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 reboot_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     reboot_relational_database(Client, Input, []).
@@ -1871,7 +2019,8 @@ reboot_relational_database(Client, Input, Options)
 %% This action is not required if you install and use the Lightsail Control
 %% (lightsailctl) plugin to push container images to your Lightsail container
 %% service. For more information, see Pushing and managing container images
-%% on your Amazon Lightsail container services in the Lightsail Dev Guide.
+%% on your Amazon Lightsail container services in the Amazon Lightsail
+%% Developer Guide.
 register_container_image(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_container_image(Client, Input, []).
@@ -1936,6 +2085,18 @@ set_ip_address_type(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SetIpAddressType">>, Input, Options).
 
+%% @doc Sets the Amazon Lightsail resources that can access the specified
+%% Lightsail bucket.
+%%
+%% Lightsail buckets currently support setting access for Lightsail instances
+%% in the same AWS Region.
+set_resource_access_for_bucket(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    set_resource_access_for_bucket(Client, Input, []).
+set_resource_access_for_bucket(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SetResourceAccessForBucket">>, Input, Options).
+
 %% @doc Starts a specific Amazon Lightsail instance from a stopped state.
 %%
 %% To restart an instance, use the `reboot instance' operation.
@@ -1943,11 +2104,11 @@ set_ip_address_type(Client, Input, Options)
 %% When you start a stopped instance, Lightsail assigns a new public IP
 %% address to the instance. To use the same IP address after stopping and
 %% starting an instance, create a static IP address and attach it to the
-%% instance. For more information, see the Lightsail Dev Guide.
+%% instance. For more information, see the Amazon Lightsail Developer Guide.
 %%
 %% The `start instance' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `instance name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 start_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_instance(Client, Input, []).
@@ -1961,7 +2122,8 @@ start_instance(Client, Input, Options)
 %%
 %% The `start relational database' operation supports tag-based access
 %% control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 start_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_relational_database(Client, Input, []).
@@ -1974,11 +2136,11 @@ start_relational_database(Client, Input, Options)
 %% When you start a stopped instance, Lightsail assigns a new public IP
 %% address to the instance. To use the same IP address after stopping and
 %% starting an instance, create a static IP address and attach it to the
-%% instance. For more information, see the Lightsail Dev Guide.
+%% instance. For more information, see the Amazon Lightsail Developer Guide.
 %%
 %% The `stop instance' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `instance name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 stop_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_instance(Client, Input, []).
@@ -1991,7 +2153,8 @@ stop_instance(Client, Input, Options)
 %%
 %% The `stop relational database' operation supports tag-based access control
 %% via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 stop_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_relational_database(Client, Input, []).
@@ -2003,11 +2166,11 @@ stop_relational_database(Client, Input, Options)
 %%
 %% Each resource can have a maximum of 50 tags. Each tag consists of a key
 %% and an optional value. Tag keys must be unique per resource. For more
-%% information about tags, see the Lightsail Dev Guide.
+%% information about tags, see the Amazon Lightsail Developer Guide.
 %%
 %% The `tag resource' operation supports tag-based access control via request
 %% tags and resource tags applied to the resource identified by `resource
-%% name'. For more information, see the Lightsail Dev Guide.
+%% name'. For more information, see the Amazon Lightsail Developer Guide.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -2033,7 +2196,7 @@ test_alarm(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TestAlarm">>, Input, Options).
 
-%% @doc Attempts to unpeer the Lightsail VPC from the user's default VPC.
+%% @doc Unpeers the Lightsail VPC from the user's default VPC.
 unpeer_vpc(Client, Input)
   when is_map(Client), is_map(Input) ->
     unpeer_vpc(Client, Input, []).
@@ -2046,13 +2209,51 @@ unpeer_vpc(Client, Input, Options)
 %%
 %% The `untag resource' operation supports tag-based access control via
 %% request tags and resource tags applied to the resource identified by
-%% `resource name'. For more information, see the Lightsail Dev Guide.
+%% `resource name'. For more information, see the Amazon Lightsail Developer
+%% Guide.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
 untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates an existing Amazon Lightsail bucket.
+%%
+%% Use this action to update the configuration of an existing bucket, such as
+%% versioning, public accessibility, and the AWS accounts that can access the
+%% bucket.
+update_bucket(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_bucket(Client, Input, []).
+update_bucket(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateBucket">>, Input, Options).
+
+%% @doc Updates the bundle, or storage plan, of an existing Amazon Lightsail
+%% bucket.
+%%
+%% A bucket bundle specifies the monthly cost, storage space, and data
+%% transfer quota for a bucket. You can update a bucket's bundle only one
+%% time within a monthly AWS billing cycle. To determine if you can update a
+%% bucket's bundle, use the `GetBuckets' action. The `ableToUpdateBundle'
+%% parameter in the response will indicate whether you can currently update a
+%% bucket's bundle.
+%%
+%% Update a bucket's bundle if it's consistently going over its storage space
+%% or data transfer quota, or if a bucket's usage is consistently in the
+%% lower range of its storage space or data transfer quota. Due to the
+%% unpredictable usage fluctuations that a bucket might experience, we
+%% strongly recommend that you update a bucket's bundle only as a long-term
+%% strategy, instead of as a short-term, monthly cost-cutting measure. Choose
+%% a bucket bundle that will provide the bucket with ample storage space and
+%% data transfer for a long time to come.
+update_bucket_bundle(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_bucket_bundle(Client, Input, []).
+update_bucket_bundle(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateBucketBundle">>, Input, Options).
 
 %% @doc Updates the configuration of your Amazon Lightsail container service,
 %% such as its power, scale, and public domain names.
@@ -2066,7 +2267,7 @@ update_container_service(Client, Input, Options)
 %% @doc Updates an existing Amazon Lightsail content delivery network (CDN)
 %% distribution.
 %%
-%% Use this action to update the configuration of your existing distribution
+%% Use this action to update the configuration of your existing distribution.
 update_distribution(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_distribution(Client, Input, []).
@@ -2099,7 +2300,7 @@ update_distribution_bundle(Client, Input, Options)
 %%
 %% The `update domain entry' operation supports tag-based access control via
 %% resource tags applied to the resource identified by `domain name'. For
-%% more information, see the Lightsail Dev Guide.
+%% more information, see the Amazon Lightsail Developer Guide.
 update_domain_entry(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_domain_entry(Client, Input, []).
@@ -2113,7 +2314,8 @@ update_domain_entry(Client, Input, Options)
 %%
 %% The `update load balancer attribute' operation supports tag-based access
 %% control via resource tags applied to the resource identified by `load
-%% balancer name'. For more information, see the Lightsail Dev Guide.
+%% balancer name'. For more information, see the Amazon Lightsail Developer
+%% Guide.
 update_load_balancer_attribute(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_load_balancer_attribute(Client, Input, []).
@@ -2130,7 +2332,8 @@ update_load_balancer_attribute(Client, Input, Options)
 %%
 %% The `update relational database' operation supports tag-based access
 %% control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 update_relational_database(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_relational_database(Client, Input, []).
@@ -2151,7 +2354,8 @@ update_relational_database(Client, Input, Options)
 %%
 %% The `update relational database parameters' operation supports tag-based
 %% access control via resource tags applied to the resource identified by
-%% relationalDatabaseName. For more information, see the Lightsail Dev Guide.
+%% relationalDatabaseName. For more information, see the Amazon Lightsail
+%% Developer Guide.
 update_relational_database_parameters(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_relational_database_parameters(Client, Input, []).

--- a/src/aws_lookoutequipment.erl
+++ b/src/aws_lookoutequipment.erl
@@ -1,0 +1,346 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Lookout for Equipment is a machine learning service that uses
+%% advanced analytics to identify anomalies in machines from sensor data for
+%% use in predictive maintenance.
+-module(aws_lookoutequipment).
+
+-export([create_dataset/2,
+         create_dataset/3,
+         create_inference_scheduler/2,
+         create_inference_scheduler/3,
+         create_model/2,
+         create_model/3,
+         delete_dataset/2,
+         delete_dataset/3,
+         delete_inference_scheduler/2,
+         delete_inference_scheduler/3,
+         delete_model/2,
+         delete_model/3,
+         describe_data_ingestion_job/2,
+         describe_data_ingestion_job/3,
+         describe_dataset/2,
+         describe_dataset/3,
+         describe_inference_scheduler/2,
+         describe_inference_scheduler/3,
+         describe_model/2,
+         describe_model/3,
+         list_data_ingestion_jobs/2,
+         list_data_ingestion_jobs/3,
+         list_datasets/2,
+         list_datasets/3,
+         list_inference_executions/2,
+         list_inference_executions/3,
+         list_inference_schedulers/2,
+         list_inference_schedulers/3,
+         list_models/2,
+         list_models/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         start_data_ingestion_job/2,
+         start_data_ingestion_job/3,
+         start_inference_scheduler/2,
+         start_inference_scheduler/3,
+         stop_inference_scheduler/2,
+         stop_inference_scheduler/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_inference_scheduler/2,
+         update_inference_scheduler/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a container for a collection of data being ingested for
+%% analysis.
+%%
+%% The dataset contains the metadata describing where the data is and what
+%% the data actually looks like. In other words, it contains the location of
+%% the data source, the data schema, and other information. A dataset also
+%% contains any tags associated with the ingested data.
+create_dataset(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_dataset(Client, Input, []).
+create_dataset(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDataset">>, Input, Options).
+
+%% @doc Creates a scheduled inference.
+%%
+%% Scheduling an inference is setting up a continuous real-time inference
+%% plan to analyze new measurement data. When setting up the schedule, you
+%% provide an S3 bucket location for the input data, assign it a delimiter
+%% between separate entries in the data, set an offset delay if desired, and
+%% set the frequency of inferencing. You must also provide an S3 bucket
+%% location for the output data.
+create_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_inference_scheduler(Client, Input, []).
+create_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateInferenceScheduler">>, Input, Options).
+
+%% @doc Creates an ML model for data inference.
+%%
+%% A machine-learning (ML) model is a mathematical model that finds patterns
+%% in your data. In Amazon Lookout for Equipment, the model learns the
+%% patterns of normal behavior and detects abnormal behavior that could be
+%% potential equipment failure (or maintenance events). The models are made
+%% by analyzing normal data and abnormalities in machine behavior that have
+%% already occurred.
+%%
+%% Your model is trained using a portion of the data from your dataset and
+%% uses that data to learn patterns of normal behavior and abnormal patterns
+%% that lead to equipment failure. Another portion of the data is used to
+%% evaluate the model's accuracy.
+create_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_model(Client, Input, []).
+create_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateModel">>, Input, Options).
+
+%% @doc Deletes a dataset and associated artifacts.
+%%
+%% The operation will check to see if any inference scheduler or data
+%% ingestion job is currently using the dataset, and if there isn't, the
+%% dataset, its metadata, and any associated data stored in S3 will be
+%% deleted. This does not affect any models that used this dataset for
+%% training and evaluation, but does prevent it from being used in the
+%% future.
+delete_dataset(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_dataset(Client, Input, []).
+delete_dataset(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteDataset">>, Input, Options).
+
+%% @doc Deletes an inference scheduler that has been set up.
+%%
+%% Already processed output results are not affected.
+delete_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_inference_scheduler(Client, Input, []).
+delete_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteInferenceScheduler">>, Input, Options).
+
+%% @doc Deletes an ML model currently available for Amazon Lookout for
+%% Equipment.
+%%
+%% This will prevent it from being used with an inference scheduler, even one
+%% that is already set up.
+delete_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_model(Client, Input, []).
+delete_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteModel">>, Input, Options).
+
+%% @doc Provides information on a specific data ingestion job such as
+%% creation time, dataset ARN, status, and so on.
+describe_data_ingestion_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_data_ingestion_job(Client, Input, []).
+describe_data_ingestion_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataIngestionJob">>, Input, Options).
+
+%% @doc Provides a JSON description of the data that is in each time series
+%% dataset, including names, column names, and data types.
+describe_dataset(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_dataset(Client, Input, []).
+describe_dataset(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataset">>, Input, Options).
+
+%% @doc Specifies information about the inference scheduler being used,
+%% including name, model, status, and associated metadata
+describe_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_inference_scheduler(Client, Input, []).
+describe_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeInferenceScheduler">>, Input, Options).
+
+%% @doc Provides a JSON containing the overall information about a specific
+%% ML model, including model name and ARN, dataset, training and evaluation
+%% information, status, and so on.
+describe_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_model(Client, Input, []).
+describe_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeModel">>, Input, Options).
+
+%% @doc Provides a list of all data ingestion jobs, including dataset name
+%% and ARN, S3 location of the input data, status, and so on.
+list_data_ingestion_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_data_ingestion_jobs(Client, Input, []).
+list_data_ingestion_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDataIngestionJobs">>, Input, Options).
+
+%% @doc Lists all datasets currently available in your account, filtering on
+%% the dataset name.
+list_datasets(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_datasets(Client, Input, []).
+list_datasets(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDatasets">>, Input, Options).
+
+%% @doc Lists all inference executions that have been performed by the
+%% specified inference scheduler.
+list_inference_executions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_inference_executions(Client, Input, []).
+list_inference_executions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListInferenceExecutions">>, Input, Options).
+
+%% @doc Retrieves a list of all inference schedulers currently available for
+%% your account.
+list_inference_schedulers(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_inference_schedulers(Client, Input, []).
+list_inference_schedulers(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListInferenceSchedulers">>, Input, Options).
+
+%% @doc Generates a list of all models in the account, including model name
+%% and ARN, dataset, and status.
+list_models(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_models(Client, Input, []).
+list_models(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListModels">>, Input, Options).
+
+%% @doc Lists all the tags for a specified resource, including key and value.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc Starts a data ingestion job.
+%%
+%% Amazon Lookout for Equipment returns the job status.
+start_data_ingestion_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_data_ingestion_job(Client, Input, []).
+start_data_ingestion_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartDataIngestionJob">>, Input, Options).
+
+%% @doc Starts an inference scheduler.
+start_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_inference_scheduler(Client, Input, []).
+start_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartInferenceScheduler">>, Input, Options).
+
+%% @doc Stops an inference scheduler.
+stop_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    stop_inference_scheduler(Client, Input, []).
+stop_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StopInferenceScheduler">>, Input, Options).
+
+%% @doc Associates a given tag to a resource in your account.
+%%
+%% A tag is a key-value pair which can be added to an Amazon Lookout for
+%% Equipment resource as metadata. Tags can be used for organizing your
+%% resources as well as helping you to search and filter by tag. Multiple
+%% tags can be added to a resource, either when you create it, or later. Up
+%% to 50 tags can be associated with each resource.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes a specific tag from a given resource.
+%%
+%% The tag is specified by its key.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates an inference scheduler.
+update_inference_scheduler(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_inference_scheduler(Client, Input, []).
+update_inference_scheduler(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateInferenceScheduler">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"lookoutequipment">>},
+    Host = build_host(<<"lookoutequipment">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"AWSLookoutEquipmentFrontendService.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_lookoutmetrics.erl
+++ b/src/aws_lookoutmetrics.erl
@@ -1,0 +1,758 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc This is the Amazon Lookout for Metrics API Reference.
+%%
+%% For an introduction to the service with tutorials for getting started,
+%% visit Amazon Lookout for Metrics Developer Guide.
+-module(aws_lookoutmetrics).
+
+-export([activate_anomaly_detector/2,
+         activate_anomaly_detector/3,
+         back_test_anomaly_detector/2,
+         back_test_anomaly_detector/3,
+         create_alert/2,
+         create_alert/3,
+         create_anomaly_detector/2,
+         create_anomaly_detector/3,
+         create_metric_set/2,
+         create_metric_set/3,
+         delete_alert/2,
+         delete_alert/3,
+         delete_anomaly_detector/2,
+         delete_anomaly_detector/3,
+         describe_alert/2,
+         describe_alert/3,
+         describe_anomaly_detection_executions/2,
+         describe_anomaly_detection_executions/3,
+         describe_anomaly_detector/2,
+         describe_anomaly_detector/3,
+         describe_metric_set/2,
+         describe_metric_set/3,
+         get_anomaly_group/2,
+         get_anomaly_group/3,
+         get_feedback/2,
+         get_feedback/3,
+         get_sample_data/2,
+         get_sample_data/3,
+         list_alerts/2,
+         list_alerts/3,
+         list_anomaly_detectors/2,
+         list_anomaly_detectors/3,
+         list_anomaly_group_summaries/2,
+         list_anomaly_group_summaries/3,
+         list_anomaly_group_time_series/2,
+         list_anomaly_group_time_series/3,
+         list_metric_sets/2,
+         list_metric_sets/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         put_feedback/2,
+         put_feedback/3,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_anomaly_detector/2,
+         update_anomaly_detector/3,
+         update_metric_set/2,
+         update_metric_set/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Activates an anomaly detector.
+activate_anomaly_detector(Client, Input) ->
+    activate_anomaly_detector(Client, Input, []).
+activate_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ActivateAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Runs a backtest for anomaly detection for the specified resource.
+back_test_anomaly_detector(Client, Input) ->
+    back_test_anomaly_detector(Client, Input, []).
+back_test_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/BackTestAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an alert for an anomaly detector.
+create_alert(Client, Input) ->
+    create_alert(Client, Input, []).
+create_alert(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/CreateAlert"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an anomaly detector.
+create_anomaly_detector(Client, Input) ->
+    create_anomaly_detector(Client, Input, []).
+create_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/CreateAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a dataset.
+create_metric_set(Client, Input) ->
+    create_metric_set(Client, Input, []).
+create_metric_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/CreateMetricSet"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an alert.
+delete_alert(Client, Input) ->
+    delete_alert(Client, Input, []).
+delete_alert(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteAlert"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a detector.
+%%
+%% Deleting an anomaly detector will delete all of its corresponding
+%% resources including any configured datasets and alerts.
+delete_anomaly_detector(Client, Input) ->
+    delete_anomaly_detector(Client, Input, []).
+delete_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes an alert.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+describe_alert(Client, Input) ->
+    describe_alert(Client, Input, []).
+describe_alert(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeAlert"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns information about the status of the specified anomaly
+%% detection jobs.
+describe_anomaly_detection_executions(Client, Input) ->
+    describe_anomaly_detection_executions(Client, Input, []).
+describe_anomaly_detection_executions(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeAnomalyDetectionExecutions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes a detector.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+describe_anomaly_detector(Client, Input) ->
+    describe_anomaly_detector(Client, Input, []).
+describe_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes a dataset.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+describe_metric_set(Client, Input) ->
+    describe_metric_set(Client, Input, []).
+describe_metric_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeMetricSet"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns details about a group of anomalous metrics.
+get_anomaly_group(Client, Input) ->
+    get_anomaly_group(Client, Input, []).
+get_anomaly_group(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetAnomalyGroup"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Get feedback for an anomaly group.
+get_feedback(Client, Input) ->
+    get_feedback(Client, Input, []).
+get_feedback(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetFeedback"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a selection of sample records from an Amazon S3 datasource.
+get_sample_data(Client, Input) ->
+    get_sample_data(Client, Input, []).
+get_sample_data(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetSampleData"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the alerts attached to a detector.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+list_alerts(Client, Input) ->
+    list_alerts(Client, Input, []).
+list_alerts(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListAlerts"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the detectors in the current AWS Region.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+list_anomaly_detectors(Client, Input) ->
+    list_anomaly_detectors(Client, Input, []).
+list_anomaly_detectors(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListAnomalyDetectors"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a list of anomaly groups.
+list_anomaly_group_summaries(Client, Input) ->
+    list_anomaly_group_summaries(Client, Input, []).
+list_anomaly_group_summaries(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListAnomalyGroupSummaries"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets a list of anomalous metrics for a measure in an anomaly group.
+list_anomaly_group_time_series(Client, Input) ->
+    list_anomaly_group_time_series(Client, Input, []).
+list_anomaly_group_time_series(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListAnomalyGroupTimeSeries"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the datasets in the current AWS Region.
+%%
+%% Amazon Lookout for Metrics API actions are eventually consistent. If you
+%% do a read operation on a resource immediately after creating or modifying
+%% it, use retries to allow time for the write operation to complete.
+list_metric_sets(Client, Input) ->
+    list_metric_sets(Client, Input, []).
+list_metric_sets(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ListMetricSets"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets a list of tags for a detector, dataset, or alert.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Add feedback for an anomalous metric.
+put_feedback(Client, Input) ->
+    put_feedback(Client, Input, []).
+put_feedback(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/PutFeedback"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds tags to a detector, dataset, or alert.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes tags from a detector, dataset, or alert.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"TagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a detector.
+%%
+%% After activation, you can only change a detector's ingestion delay and
+%% description.
+update_anomaly_detector(Client, Input) ->
+    update_anomaly_detector(Client, Input, []).
+update_anomaly_detector(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/UpdateAnomalyDetector"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a dataset.
+update_metric_set(Client, Input) ->
+    update_metric_set(Client, Input, []).
+update_metric_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/UpdateMetricSet"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"lookoutmetrics">>},
+    Host = build_host(<<"lookoutmetrics">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_lookoutvision.erl
+++ b/src/aws_lookoutvision.erl
@@ -740,6 +740,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_machine_learning.erl
+++ b/src/aws_machine_learning.erl
@@ -1,0 +1,551 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Definition of the public APIs exposed by Amazon Machine Learning
+-module(aws_machine_learning).
+
+-export([add_tags/2,
+         add_tags/3,
+         create_batch_prediction/2,
+         create_batch_prediction/3,
+         create_data_source_from_rds/2,
+         create_data_source_from_rds/3,
+         create_data_source_from_redshift/2,
+         create_data_source_from_redshift/3,
+         create_data_source_from_s3/2,
+         create_data_source_from_s3/3,
+         create_evaluation/2,
+         create_evaluation/3,
+         create_ml_model/2,
+         create_ml_model/3,
+         create_realtime_endpoint/2,
+         create_realtime_endpoint/3,
+         delete_batch_prediction/2,
+         delete_batch_prediction/3,
+         delete_data_source/2,
+         delete_data_source/3,
+         delete_evaluation/2,
+         delete_evaluation/3,
+         delete_ml_model/2,
+         delete_ml_model/3,
+         delete_realtime_endpoint/2,
+         delete_realtime_endpoint/3,
+         delete_tags/2,
+         delete_tags/3,
+         describe_batch_predictions/2,
+         describe_batch_predictions/3,
+         describe_data_sources/2,
+         describe_data_sources/3,
+         describe_evaluations/2,
+         describe_evaluations/3,
+         describe_ml_models/2,
+         describe_ml_models/3,
+         describe_tags/2,
+         describe_tags/3,
+         get_batch_prediction/2,
+         get_batch_prediction/3,
+         get_data_source/2,
+         get_data_source/3,
+         get_evaluation/2,
+         get_evaluation/3,
+         get_ml_model/2,
+         get_ml_model/3,
+         predict/2,
+         predict/3,
+         update_batch_prediction/2,
+         update_batch_prediction/3,
+         update_data_source/2,
+         update_data_source/3,
+         update_evaluation/2,
+         update_evaluation/3,
+         update_ml_model/2,
+         update_ml_model/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Adds one or more tags to an object, up to a limit of 10.
+%%
+%% Each tag consists of a key and an optional value. If you add a tag using a
+%% key that is already associated with the ML object, `AddTags' updates the
+%% tag's value.
+add_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    add_tags(Client, Input, []).
+add_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AddTags">>, Input, Options).
+
+%% @doc Generates predictions for a group of observations.
+%%
+%% The observations to process exist in one or more data files referenced by
+%% a `DataSource'. This operation creates a new `BatchPrediction', and uses
+%% an `MLModel' and the data files referenced by the `DataSource' as
+%% information sources.
+%%
+%% `CreateBatchPrediction' is an asynchronous operation. In response to
+%% `CreateBatchPrediction', Amazon Machine Learning (Amazon ML) immediately
+%% returns and sets the `BatchPrediction' status to `PENDING'. After the
+%% `BatchPrediction' completes, Amazon ML sets the status to `COMPLETED'.
+%%
+%% You can poll for status updates by using the `GetBatchPrediction'
+%% operation and checking the `Status' parameter of the result. After the
+%% `COMPLETED' status appears, the results are available in the location
+%% specified by the `OutputUri' parameter.
+create_batch_prediction(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_batch_prediction(Client, Input, []).
+create_batch_prediction(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateBatchPrediction">>, Input, Options).
+
+%% @doc Creates a `DataSource' object from an Amazon Relational Database
+%% Service (Amazon RDS).
+%%
+%% A `DataSource' references data that can be used to perform
+%% `CreateMLModel', `CreateEvaluation', or `CreateBatchPrediction'
+%% operations.
+%%
+%% `CreateDataSourceFromRDS' is an asynchronous operation. In response to
+%% `CreateDataSourceFromRDS', Amazon Machine Learning (Amazon ML) immediately
+%% returns and sets the `DataSource' status to `PENDING'. After the
+%% `DataSource' is created and ready for use, Amazon ML sets the `Status'
+%% parameter to `COMPLETED'. `DataSource' in the `COMPLETED' or `PENDING'
+%% state can be used only to perform `>CreateMLModel'>, `CreateEvaluation',
+%% or `CreateBatchPrediction' operations.
+%%
+%% If Amazon ML cannot accept the input source, it sets the `Status'
+%% parameter to `FAILED' and includes an error message in the `Message'
+%% attribute of the `GetDataSource' operation response.
+create_data_source_from_rds(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_data_source_from_rds(Client, Input, []).
+create_data_source_from_rds(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDataSourceFromRDS">>, Input, Options).
+
+%% @doc Creates a `DataSource' from a database hosted on an Amazon Redshift
+%% cluster.
+%%
+%% A `DataSource' references data that can be used to perform either
+%% `CreateMLModel', `CreateEvaluation', or `CreateBatchPrediction'
+%% operations.
+%%
+%% `CreateDataSourceFromRedshift' is an asynchronous operation. In response
+%% to `CreateDataSourceFromRedshift', Amazon Machine Learning (Amazon ML)
+%% immediately returns and sets the `DataSource' status to `PENDING'. After
+%% the `DataSource' is created and ready for use, Amazon ML sets the `Status'
+%% parameter to `COMPLETED'. `DataSource' in `COMPLETED' or `PENDING' states
+%% can be used to perform only `CreateMLModel', `CreateEvaluation', or
+%% `CreateBatchPrediction' operations.
+%%
+%% If Amazon ML can't accept the input source, it sets the `Status' parameter
+%% to `FAILED' and includes an error message in the `Message' attribute of
+%% the `GetDataSource' operation response.
+%%
+%% The observations should be contained in the database hosted on an Amazon
+%% Redshift cluster and should be specified by a `SelectSqlQuery' query.
+%% Amazon ML executes an `Unload' command in Amazon Redshift to transfer the
+%% result set of the `SelectSqlQuery' query to `S3StagingLocation'.
+%%
+%% After the `DataSource' has been created, it's ready for use in evaluations
+%% and batch predictions. If you plan to use the `DataSource' to train an
+%% `MLModel', the `DataSource' also requires a recipe. A recipe describes how
+%% each input variable will be used in training an `MLModel'. Will the
+%% variable be included or excluded from training? Will the variable be
+%% manipulated; for example, will it be combined with another variable or
+%% will it be split apart into word combinations? The recipe provides answers
+%% to these questions.
+%%
+%% You can't change an existing datasource, but you can copy and modify the
+%% settings from an existing Amazon Redshift datasource to create a new
+%% datasource. To do so, call `GetDataSource' for an existing datasource and
+%% copy the values to a `CreateDataSource' call. Change the settings that you
+%% want to change and make sure that all required fields have the appropriate
+%% values.
+create_data_source_from_redshift(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_data_source_from_redshift(Client, Input, []).
+create_data_source_from_redshift(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDataSourceFromRedshift">>, Input, Options).
+
+%% @doc Creates a `DataSource' object.
+%%
+%% A `DataSource' references data that can be used to perform
+%% `CreateMLModel', `CreateEvaluation', or `CreateBatchPrediction'
+%% operations.
+%%
+%% `CreateDataSourceFromS3' is an asynchronous operation. In response to
+%% `CreateDataSourceFromS3', Amazon Machine Learning (Amazon ML) immediately
+%% returns and sets the `DataSource' status to `PENDING'. After the
+%% `DataSource' has been created and is ready for use, Amazon ML sets the
+%% `Status' parameter to `COMPLETED'. `DataSource' in the `COMPLETED' or
+%% `PENDING' state can be used to perform only `CreateMLModel',
+%% `CreateEvaluation' or `CreateBatchPrediction' operations.
+%%
+%% If Amazon ML can't accept the input source, it sets the `Status' parameter
+%% to `FAILED' and includes an error message in the `Message' attribute of
+%% the `GetDataSource' operation response.
+%%
+%% The observation data used in a `DataSource' should be ready to use; that
+%% is, it should have a consistent structure, and missing data values should
+%% be kept to a minimum. The observation data must reside in one or more .csv
+%% files in an Amazon Simple Storage Service (Amazon S3) location, along with
+%% a schema that describes the data items by name and type. The same schema
+%% must be used for all of the data files referenced by the `DataSource'.
+%%
+%% After the `DataSource' has been created, it's ready to use in evaluations
+%% and batch predictions. If you plan to use the `DataSource' to train an
+%% `MLModel', the `DataSource' also needs a recipe. A recipe describes how
+%% each input variable will be used in training an `MLModel'. Will the
+%% variable be included or excluded from training? Will the variable be
+%% manipulated; for example, will it be combined with another variable or
+%% will it be split apart into word combinations? The recipe provides answers
+%% to these questions.
+create_data_source_from_s3(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_data_source_from_s3(Client, Input, []).
+create_data_source_from_s3(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDataSourceFromS3">>, Input, Options).
+
+%% @doc Creates a new `Evaluation' of an `MLModel'.
+%%
+%% An `MLModel' is evaluated on a set of observations associated to a
+%% `DataSource'. Like a `DataSource' for an `MLModel', the `DataSource' for
+%% an `Evaluation' contains values for the `Target Variable'. The
+%% `Evaluation' compares the predicted result for each observation to the
+%% actual outcome and provides a summary so that you know how effective the
+%% `MLModel' functions on the test data. Evaluation generates a relevant
+%% performance metric, such as BinaryAUC, RegressionRMSE or
+%% MulticlassAvgFScore based on the corresponding `MLModelType': `BINARY',
+%% `REGRESSION' or `MULTICLASS'.
+%%
+%% `CreateEvaluation' is an asynchronous operation. In response to
+%% `CreateEvaluation', Amazon Machine Learning (Amazon ML) immediately
+%% returns and sets the evaluation status to `PENDING'. After the
+%% `Evaluation' is created and ready for use, Amazon ML sets the status to
+%% `COMPLETED'.
+%%
+%% You can use the `GetEvaluation' operation to check progress of the
+%% evaluation during the creation operation.
+create_evaluation(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_evaluation(Client, Input, []).
+create_evaluation(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEvaluation">>, Input, Options).
+
+%% @doc Creates a new `MLModel' using the `DataSource' and the recipe as
+%% information sources.
+%%
+%% An `MLModel' is nearly immutable. Users can update only the `MLModelName'
+%% and the `ScoreThreshold' in an `MLModel' without creating a new `MLModel'.
+%%
+%% `CreateMLModel' is an asynchronous operation. In response to
+%% `CreateMLModel', Amazon Machine Learning (Amazon ML) immediately returns
+%% and sets the `MLModel' status to `PENDING'. After the `MLModel' has been
+%% created and ready is for use, Amazon ML sets the status to `COMPLETED'.
+%%
+%% You can use the `GetMLModel' operation to check the progress of the
+%% `MLModel' during the creation operation.
+%%
+%% `CreateMLModel' requires a `DataSource' with computed statistics, which
+%% can be created by setting `ComputeStatistics' to `true' in
+%% `CreateDataSourceFromRDS', `CreateDataSourceFromS3', or
+%% `CreateDataSourceFromRedshift' operations.
+create_ml_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_ml_model(Client, Input, []).
+create_ml_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateMLModel">>, Input, Options).
+
+%% @doc Creates a real-time endpoint for the `MLModel'.
+%%
+%% The endpoint contains the URI of the `MLModel'; that is, the location to
+%% send real-time prediction requests for the specified `MLModel'.
+create_realtime_endpoint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_realtime_endpoint(Client, Input, []).
+create_realtime_endpoint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateRealtimeEndpoint">>, Input, Options).
+
+%% @doc Assigns the DELETED status to a `BatchPrediction', rendering it
+%% unusable.
+%%
+%% After using the `DeleteBatchPrediction' operation, you can use the
+%% `GetBatchPrediction' operation to verify that the status of the
+%% `BatchPrediction' changed to DELETED.
+%%
+%% Caution: The result of the `DeleteBatchPrediction' operation is
+%% irreversible.
+delete_batch_prediction(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_batch_prediction(Client, Input, []).
+delete_batch_prediction(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteBatchPrediction">>, Input, Options).
+
+%% @doc Assigns the DELETED status to a `DataSource', rendering it unusable.
+%%
+%% After using the `DeleteDataSource' operation, you can use the
+%% `GetDataSource' operation to verify that the status of the `DataSource'
+%% changed to DELETED.
+%%
+%% Caution: The results of the `DeleteDataSource' operation are irreversible.
+delete_data_source(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_data_source(Client, Input, []).
+delete_data_source(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteDataSource">>, Input, Options).
+
+%% @doc Assigns the `DELETED' status to an `Evaluation', rendering it
+%% unusable.
+%%
+%% After invoking the `DeleteEvaluation' operation, you can use the
+%% `GetEvaluation' operation to verify that the status of the `Evaluation'
+%% changed to `DELETED'.
+%%
+%% Caution: The results of the `DeleteEvaluation' operation are irreversible.
+delete_evaluation(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_evaluation(Client, Input, []).
+delete_evaluation(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEvaluation">>, Input, Options).
+
+%% @doc Assigns the `DELETED' status to an `MLModel', rendering it unusable.
+%%
+%% After using the `DeleteMLModel' operation, you can use the `GetMLModel'
+%% operation to verify that the status of the `MLModel' changed to DELETED.
+%%
+%% Caution: The result of the `DeleteMLModel' operation is irreversible.
+delete_ml_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_ml_model(Client, Input, []).
+delete_ml_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteMLModel">>, Input, Options).
+
+%% @doc Deletes a real time endpoint of an `MLModel'.
+delete_realtime_endpoint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_realtime_endpoint(Client, Input, []).
+delete_realtime_endpoint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteRealtimeEndpoint">>, Input, Options).
+
+%% @doc Deletes the specified tags associated with an ML object.
+%%
+%% After this operation is complete, you can't recover deleted tags.
+%%
+%% If you specify a tag that doesn't exist, Amazon ML ignores it.
+delete_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_tags(Client, Input, []).
+delete_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteTags">>, Input, Options).
+
+%% @doc Returns a list of `BatchPrediction' operations that match the search
+%% criteria in the request.
+describe_batch_predictions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_batch_predictions(Client, Input, []).
+describe_batch_predictions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeBatchPredictions">>, Input, Options).
+
+%% @doc Returns a list of `DataSource' that match the search criteria in the
+%% request.
+describe_data_sources(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_data_sources(Client, Input, []).
+describe_data_sources(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataSources">>, Input, Options).
+
+%% @doc Returns a list of `DescribeEvaluations' that match the search
+%% criteria in the request.
+describe_evaluations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_evaluations(Client, Input, []).
+describe_evaluations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEvaluations">>, Input, Options).
+
+%% @doc Returns a list of `MLModel' that match the search criteria in the
+%% request.
+describe_ml_models(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_ml_models(Client, Input, []).
+describe_ml_models(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeMLModels">>, Input, Options).
+
+%% @doc Describes one or more of the tags for your Amazon ML object.
+describe_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_tags(Client, Input, []).
+describe_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeTags">>, Input, Options).
+
+%% @doc Returns a `BatchPrediction' that includes detailed metadata, status,
+%% and data file information for a `Batch Prediction' request.
+get_batch_prediction(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_batch_prediction(Client, Input, []).
+get_batch_prediction(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetBatchPrediction">>, Input, Options).
+
+%% @doc Returns a `DataSource' that includes metadata and data file
+%% information, as well as the current status of the `DataSource'.
+%%
+%% `GetDataSource' provides results in normal or verbose format. The verbose
+%% format adds the schema description and the list of files pointed to by the
+%% DataSource to the normal format.
+get_data_source(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_data_source(Client, Input, []).
+get_data_source(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetDataSource">>, Input, Options).
+
+%% @doc Returns an `Evaluation' that includes metadata as well as the current
+%% status of the `Evaluation'.
+get_evaluation(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_evaluation(Client, Input, []).
+get_evaluation(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEvaluation">>, Input, Options).
+
+%% @doc Returns an `MLModel' that includes detailed metadata, data source
+%% information, and the current status of the `MLModel'.
+%%
+%% `GetMLModel' provides results in normal or verbose format.
+get_ml_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_ml_model(Client, Input, []).
+get_ml_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetMLModel">>, Input, Options).
+
+%% @doc Generates a prediction for the observation using the specified `ML
+%% Model'.
+%%
+%% Note: Not all response parameters will be populated. Whether a response
+%% parameter is populated depends on the type of model requested.
+predict(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    predict(Client, Input, []).
+predict(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"Predict">>, Input, Options).
+
+%% @doc Updates the `BatchPredictionName' of a `BatchPrediction'.
+%%
+%% You can use the `GetBatchPrediction' operation to view the contents of the
+%% updated data element.
+update_batch_prediction(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_batch_prediction(Client, Input, []).
+update_batch_prediction(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateBatchPrediction">>, Input, Options).
+
+%% @doc Updates the `DataSourceName' of a `DataSource'.
+%%
+%% You can use the `GetDataSource' operation to view the contents of the
+%% updated data element.
+update_data_source(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_data_source(Client, Input, []).
+update_data_source(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateDataSource">>, Input, Options).
+
+%% @doc Updates the `EvaluationName' of an `Evaluation'.
+%%
+%% You can use the `GetEvaluation' operation to view the contents of the
+%% updated data element.
+update_evaluation(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_evaluation(Client, Input, []).
+update_evaluation(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEvaluation">>, Input, Options).
+
+%% @doc Updates the `MLModelName' and the `ScoreThreshold' of an `MLModel'.
+%%
+%% You can use the `GetMLModel' operation to view the contents of the updated
+%% data element.
+update_ml_model(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_ml_model(Client, Input, []).
+update_ml_model(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateMLModel">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"machinelearning">>},
+    Host = build_host(<<"machinelearning">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
+        {<<"X-Amz-Target">>, <<"AmazonML_20141212.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -79,6 +79,9 @@
          get_findings_filter/2,
          get_findings_filter/4,
          get_findings_filter/5,
+         get_findings_publication_configuration/1,
+         get_findings_publication_configuration/3,
+         get_findings_publication_configuration/4,
          get_invitations_count/1,
          get_invitations_count/3,
          get_invitations_count/4,
@@ -108,6 +111,8 @@
          list_invitations/1,
          list_invitations/3,
          list_invitations/4,
+         list_managed_data_identifiers/2,
+         list_managed_data_identifiers/3,
          list_members/1,
          list_members/3,
          list_members/4,
@@ -119,6 +124,10 @@
          list_tags_for_resource/5,
          put_classification_export_configuration/2,
          put_classification_export_configuration/3,
+         put_findings_publication_configuration/2,
+         put_findings_publication_configuration/3,
+         search_resources/2,
+         search_resources/3,
          tag_resource/3,
          tag_resource/4,
          test_custom_data_identifier/2,
@@ -494,8 +503,8 @@ describe_classification_job(Client, JobId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the Amazon Macie configuration settings for an AWS
-%% organization.
+%% @doc Retrieves the Amazon Macie configuration settings for an Amazon Web
+%% Services organization.
 describe_organization_configuration(Client)
   when is_map(Client) ->
     describe_organization_configuration(Client, #{}, #{}).
@@ -543,7 +552,7 @@ disable_macie(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Disables an account as the delegated Amazon Macie administrator
-%% account for an AWS organization.
+%% account for an Amazon Web Services organization.
 disable_organization_admin_account(Client, Input) ->
     disable_organization_admin_account(Client, Input, []).
 disable_organization_admin_account(Client, Input0, Options0) ->
@@ -667,7 +676,7 @@ enable_macie(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Designates an account as the delegated Amazon Macie administrator
-%% account for an AWS organization.
+%% account for an Amazon Web Services organization.
 enable_organization_admin_account(Client, Input) ->
     enable_organization_admin_account(Client, Input, []).
 enable_organization_admin_account(Client, Input0, Options0) ->
@@ -844,6 +853,30 @@ get_findings_filter(Client, Id, QueryMap, HeadersMap)
 get_findings_filter(Client, Id, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/findingsfilters/", aws_util:encode_uri(Id), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the configuration settings for publishing findings to
+%% Security Hub.
+get_findings_publication_configuration(Client)
+  when is_map(Client) ->
+    get_findings_publication_configuration(Client, #{}, #{}).
+
+get_findings_publication_configuration(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_findings_publication_configuration(Client, QueryMap, HeadersMap, []).
+
+get_findings_publication_configuration(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/findings-publication-configuration"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1104,8 +1137,8 @@ list_findings_filters(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves information about all the Amazon Macie membership
-%% invitations that were received by an account.
+%% @doc Retrieves information about the Amazon Macie membership invitations
+%% that were received by an account.
 list_invitations(Client)
   when is_map(Client) ->
     list_invitations(Client, #{}, #{}).
@@ -1132,6 +1165,30 @@ list_invitations(Client, QueryMap, HeadersMap, Options0)
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about all the managed data identifiers that
+%% Amazon Macie currently provides.
+list_managed_data_identifiers(Client, Input) ->
+    list_managed_data_identifiers(Client, Input, []).
+list_managed_data_identifiers(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/managed-data-identifiers/list"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Retrieves information about the accounts that are associated with an
 %% Amazon Macie administrator account.
@@ -1164,7 +1221,7 @@ list_members(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves information about the delegated Amazon Macie administrator
-%% account for an AWS organization.
+%% account for an Amazon Web Services organization.
 list_organization_admin_accounts(Client)
   when is_map(Client) ->
     list_organization_admin_accounts(Client, #{}, #{}).
@@ -1224,6 +1281,54 @@ put_classification_export_configuration(Client, Input) ->
 put_classification_export_configuration(Client, Input0, Options0) ->
     Method = put,
     Path = ["/classification-export-configuration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the configuration settings for publishing findings to
+%% Security Hub.
+put_findings_publication_configuration(Client, Input) ->
+    put_findings_publication_configuration(Client, Input, []).
+put_findings_publication_configuration(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/findings-publication-configuration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves (queries) statistical data and other information about
+%% Amazon Web Services resources that Amazon Macie monitors and analyzes.
+search_resources(Client, Input) ->
+    search_resources(Client, Input, []).
+search_resources(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/datasources/search-resources"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1384,8 +1489,8 @@ update_macie_session(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Enables an Amazon Macie administrator to suspend or re-enable a
-%% member account.
+%% @doc Enables an Amazon Macie administrator to suspend or re-enable Macie
+%% for a member account.
 update_member_session(Client, Id, Input) ->
     update_member_session(Client, Id, Input, []).
 update_member_session(Client, Id, Input0, Options0) ->
@@ -1408,8 +1513,8 @@ update_member_session(Client, Id, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the Amazon Macie configuration settings for an AWS
-%% organization.
+%% @doc Updates the Amazon Macie configuration settings for an Amazon Web
+%% Services organization.
 update_organization_configuration(Client, Input) ->
     update_organization_configuration(Client, Input, []).
 update_organization_configuration(Client, Input0, Options0) ->
@@ -1467,6 +1572,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -782,6 +782,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -181,9 +181,12 @@ list_entities(Client, Input0, Options0) ->
 %% try to start a ChangeSet containing a change against an entity that is
 %% already locked, you will receive a `ResourceInUseException'.
 %%
-%% For example, you cannot start the ChangeSet described in the example below
-%% because it contains two changes to execute the same change type
-%% (`AddRevisions') against the same entity (`entity-id@1)'.
+%% For example, you cannot start the ChangeSet described in the example later
+%% in this topic, because it contains two changes to execute the same change
+%% type (`AddRevisions') against the same entity (`entity-id@1)'.
+%%
+%% For more information about working with change sets, see Working with
+%% change sets.
 start_change_set(Client, Input) ->
     start_change_set(Client, Input, []).
 start_change_set(Client, Input0, Options0) ->
@@ -241,6 +244,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -4,7 +4,9 @@
 %% @doc API for AWS Elemental MediaConnect
 -module(aws_mediaconnect).
 
--export([add_flow_outputs/3,
+-export([add_flow_media_streams/3,
+         add_flow_media_streams/4,
+         add_flow_outputs/3,
          add_flow_outputs/4,
          add_flow_sources/3,
          add_flow_sources/4,
@@ -42,6 +44,8 @@
          list_tags_for_resource/5,
          purchase_offering/3,
          purchase_offering/4,
+         remove_flow_media_stream/4,
+         remove_flow_media_stream/5,
          remove_flow_output/4,
          remove_flow_output/5,
          remove_flow_source/4,
@@ -62,6 +66,8 @@
          update_flow/4,
          update_flow_entitlement/4,
          update_flow_entitlement/5,
+         update_flow_media_stream/4,
+         update_flow_media_stream/5,
          update_flow_output/4,
          update_flow_output/5,
          update_flow_source/4,
@@ -72,6 +78,32 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Adds media streams to an existing flow.
+%%
+%% After you add a media stream to a flow, you can associate it with a source
+%% and/or an output that uses the ST 2110 JPEG XS or CDI protocol.
+add_flow_media_streams(Client, FlowArn, Input) ->
+    add_flow_media_streams(Client, FlowArn, Input, []).
+add_flow_media_streams(Client, FlowArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/flows/", aws_util:encode_uri(FlowArn), "/mediaStreams"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Adds outputs to an existing flow.
 %%
@@ -472,6 +504,32 @@ purchase_offering(Client, OfferingArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Removes a media stream from a flow.
+%%
+%% This action is only available if the media stream is not associated with a
+%% source or output.
+remove_flow_media_stream(Client, FlowArn, MediaStreamName, Input) ->
+    remove_flow_media_stream(Client, FlowArn, MediaStreamName, Input, []).
+remove_flow_media_stream(Client, FlowArn, MediaStreamName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v1/flows/", aws_util:encode_uri(FlowArn), "/mediaStreams/", aws_util:encode_uri(MediaStreamName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Removes an output from an existing flow.
 %%
 %% This request can be made only on an output that does not have an
@@ -728,6 +786,29 @@ update_flow_entitlement(Client, EntitlementArn, FlowArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates an existing media stream.
+update_flow_media_stream(Client, FlowArn, MediaStreamName, Input) ->
+    update_flow_media_stream(Client, FlowArn, MediaStreamName, Input, []).
+update_flow_media_stream(Client, FlowArn, MediaStreamName, Input0, Options0) ->
+    Method = put,
+    Path = ["/v1/flows/", aws_util:encode_uri(FlowArn), "/mediaStreams/", aws_util:encode_uri(MediaStreamName), ""],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates an existing flow output.
 update_flow_output(Client, FlowArn, OutputArn, Input) ->
     update_flow_output(Client, FlowArn, OutputArn, Input, []).
@@ -809,6 +890,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -18,6 +18,8 @@
          create_queue/3,
          delete_job_template/3,
          delete_job_template/4,
+         delete_policy/2,
+         delete_policy/3,
          delete_preset/3,
          delete_preset/4,
          delete_queue/3,
@@ -32,6 +34,9 @@
          get_job_template/2,
          get_job_template/4,
          get_job_template/5,
+         get_policy/1,
+         get_policy/3,
+         get_policy/4,
          get_preset/2,
          get_preset/4,
          get_preset/5,
@@ -53,6 +58,8 @@
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
+         put_policy/2,
+         put_policy/3,
          tag_resource/2,
          tag_resource/3,
          untag_resource/3,
@@ -246,6 +253,29 @@ delete_job_template(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Permanently delete a policy that you created.
+delete_policy(Client, Input) ->
+    delete_policy(Client, Input, []).
+delete_policy(Client, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2017-08-29/policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Permanently delete a preset you have created.
 delete_preset(Client, Name, Input) ->
     delete_preset(Client, Name, Input, []).
@@ -376,6 +406,29 @@ get_job_template(Client, Name, QueryMap, HeadersMap)
 get_job_template(Client, Name, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/2017-08-29/jobTemplates/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieve the JSON for your policy.
+get_policy(Client)
+  when is_map(Client) ->
+    get_policy(Client, #{}, #{}).
+
+get_policy(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_policy(Client, QueryMap, HeadersMap, []).
+
+get_policy(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2017-08-29/policy"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -597,6 +650,32 @@ list_tags_for_resource(Client, Arn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Create or change your policy.
+%%
+%% For more information about policies, see the user guide at
+%% http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html
+put_policy(Client, Input) ->
+    put_policy(Client, Input, []).
+put_policy(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/2017-08-29/policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Add tags to a MediaConvert queue, preset, or job template.
 %%
 %% For information about tagging, see the User Guide at
@@ -753,6 +832,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -16,6 +16,8 @@
          batch_update_schedule/4,
          cancel_input_device_transfer/3,
          cancel_input_device_transfer/4,
+         claim_device/2,
+         claim_device/3,
          create_channel/2,
          create_channel/3,
          create_input/2,
@@ -266,6 +268,32 @@ cancel_input_device_transfer(Client, InputDeviceId, Input) ->
 cancel_input_device_transfer(Client, InputDeviceId, Input0, Options0) ->
     Method = post,
     Path = ["/prod/inputDevices/", aws_util:encode_uri(InputDeviceId), "/cancel"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Send a request to claim an AWS Elemental device that you have
+%% purchased from a third-party vendor.
+%%
+%% After the request succeeds, you will own the device.
+claim_device(Client, Input) ->
+    claim_device(Client, Input, []).
+claim_device(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/prod/claimDevice"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1577,6 +1605,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -551,6 +551,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -506,6 +506,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -240,6 +240,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -1,44 +1,303 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Use the AWS Elemental MediaTailor SDK to configure scalable ad
-%% insertion for your live and VOD content.
+%% @doc Use the AWS Elemental MediaTailor SDKs and CLI to configure scalable
+%% ad insertion and linear channels.
 %%
-%% With AWS Elemental MediaTailor, you can serve targeted ads to viewers
-%% while maintaining broadcast quality in over-the-top (OTT) video
-%% applications. For information about using the service, including detailed
-%% information about the settings covered in this guide, see the AWS
-%% Elemental MediaTailor User Guide.
+%% With MediaTailor, you can assemble existing content into a linear stream
+%% and serve targeted ads to viewers while maintaining broadcast quality in
+%% over-the-top (OTT) video applications. For information about using the
+%% service, including detailed information about the settings covered in this
+%% guide, see the AWS Elemental MediaTailor User Guide.
 %%
-%% Through the SDK, you manage AWS Elemental MediaTailor configurations the
-%% same as you do through the console. For example, you specify ad insertion
-%% behavior and mapping information for the origin server and the ad decision
-%% server (ADS).
+%% Through the SDKs and the CLI you manage AWS Elemental MediaTailor
+%% configurations and channels the same as you do through the console. For
+%% example, you specify ad insertion behavior and mapping information for the
+%% origin server and the ad decision server (ADS).
 -module(aws_mediatailor).
 
--export([delete_playback_configuration/3,
+-export([configure_logs_for_playback_configuration/2,
+         configure_logs_for_playback_configuration/3,
+         create_channel/3,
+         create_channel/4,
+         create_prefetch_schedule/4,
+         create_prefetch_schedule/5,
+         create_program/4,
+         create_program/5,
+         create_source_location/3,
+         create_source_location/4,
+         create_vod_source/4,
+         create_vod_source/5,
+         delete_channel/3,
+         delete_channel/4,
+         delete_channel_policy/3,
+         delete_channel_policy/4,
+         delete_playback_configuration/3,
          delete_playback_configuration/4,
+         delete_prefetch_schedule/4,
+         delete_prefetch_schedule/5,
+         delete_program/4,
+         delete_program/5,
+         delete_source_location/3,
+         delete_source_location/4,
+         delete_vod_source/4,
+         delete_vod_source/5,
+         describe_channel/2,
+         describe_channel/4,
+         describe_channel/5,
+         describe_program/3,
+         describe_program/5,
+         describe_program/6,
+         describe_source_location/2,
+         describe_source_location/4,
+         describe_source_location/5,
+         describe_vod_source/3,
+         describe_vod_source/5,
+         describe_vod_source/6,
+         get_channel_policy/2,
+         get_channel_policy/4,
+         get_channel_policy/5,
+         get_channel_schedule/2,
+         get_channel_schedule/4,
+         get_channel_schedule/5,
          get_playback_configuration/2,
          get_playback_configuration/4,
          get_playback_configuration/5,
+         get_prefetch_schedule/3,
+         get_prefetch_schedule/5,
+         get_prefetch_schedule/6,
+         list_alerts/2,
+         list_alerts/4,
+         list_alerts/5,
+         list_channels/1,
+         list_channels/3,
+         list_channels/4,
          list_playback_configurations/1,
          list_playback_configurations/3,
          list_playback_configurations/4,
+         list_prefetch_schedules/3,
+         list_prefetch_schedules/4,
+         list_source_locations/1,
+         list_source_locations/3,
+         list_source_locations/4,
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
+         list_vod_sources/2,
+         list_vod_sources/4,
+         list_vod_sources/5,
+         put_channel_policy/3,
+         put_channel_policy/4,
          put_playback_configuration/2,
          put_playback_configuration/3,
+         start_channel/3,
+         start_channel/4,
+         stop_channel/3,
+         stop_channel/4,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
-         untag_resource/4]).
+         untag_resource/4,
+         update_channel/3,
+         update_channel/4,
+         update_source_location/3,
+         update_source_location/4,
+         update_vod_source/4,
+         update_vod_source/5]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Configures Amazon CloudWatch log settings for a playback
+%% configuration.
+configure_logs_for_playback_configuration(Client, Input) ->
+    configure_logs_for_playback_configuration(Client, Input, []).
+configure_logs_for_playback_configuration(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/configureLogs/playbackConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a channel.
+create_channel(Client, ChannelName, Input) ->
+    create_channel(Client, ChannelName, Input, []).
+create_channel(Client, ChannelName, Input0, Options0) ->
+    Method = post,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new prefetch schedule for the specified playback
+%% configuration.
+create_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input) ->
+    create_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input, []).
+create_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input0, Options0) ->
+    Method = post,
+    Path = ["/prefetchSchedule/", aws_util:encode_uri(PlaybackConfigurationName), "/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a program.
+create_program(Client, ChannelName, ProgramName, Input) ->
+    create_program(Client, ChannelName, ProgramName, Input, []).
+create_program(Client, ChannelName, ProgramName, Input0, Options0) ->
+    Method = post,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/program/", aws_util:encode_uri(ProgramName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a source location on a specific channel.
+create_source_location(Client, SourceLocationName, Input) ->
+    create_source_location(Client, SourceLocationName, Input, []).
+create_source_location(Client, SourceLocationName, Input0, Options0) ->
+    Method = post,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates name for a specific VOD source in a source location.
+create_vod_source(Client, SourceLocationName, VodSourceName, Input) ->
+    create_vod_source(Client, SourceLocationName, VodSourceName, Input, []).
+create_vod_source(Client, SourceLocationName, VodSourceName, Input0, Options0) ->
+    Method = post,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), "/vodSource/", aws_util:encode_uri(VodSourceName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a channel.
+%%
+%% You must stop the channel before it can be deleted.
+delete_channel(Client, ChannelName, Input) ->
+    delete_channel(Client, ChannelName, Input, []).
+delete_channel(Client, ChannelName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a channel's IAM policy.
+delete_channel_policy(Client, ChannelName, Input) ->
+    delete_channel_policy(Client, ChannelName, Input, []).
+delete_channel_policy(Client, ChannelName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the playback configuration for the specified name.
 delete_playback_configuration(Client, Name, Input) ->
@@ -63,6 +322,246 @@ delete_playback_configuration(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes a prefetch schedule for a specific playback configuration.
+%%
+%% If you call DeletePrefetchSchedule on an expired prefetch schedule,
+%% MediaTailor returns an HTTP 404 status code.
+delete_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input) ->
+    delete_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input, []).
+delete_prefetch_schedule(Client, Name, PlaybackConfigurationName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/prefetchSchedule/", aws_util:encode_uri(PlaybackConfigurationName), "/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a specific program on a specific channel.
+delete_program(Client, ChannelName, ProgramName, Input) ->
+    delete_program(Client, ChannelName, ProgramName, Input, []).
+delete_program(Client, ChannelName, ProgramName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/program/", aws_util:encode_uri(ProgramName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a source location on a specific channel.
+delete_source_location(Client, SourceLocationName, Input) ->
+    delete_source_location(Client, SourceLocationName, Input, []).
+delete_source_location(Client, SourceLocationName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a specific VOD source in a specific source location.
+delete_vod_source(Client, SourceLocationName, VodSourceName, Input) ->
+    delete_vod_source(Client, SourceLocationName, VodSourceName, Input, []).
+delete_vod_source(Client, SourceLocationName, VodSourceName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), "/vodSource/", aws_util:encode_uri(VodSourceName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes the properties of a specific channel.
+describe_channel(Client, ChannelName)
+  when is_map(Client) ->
+    describe_channel(Client, ChannelName, #{}, #{}).
+
+describe_channel(Client, ChannelName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_channel(Client, ChannelName, QueryMap, HeadersMap, []).
+
+describe_channel(Client, ChannelName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the properties of the requested program.
+describe_program(Client, ChannelName, ProgramName)
+  when is_map(Client) ->
+    describe_program(Client, ChannelName, ProgramName, #{}, #{}).
+
+describe_program(Client, ChannelName, ProgramName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_program(Client, ChannelName, ProgramName, QueryMap, HeadersMap, []).
+
+describe_program(Client, ChannelName, ProgramName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/program/", aws_util:encode_uri(ProgramName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the properties of the requested source location.
+describe_source_location(Client, SourceLocationName)
+  when is_map(Client) ->
+    describe_source_location(Client, SourceLocationName, #{}, #{}).
+
+describe_source_location(Client, SourceLocationName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_source_location(Client, SourceLocationName, QueryMap, HeadersMap, []).
+
+describe_source_location(Client, SourceLocationName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Provides details about a specific VOD source in a specific source
+%% location.
+describe_vod_source(Client, SourceLocationName, VodSourceName)
+  when is_map(Client) ->
+    describe_vod_source(Client, SourceLocationName, VodSourceName, #{}, #{}).
+
+describe_vod_source(Client, SourceLocationName, VodSourceName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_vod_source(Client, SourceLocationName, VodSourceName, QueryMap, HeadersMap, []).
+
+describe_vod_source(Client, SourceLocationName, VodSourceName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), "/vodSource/", aws_util:encode_uri(VodSourceName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about a channel's IAM policy.
+get_channel_policy(Client, ChannelName)
+  when is_map(Client) ->
+    get_channel_policy(Client, ChannelName, #{}, #{}).
+
+get_channel_policy(Client, ChannelName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_channel_policy(Client, ChannelName, QueryMap, HeadersMap, []).
+
+get_channel_policy(Client, ChannelName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about your channel's schedule.
+get_channel_schedule(Client, ChannelName)
+  when is_map(Client) ->
+    get_channel_schedule(Client, ChannelName, #{}, #{}).
+
+get_channel_schedule(Client, ChannelName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_channel_schedule(Client, ChannelName, QueryMap, HeadersMap, []).
+
+get_channel_schedule(Client, ChannelName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/schedule"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"durationMinutes">>, maps:get(<<"durationMinutes">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns the playback configuration for the specified name.
 get_playback_configuration(Client, Name)
   when is_map(Client) ->
@@ -83,6 +582,90 @@ get_playback_configuration(Client, Name, QueryMap, HeadersMap, Options0)
     Headers = [],
 
     Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about the prefetch schedule for a specific
+%% playback configuration.
+%%
+%% If you call GetPrefetchSchedule on an expired prefetch schedule,
+%% MediaTailor returns an HTTP 404 status code.
+get_prefetch_schedule(Client, Name, PlaybackConfigurationName)
+  when is_map(Client) ->
+    get_prefetch_schedule(Client, Name, PlaybackConfigurationName, #{}, #{}).
+
+get_prefetch_schedule(Client, Name, PlaybackConfigurationName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_prefetch_schedule(Client, Name, PlaybackConfigurationName, QueryMap, HeadersMap, []).
+
+get_prefetch_schedule(Client, Name, PlaybackConfigurationName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/prefetchSchedule/", aws_util:encode_uri(PlaybackConfigurationName), "/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of alerts for the given resource.
+list_alerts(Client, ResourceArn)
+  when is_map(Client) ->
+    list_alerts(Client, ResourceArn, #{}, #{}).
+
+list_alerts(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_alerts(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_alerts(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/alerts"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"resourceArn">>, ResourceArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves a list of channels that are associated with this account.
+list_channels(Client)
+  when is_map(Client) ->
+    list_channels(Client, #{}, #{}).
+
+list_channels(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_channels(Client, QueryMap, HeadersMap, []).
+
+list_channels(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/channels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
@@ -121,6 +704,57 @@ list_playback_configurations(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Creates a new prefetch schedule.
+list_prefetch_schedules(Client, PlaybackConfigurationName, Input) ->
+    list_prefetch_schedules(Client, PlaybackConfigurationName, Input, []).
+list_prefetch_schedules(Client, PlaybackConfigurationName, Input0, Options0) ->
+    Method = post,
+    Path = ["/prefetchSchedule/", aws_util:encode_uri(PlaybackConfigurationName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves a list of source locations.
+list_source_locations(Client)
+  when is_map(Client) ->
+    list_source_locations(Client, #{}, #{}).
+
+list_source_locations(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_source_locations(Client, QueryMap, HeadersMap, []).
+
+list_source_locations(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/sourceLocations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns a list of the tags assigned to the specified playback
 %% configuration resource.
 list_tags_for_resource(Client, ResourceArn)
@@ -145,12 +779,109 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Lists all the VOD sources in a source location.
+list_vod_sources(Client, SourceLocationName)
+  when is_map(Client) ->
+    list_vod_sources(Client, SourceLocationName, #{}, #{}).
+
+list_vod_sources(Client, SourceLocationName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_vod_sources(Client, SourceLocationName, QueryMap, HeadersMap, []).
+
+list_vod_sources(Client, SourceLocationName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), "/vodSources"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Creates an IAM policy for the channel.
+put_channel_policy(Client, ChannelName, Input) ->
+    put_channel_policy(Client, ChannelName, Input, []).
+put_channel_policy(Client, ChannelName, Input0, Options0) ->
+    Method = put,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Adds a new playback configuration to AWS Elemental MediaTailor.
 put_playback_configuration(Client, Input) ->
     put_playback_configuration(Client, Input, []).
 put_playback_configuration(Client, Input0, Options0) ->
     Method = put,
     Path = ["/playbackConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a specific channel.
+start_channel(Client, ChannelName, Input) ->
+    start_channel(Client, ChannelName, Input, []).
+start_channel(Client, ChannelName, Input0, Options0) ->
+    Method = put,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/start"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Stops a specific channel.
+stop_channel(Client, ChannelName, Input) ->
+    stop_channel(Client, ChannelName, Input, []).
+stop_channel(Client, ChannelName, Input0, Options0) ->
+    Method = put,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), "/stop"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -219,6 +950,75 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates an existing channel.
+update_channel(Client, ChannelName, Input) ->
+    update_channel(Client, ChannelName, Input, []).
+update_channel(Client, ChannelName, Input0, Options0) ->
+    Method = put,
+    Path = ["/channel/", aws_util:encode_uri(ChannelName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a source location on a specific channel.
+update_source_location(Client, SourceLocationName, Input) ->
+    update_source_location(Client, SourceLocationName, Input, []).
+update_source_location(Client, SourceLocationName, Input0, Options0) ->
+    Method = put,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a specific VOD source in a specific source location.
+update_vod_source(Client, SourceLocationName, VodSourceName, Input) ->
+    update_vod_source(Client, SourceLocationName, VodSourceName, Input, []).
+update_vod_source(Client, SourceLocationName, VodSourceName, Input0, Options0) ->
+    Method = put,
+    Path = ["/sourceLocation/", aws_util:encode_uri(SourceLocationName), "/vodSource/", aws_util:encode_uri(VodSourceName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -254,6 +1054,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_memorydb.erl
+++ b/src/aws_memorydb.erl
@@ -1,0 +1,516 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc MemoryDB for Redis is a fully managed, Redis-compatible, in-memory
+%% database that delivers ultra-fast performance and Multi-AZ durability for
+%% modern applications built using microservices architectures.
+%%
+%% MemoryDB stores the entire database in-memory, enabling low latency and
+%% high throughput data access. It is compatible with Redis, a popular open
+%% source data store, enabling you to leverage Redis’ flexible and friendly
+%% data structures, APIs, and commands.
+-module(aws_memorydb).
+
+-export([batch_update_cluster/2,
+         batch_update_cluster/3,
+         copy_snapshot/2,
+         copy_snapshot/3,
+         create_acl/2,
+         create_acl/3,
+         create_cluster/2,
+         create_cluster/3,
+         create_parameter_group/2,
+         create_parameter_group/3,
+         create_snapshot/2,
+         create_snapshot/3,
+         create_subnet_group/2,
+         create_subnet_group/3,
+         create_user/2,
+         create_user/3,
+         delete_acl/2,
+         delete_acl/3,
+         delete_cluster/2,
+         delete_cluster/3,
+         delete_parameter_group/2,
+         delete_parameter_group/3,
+         delete_snapshot/2,
+         delete_snapshot/3,
+         delete_subnet_group/2,
+         delete_subnet_group/3,
+         delete_user/2,
+         delete_user/3,
+         describe_acls/2,
+         describe_acls/3,
+         describe_clusters/2,
+         describe_clusters/3,
+         describe_engine_versions/2,
+         describe_engine_versions/3,
+         describe_events/2,
+         describe_events/3,
+         describe_parameter_groups/2,
+         describe_parameter_groups/3,
+         describe_parameters/2,
+         describe_parameters/3,
+         describe_service_updates/2,
+         describe_service_updates/3,
+         describe_snapshots/2,
+         describe_snapshots/3,
+         describe_subnet_groups/2,
+         describe_subnet_groups/3,
+         describe_users/2,
+         describe_users/3,
+         failover_shard/2,
+         failover_shard/3,
+         list_allowed_node_type_updates/2,
+         list_allowed_node_type_updates/3,
+         list_tags/2,
+         list_tags/3,
+         reset_parameter_group/2,
+         reset_parameter_group/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_acl/2,
+         update_acl/3,
+         update_cluster/2,
+         update_cluster/3,
+         update_parameter_group/2,
+         update_parameter_group/3,
+         update_subnet_group/2,
+         update_subnet_group/3,
+         update_user/2,
+         update_user/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Apply the service update to a list of clusters supplied.
+%%
+%% For more information on service updates and applying them, see Applying
+%% the service updates.
+batch_update_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_update_cluster(Client, Input, []).
+batch_update_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchUpdateCluster">>, Input, Options).
+
+%% @doc Makes a copy of an existing snapshot.
+copy_snapshot(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    copy_snapshot(Client, Input, []).
+copy_snapshot(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CopySnapshot">>, Input, Options).
+
+%% @doc Creates an Access Control List.
+%%
+%% For more information, see Authenticating users with Access Contol Lists
+%% (ACLs).
+create_acl(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_acl(Client, Input, []).
+create_acl(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateACL">>, Input, Options).
+
+%% @doc Creates a cluster.
+%%
+%% All nodes in the cluster run the same protocol-compliant engine software.
+create_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_cluster(Client, Input, []).
+create_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateCluster">>, Input, Options).
+
+%% @doc Creates a new MemoryDB parameter group.
+%%
+%% A parameter group is a collection of parameters and their values that are
+%% applied to all of the nodes in any cluster. For more information, see
+%% Configuring engine parameters using parameter groups.
+create_parameter_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_parameter_group(Client, Input, []).
+create_parameter_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateParameterGroup">>, Input, Options).
+
+%% @doc Creates a copy of an entire cluster at a specific moment in time.
+create_snapshot(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_snapshot(Client, Input, []).
+create_snapshot(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateSnapshot">>, Input, Options).
+
+%% @doc Creates a subnet group.
+%%
+%% A subnet group is a collection of subnets (typically private) that you can
+%% designate for your clusters running in an Amazon Virtual Private Cloud
+%% (VPC) environment. When you create a cluster in an Amazon VPC, you must
+%% specify a subnet group. MemoryDB uses that subnet group to choose a subnet
+%% and IP addresses within that subnet to associate with your nodes. For more
+%% information, see Subnets and subnet groups.
+create_subnet_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_subnet_group(Client, Input, []).
+create_subnet_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateSubnetGroup">>, Input, Options).
+
+%% @doc Creates a MemoryDB user.
+%%
+%% For more information, see Authenticating users with Access Contol Lists
+%% (ACLs).
+create_user(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_user(Client, Input, []).
+create_user(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateUser">>, Input, Options).
+
+%% @doc Deletes an Access Control List.
+%%
+%% The ACL must first be disassociated from the cluster before it can be
+%% deleted. For more information, see Authenticating users with Access Contol
+%% Lists (ACLs).
+delete_acl(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_acl(Client, Input, []).
+delete_acl(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteACL">>, Input, Options).
+
+%% @doc Deletes a cluster.
+%%
+%% It also deletes all associated nodes and node endpoints
+delete_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_cluster(Client, Input, []).
+delete_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteCluster">>, Input, Options).
+
+%% @doc Deletes the specified parameter group.
+%%
+%% You cannot delete a parameter group if it is associated with any clusters.
+%% You cannot delete the default parameter groups in your account.
+delete_parameter_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_parameter_group(Client, Input, []).
+delete_parameter_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteParameterGroup">>, Input, Options).
+
+%% @doc Deletes an existing snapshot.
+%%
+%% When you receive a successful response from this operation, MemoryDB
+%% immediately begins deleting the snapshot; you cannot cancel or revert this
+%% operation.
+delete_snapshot(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_snapshot(Client, Input, []).
+delete_snapshot(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteSnapshot">>, Input, Options).
+
+%% @doc Deletes a subnet group.
+%%
+%% You cannot delete a default subnet group or one that is associated with
+%% any clusters.
+delete_subnet_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_subnet_group(Client, Input, []).
+delete_subnet_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteSubnetGroup">>, Input, Options).
+
+%% @doc Deletes a user.
+%%
+%% The user will be removed from all ACLs and in turn removed from all
+%% clusters.
+delete_user(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_user(Client, Input, []).
+delete_user(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteUser">>, Input, Options).
+
+%% @doc Returns a list of ACLs
+describe_acls(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_acls(Client, Input, []).
+describe_acls(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeACLs">>, Input, Options).
+
+%% @doc Returns information about all provisioned clusters if no cluster
+%% identifier is specified, or about a specific cluster if a cluster name is
+%% supplied.
+describe_clusters(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_clusters(Client, Input, []).
+describe_clusters(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeClusters">>, Input, Options).
+
+%% @doc Returns a list of the available Redis engine versions.
+describe_engine_versions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_engine_versions(Client, Input, []).
+describe_engine_versions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEngineVersions">>, Input, Options).
+
+%% @doc Returns events related to clusters, security groups, and parameter
+%% groups.
+%%
+%% You can obtain events specific to a particular cluster, security group, or
+%% parameter group by providing the name as a parameter. By default, only the
+%% events occurring within the last hour are returned; however, you can
+%% retrieve up to 14 days' worth of events if necessary.
+describe_events(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_events(Client, Input, []).
+describe_events(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEvents">>, Input, Options).
+
+%% @doc Returns a list of parameter group descriptions.
+%%
+%% If a parameter group name is specified, the list contains only the
+%% descriptions for that group.
+describe_parameter_groups(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_parameter_groups(Client, Input, []).
+describe_parameter_groups(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeParameterGroups">>, Input, Options).
+
+%% @doc Returns the detailed parameter list for a particular parameter group.
+describe_parameters(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_parameters(Client, Input, []).
+describe_parameters(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeParameters">>, Input, Options).
+
+%% @doc Returns details of the service updates
+describe_service_updates(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_service_updates(Client, Input, []).
+describe_service_updates(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeServiceUpdates">>, Input, Options).
+
+%% @doc Returns information about cluster snapshots.
+%%
+%% By default, DescribeSnapshots lists all of your snapshots; it can
+%% optionally describe a single snapshot, or just the snapshots associated
+%% with a particular cluster.
+describe_snapshots(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_snapshots(Client, Input, []).
+describe_snapshots(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeSnapshots">>, Input, Options).
+
+%% @doc Returns a list of subnet group descriptions.
+%%
+%% If a subnet group name is specified, the list contains only the
+%% description of that group.
+describe_subnet_groups(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_subnet_groups(Client, Input, []).
+describe_subnet_groups(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeSubnetGroups">>, Input, Options).
+
+%% @doc Returns a list of users.
+describe_users(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_users(Client, Input, []).
+describe_users(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeUsers">>, Input, Options).
+
+%% @doc Used to failover a shard
+failover_shard(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    failover_shard(Client, Input, []).
+failover_shard(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"FailoverShard">>, Input, Options).
+
+%% @doc Lists all available node types that you can scale to from your
+%% cluster's current node type.
+%%
+%% When you use the UpdateCluster operation to scale your cluster, the value
+%% of the NodeType parameter must be one of the node types returned by this
+%% operation.
+list_allowed_node_type_updates(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_allowed_node_type_updates(Client, Input, []).
+list_allowed_node_type_updates(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListAllowedNodeTypeUpdates">>, Input, Options).
+
+%% @doc Lists all tags currently on a named resource.
+%%
+%% A tag is a key-value pair where the key and value are case-sensitive. You
+%% can use tags to categorize and track your MemoryDB resources. For more
+%% information, see Tagging your MemoryDB resources
+list_tags(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags(Client, Input, []).
+list_tags(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTags">>, Input, Options).
+
+%% @doc Modifies the parameters of a parameter group to the engine or system
+%% default value.
+%%
+%% You can reset specific parameters by submitting a list of parameter names.
+%% To reset the entire parameter group, specify the AllParameters and
+%% ParameterGroupName parameters.
+reset_parameter_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    reset_parameter_group(Client, Input, []).
+reset_parameter_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ResetParameterGroup">>, Input, Options).
+
+%% @doc A tag is a key-value pair where the key and value are case-sensitive.
+%%
+%% You can use tags to categorize and track all your MemoryDB resources. When
+%% you add or remove tags on clusters, those actions will be replicated to
+%% all nodes in the cluster. For more information, see Resource-level
+%% permissions.
+%%
+%% For example, you can use cost-allocation tags to your MemoryDB resources,
+%% Amazon generates a cost allocation report as a comma-separated value (CSV)
+%% file with your usage and costs aggregated by your tags. You can apply tags
+%% that represent business categories (such as cost centers, application
+%% names, or owners) to organize your costs across multiple services. For
+%% more information, see Using Cost Allocation Tags.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Use this operation to remove tags on a resource
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Changes the list of users that belong to the Access Control List.
+update_acl(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_acl(Client, Input, []).
+update_acl(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateACL">>, Input, Options).
+
+%% @doc Modifies the settings for a cluster.
+%%
+%% You can use this operation to change one or more cluster configuration
+%% settings by specifying the settings and the new values.
+update_cluster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_cluster(Client, Input, []).
+update_cluster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateCluster">>, Input, Options).
+
+%% @doc Updates the parameters of a parameter group.
+%%
+%% You can modify up to 20 parameters in a single request by submitting a
+%% list parameter name and value pairs.
+update_parameter_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_parameter_group(Client, Input, []).
+update_parameter_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateParameterGroup">>, Input, Options).
+
+%% @doc Updates a subnet group.
+%%
+%% For more information, see Updating a subnet group
+update_subnet_group(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_subnet_group(Client, Input, []).
+update_subnet_group(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateSubnetGroup">>, Input, Options).
+
+%% @doc Changes user password(s) and/or access string.
+update_user(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_user(Client, Input, []).
+update_user(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateUser">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"memorydb">>},
+    Host = build_host(<<"memory-db">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
+        {<<"X-Amz-Target">>, <<"AmazonMemoryDB.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_mgn.erl
+++ b/src/aws_mgn.erl
@@ -1,0 +1,792 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc The Application Migration Service service.
+-module(aws_mgn).
+
+-export([change_server_life_cycle_state/2,
+         change_server_life_cycle_state/3,
+         create_replication_configuration_template/2,
+         create_replication_configuration_template/3,
+         delete_job/2,
+         delete_job/3,
+         delete_replication_configuration_template/2,
+         delete_replication_configuration_template/3,
+         delete_source_server/2,
+         delete_source_server/3,
+         describe_job_log_items/2,
+         describe_job_log_items/3,
+         describe_jobs/2,
+         describe_jobs/3,
+         describe_replication_configuration_templates/2,
+         describe_replication_configuration_templates/3,
+         describe_source_servers/2,
+         describe_source_servers/3,
+         disconnect_from_service/2,
+         disconnect_from_service/3,
+         finalize_cutover/2,
+         finalize_cutover/3,
+         get_launch_configuration/2,
+         get_launch_configuration/3,
+         get_replication_configuration/2,
+         get_replication_configuration/3,
+         initialize_service/2,
+         initialize_service/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         mark_as_archived/2,
+         mark_as_archived/3,
+         retry_data_replication/2,
+         retry_data_replication/3,
+         start_cutover/2,
+         start_cutover/3,
+         start_test/2,
+         start_test/3,
+         tag_resource/3,
+         tag_resource/4,
+         terminate_target_instances/2,
+         terminate_target_instances/3,
+         untag_resource/3,
+         untag_resource/4,
+         update_launch_configuration/2,
+         update_launch_configuration/3,
+         update_replication_configuration/2,
+         update_replication_configuration/3,
+         update_replication_configuration_template/2,
+         update_replication_configuration_template/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Allows the user to set the SourceServer.LifeCycle.state property for
+%% specific Source Server IDs to one of the following: READY_FOR_TEST or
+%% READY_FOR_CUTOVER.
+%%
+%% This command only works if the Source Server is already launchable
+%% (dataReplicationInfo.lagDuration is not null.)
+change_server_life_cycle_state(Client, Input) ->
+    change_server_life_cycle_state(Client, Input, []).
+change_server_life_cycle_state(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/ChangeServerLifeCycleState"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new ReplicationConfigurationTemplate.
+create_replication_configuration_template(Client, Input) ->
+    create_replication_configuration_template(Client, Input, []).
+create_replication_configuration_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/CreateReplicationConfigurationTemplate"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a single Job by ID.
+delete_job(Client, Input) ->
+    delete_job(Client, Input, []).
+delete_job(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteJob"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a single Replication Configuration Template by ID
+delete_replication_configuration_template(Client, Input) ->
+    delete_replication_configuration_template(Client, Input, []).
+delete_replication_configuration_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteReplicationConfigurationTemplate"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a single source server by ID.
+delete_source_server(Client, Input) ->
+    delete_source_server(Client, Input, []).
+delete_source_server(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DeleteSourceServer"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves detailed Job log with paging.
+describe_job_log_items(Client, Input) ->
+    describe_job_log_items(Client, Input, []).
+describe_job_log_items(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeJobLogItems"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a list of Jobs.
+%%
+%% Use the JobsID and fromDate and toData filters to limit which jobs are
+%% returned. The response is sorted by creationDataTime - latest date first.
+%% Jobs are normaly created by the StartTest, StartCutover, and
+%% TerminateTargetInstances APIs. Jobs are also created by DiagnosticLaunch
+%% and TerminateDiagnosticInstances, which are APIs available only to
+%% *Support* and only used in response to relevant support tickets.
+describe_jobs(Client, Input) ->
+    describe_jobs(Client, Input, []).
+describe_jobs(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeJobs"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all ReplicationConfigurationTemplates, filtered by Source
+%% Server IDs.
+describe_replication_configuration_templates(Client, Input) ->
+    describe_replication_configuration_templates(Client, Input, []).
+describe_replication_configuration_templates(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeReplicationConfigurationTemplates"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves all SourceServers or multiple SourceServers by ID.
+describe_source_servers(Client, Input) ->
+    describe_source_servers(Client, Input, []).
+describe_source_servers(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DescribeSourceServers"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Disconnects specific Source Servers from Application Migration
+%% Service.
+%%
+%% Data replication is stopped immediately. All AWS resources created by
+%% Application Migration Service for enabling the replication of these source
+%% servers will be terminated / deleted within 90 minutes. Launched Test or
+%% Cutover instances will NOT be terminated. If the agent on the source
+%% server has not been prevented from communciating with the Application
+%% Migration Service service, then it will receive a command to uninstall
+%% itself (within approximately 10 minutes). The following properties of the
+%% SourceServer will be changed immediately:
+%% dataReplicationInfo.dataReplicationState will be set to DISCONNECTED; The
+%% totalStorageBytes property for each of dataReplicationInfo.replicatedDisks
+%% will be set to zero; dataReplicationInfo.lagDuration and
+%% dataReplicationInfo.lagDurationwill be nullified.
+disconnect_from_service(Client, Input) ->
+    disconnect_from_service(Client, Input, []).
+disconnect_from_service(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/DisconnectFromService"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Finalizes the cutover immediately for specific Source Servers.
+%%
+%% All AWS resources created by Application Migration Service for enabling
+%% the replication of these source servers will be terminated / deleted
+%% within 90 minutes. Launched Test or Cutover instances will NOT be
+%% terminated. The AWS Replication Agent will receive a command to uninstall
+%% itself (within 10 minutes). The following properties of the SourceServer
+%% will be changed immediately: dataReplicationInfo.dataReplicationState will
+%% be to DISCONNECTED; The SourceServer.lifeCycle.state will be changed to
+%% CUTOVER; The totalStorageBytes property fo each of
+%% dataReplicationInfo.replicatedDisks will be set to zero;
+%% dataReplicationInfo.lagDuration and dataReplicationInfo.lagDurationwill be
+%% nullified.
+finalize_cutover(Client, Input) ->
+    finalize_cutover(Client, Input, []).
+finalize_cutover(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/FinalizeCutover"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all LaunchConfigurations available, filtered by Source Server
+%% IDs.
+get_launch_configuration(Client, Input) ->
+    get_launch_configuration(Client, Input, []).
+get_launch_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetLaunchConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all ReplicationConfigurations, filtered by Source Server ID.
+get_replication_configuration(Client, Input) ->
+    get_replication_configuration(Client, Input, []).
+get_replication_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/GetReplicationConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Initialize Application Migration Service.
+initialize_service(Client, Input) ->
+    initialize_service(Client, Input, []).
+initialize_service(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/InitializeService"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc List all tags for your Application Migration Service resources.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Archives specific Source Servers by setting the
+%% SourceServer.isArchived property to true for specified SourceServers by
+%% ID.
+%%
+%% This command only works for SourceServers with a lifecycle.state which
+%% equals DISCONNECTED or CUTOVER.
+mark_as_archived(Client, Input) ->
+    mark_as_archived(Client, Input, []).
+mark_as_archived(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/MarkAsArchived"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Causes the data replication initiation sequence to begin immediately
+%% upon next Handshake for specified SourceServer IDs, regardless of when the
+%% previous initiation started.
+%%
+%% This command will not work if the SourceServer is not stalled or is in a
+%% DISCONNECTED or STOPPED state.
+retry_data_replication(Client, Input) ->
+    retry_data_replication(Client, Input, []).
+retry_data_replication(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/RetryDataReplication"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Launches a Cutover Instance for specific Source Servers.
+%%
+%% This command starts a LAUNCH job whose initiatedBy property is
+%% StartCutover and changes the SourceServer.lifeCycle.state property to
+%% CUTTING_OVER.
+start_cutover(Client, Input) ->
+    start_cutover(Client, Input, []).
+start_cutover(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/StartCutover"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lauches a Test Instance for specific Source Servers.
+%%
+%% This command starts a LAUNCH job whose initiatedBy property is StartTest
+%% and changes the SourceServer.lifeCycle.state property to TESTING.
+start_test(Client, Input) ->
+    start_test(Client, Input, []).
+start_test(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/StartTest"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds or overwrites only the specified tags for the specified
+%% Application Migration Service resource or resources.
+%%
+%% When you specify an existing tag key, the value is overwritten with the
+%% new value. Each resource can have a maximum of 50 tags. Each tag consists
+%% of a key and optional value.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts a job that terminates specific launched EC2 Test and Cutover
+%% instances.
+%%
+%% This command will not work for any Source Server with a lifecycle.state of
+%% TESTING, CUTTING_OVER, or CUTOVER.
+terminate_target_instances(Client, Input) ->
+    terminate_target_instances(Client, Input, []).
+terminate_target_instances(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/TerminateTargetInstances"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified set of tags from the specified set of
+%% Application Migration Service resources.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates multiple LaunchConfigurations by Source Server ID.
+update_launch_configuration(Client, Input) ->
+    update_launch_configuration(Client, Input, []).
+update_launch_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/UpdateLaunchConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows you to update multiple ReplicationConfigurations by Source
+%% Server ID.
+update_replication_configuration(Client, Input) ->
+    update_replication_configuration(Client, Input, []).
+update_replication_configuration(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/UpdateReplicationConfiguration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates multiple ReplicationConfigurationTemplates by ID.
+update_replication_configuration_template(Client, Input) ->
+    update_replication_configuration_template(Client, Input, []).
+update_replication_configuration_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/UpdateReplicationConfigurationTemplate"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"mgn">>},
+    Host = build_host(<<"mgn">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_mobile.erl
+++ b/src/aws_mobile.erl
@@ -305,6 +305,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mobileanalytics.erl
+++ b/src/aws_mobileanalytics.erl
@@ -79,6 +79,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -75,6 +75,42 @@
 %% @doc Creates a broker.
 %%
 %% Note: This API is asynchronous.
+%%
+%% To create a broker, you must either use the AmazonMQFullAccess IAM policy
+%% or include the following EC2 permissions in your IAM policy.
+%%
+%% <ul><li>ec2:CreateNetworkInterface
+%%
+%% This permission is required to allow Amazon MQ to create an elastic
+%% network interface (ENI) on behalf of your account.
+%%
+%% </li> <li>ec2:CreateNetworkInterfacePermission
+%%
+%% This permission is required to attach the ENI to the broker instance.
+%%
+%% </li> <li>ec2:DeleteNetworkInterface
+%%
+%% </li> <li>ec2:DeleteNetworkInterfacePermission
+%%
+%% </li> <li>ec2:DetachNetworkInterface
+%%
+%% </li> <li>ec2:DescribeInternetGateways
+%%
+%% </li> <li>ec2:DescribeNetworkInterfaces
+%%
+%% </li> <li>ec2:DescribeNetworkInterfacePermissions
+%%
+%% </li> <li>ec2:DescribeRouteTables
+%%
+%% </li> <li>ec2:DescribeSecurityGroups
+%%
+%% </li> <li>ec2:DescribeSubnets
+%%
+%% </li> <li>ec2:DescribeVpcs
+%%
+%% </li></ul> For more information, see Create an IAM User and Get Your AWS
+%% Credentials and Never Modify or Delete the Amazon MQ Elastic Network
+%% Interface in the Amazon MQ Developer Guide.
 create_broker(Client, Input) ->
     create_broker(Client, Input, []).
 create_broker(Client, Input0, Options0) ->
@@ -657,6 +693,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_mturk.erl
+++ b/src/aws_mturk.erl
@@ -343,8 +343,13 @@ disassociate_qualification_from_worker(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisassociateQualificationFromWorker">>, Input, Options).
 
-%% @doc The `GetAccountBalance' operation retrieves the amount of money in
-%% your Amazon Mechanical Turk account.
+%% @doc The `GetAccountBalance' operation retrieves the Prepaid HITs balance
+%% in your Amazon Mechanical Turk account if you are a Prepaid Requester.
+%%
+%% Alternatively, this operation will retrieve the remaining available AWS
+%% Billing usage if you have enabled AWS Billing. Note: If you have enabled
+%% AWS Billing and still have a remaining Prepaid HITs balance, this balance
+%% can be viewed on the My Account page in the Requester console.
 get_account_balance(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_account_balance(Client, Input, []).

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -64,7 +64,8 @@ create_cli_token(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc JSON blob that describes the environment to create.
+%% @doc Creates an Amazon Managed Workflows for Apache Airflow (MWAA)
+%% environment.
 create_environment(Client, Name, Input) ->
     create_environment(Client, Name, Input, []).
 create_environment(Client, Name, Input0, Options0) ->
@@ -111,7 +112,8 @@ create_web_login_token(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Delete an existing environment.
+%% @doc Deletes an Amazon Managed Workflows for Apache Airflow (MWAA)
+%% environment.
 delete_environment(Client, Name, Input) ->
     delete_environment(Client, Name, Input, []).
 delete_environment(Client, Name, Input0, Options0) ->
@@ -134,7 +136,8 @@ delete_environment(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Get details of an existing environment.
+%% @doc Retrieves the details of an Amazon Managed Workflows for Apache
+%% Airflow (MWAA) environment.
 get_environment(Client, Name)
   when is_map(Client) ->
     get_environment(Client, Name, #{}, #{}).
@@ -157,7 +160,8 @@ get_environment(Client, Name, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc List Amazon MWAA Environments.
+%% @doc Lists the Amazon Managed Workflows for Apache Airflow (MWAA)
+%% environments.
 list_environments(Client)
   when is_map(Client) ->
     list_environments(Client, #{}, #{}).
@@ -185,7 +189,10 @@ list_environments(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc List the tags for MWAA environments.
+%% @doc Lists the key-value tag pairs associated to the Amazon Managed
+%% Workflows for Apache Airflow (MWAA) environment.
+%%
+%% For example, `"Environment": "Staging"'.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -232,7 +239,8 @@ publish_metrics(Client, EnvironmentName, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Add tag to the MWAA environments.
+%% @doc Associates key-value tag pairs to your Amazon Managed Workflows for
+%% Apache Airflow (MWAA) environment.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -255,7 +263,10 @@ tag_resource(Client, ResourceArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Remove a tag from the MWAA environments.
+%% @doc Removes key-value tag pairs associated to your Amazon Managed
+%% Workflows for Apache Airflow (MWAA) environment.
+%%
+%% For example, `"Environment": "Staging"'.
 untag_resource(Client, ResourceArn, Input) ->
     untag_resource(Client, ResourceArn, Input, []).
 untag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -279,7 +290,8 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Update an MWAA environment.
+%% @doc Updates an Amazon Managed Workflows for Apache Airflow (MWAA)
+%% environment.
 update_environment(Client, Name, Input) ->
     update_environment(Client, Name, Input, []).
 update_environment(Client, Name, Input0, Options0) ->
@@ -337,6 +349,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_neptune.erl
+++ b/src/aws_neptune.erl
@@ -160,7 +160,7 @@
 %% API
 %%====================================================================
 
-%% @doc Associates an Identity and Access Management (IAM) role from an
+%% @doc Associates an Identity and Access Management (IAM) role with an
 %% Neptune DB cluster.
 add_role_to_db_cluster(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -334,7 +334,7 @@ create_db_parameter_group(Client, Input, Options)
 %% @doc Creates a new DB subnet group.
 %%
 %% DB subnet groups must contain at least one subnet in at least two AZs in
-%% the AWS Region.
+%% the Amazon Region.
 create_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_db_subnet_group(Client, Input, []).
@@ -509,15 +509,15 @@ describe_db_cluster_parameters(Client, Input, Options)
 %% @doc Returns a list of DB cluster snapshot attribute names and values for
 %% a manual DB cluster snapshot.
 %%
-%% When sharing snapshots with other AWS accounts,
+%% When sharing snapshots with other Amazon accounts,
 %% `DescribeDBClusterSnapshotAttributes' returns the `restore' attribute and
-%% a list of IDs for the AWS accounts that are authorized to copy or restore
-%% the manual DB cluster snapshot. If `all' is included in the list of values
-%% for the `restore' attribute, then the manual DB cluster snapshot is public
-%% and can be copied or restored by all AWS accounts.
+%% a list of IDs for the Amazon accounts that are authorized to copy or
+%% restore the manual DB cluster snapshot. If `all' is included in the list
+%% of values for the `restore' attribute, then the manual DB cluster snapshot
+%% is public and can be copied or restored by all Amazon accounts.
 %%
-%% To add or remove access for an AWS account to copy or restore a manual DB
-%% cluster snapshot, or to make the manual DB cluster snapshot public or
+%% To add or remove access for an Amazon account to copy or restore a manual
+%% DB cluster snapshot, or to make the manual DB cluster snapshot public or
 %% private, use the `ModifyDBClusterSnapshotAttribute' API action.
 describe_db_cluster_snapshot_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -762,19 +762,19 @@ modify_db_cluster_parameter_group(Client, Input, Options)
 %% @doc Adds an attribute and values to, or removes an attribute and values
 %% from, a manual DB cluster snapshot.
 %%
-%% To share a manual DB cluster snapshot with other AWS accounts, specify
+%% To share a manual DB cluster snapshot with other Amazon accounts, specify
 %% `restore' as the `AttributeName' and use the `ValuesToAdd' parameter to
-%% add a list of IDs of the AWS accounts that are authorized to restore the
-%% manual DB cluster snapshot. Use the value `all' to make the manual DB
+%% add a list of IDs of the Amazon accounts that are authorized to restore
+%% the manual DB cluster snapshot. Use the value `all' to make the manual DB
 %% cluster snapshot public, which means that it can be copied or restored by
-%% all AWS accounts. Do not add the `all' value for any manual DB cluster
+%% all Amazon accounts. Do not add the `all' value for any manual DB cluster
 %% snapshots that contain private information that you don't want available
-%% to all AWS accounts. If a manual DB cluster snapshot is encrypted, it can
-%% be shared, but only by specifying a list of authorized AWS account IDs for
-%% the `ValuesToAdd' parameter. You can't use `all' as a value for that
-%% parameter in this case.
+%% to all Amazon accounts. If a manual DB cluster snapshot is encrypted, it
+%% can be shared, but only by specifying a list of authorized Amazon account
+%% IDs for the `ValuesToAdd' parameter. You can't use `all' as a value for
+%% that parameter in this case.
 %%
-%% To view which AWS accounts have access to copy or restore a manual DB
+%% To view which Amazon accounts have access to copy or restore a manual DB
 %% cluster snapshot, or whether a manual DB cluster snapshot public or
 %% private, use the `DescribeDBClusterSnapshotAttributes' API action.
 modify_db_cluster_snapshot_attribute(Client, Input)
@@ -827,7 +827,7 @@ modify_db_parameter_group(Client, Input, Options)
 %% @doc Modifies an existing DB subnet group.
 %%
 %% DB subnet groups must contain at least one subnet in at least two AZs in
-%% the AWS Region.
+%% the Amazon Region.
 modify_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_subnet_group(Client, Input, []).
@@ -976,8 +976,8 @@ restore_db_cluster_to_point_in_time(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RestoreDBClusterToPointInTime">>, Input, Options).
 
-%% @doc Starts an Amazon Neptune DB cluster that was stopped using the AWS
-%% console, the AWS CLI stop-db-cluster command, or the StopDBCluster API.
+%% @doc Starts an Amazon Neptune DB cluster that was stopped using the Amazon
+%% console, the Amazon CLI stop-db-cluster command, or the StopDBCluster API.
 start_db_cluster(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_db_cluster(Client, Input, []).

--- a/src/aws_network_firewall.erl
+++ b/src/aws_network_firewall.erl
@@ -27,8 +27,9 @@
 %% perimeter of your VPC. This includes filtering traffic going to and coming
 %% from an internet gateway, NAT gateway, or over VPN or AWS Direct Connect.
 %% Network Firewall uses rules that are compatible with Suricata, a free,
-%% open source intrusion detection system (IDS) engine. For information about
-%% Suricata, see the Suricata website.
+%% open source intrusion detection system (IDS) engine. AWS Network Firewall
+%% supports Suricata version 5.0.2. For information about Suricata, see the
+%% Suricata website.
 %%
 %% You can use Network Firewall to monitor and protect your VPC traffic in a
 %% number of ways. The following are just a few examples:
@@ -41,9 +42,6 @@
 %%
 %% </li> <li> Perform deep packet inspection on traffic entering or leaving
 %% your VPC.
-%%
-%% </li> <li> Rate limit traffic going from AWS to on-premises IP
-%% destinations.
 %%
 %% </li> <li> Use stateful protocol detection to filter protocols like HTTPS,
 %% regardless of the port used.

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -2,12 +2,8 @@
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
 %% @doc Transit Gateway Network Manager (Network Manager) enables you to
-%% create a global network, in which you can monitor your AWS and on-premises
-%% networks that are built around transit gateways.
-%%
-%% The Network Manager APIs are supported in the US West (Oregon) Region
-%% only. You must specify the `us-west-2' Region in all requests made to
-%% Network Manager.
+%% create a global network, in which you can monitor your Amazon Web Services
+%% and on-premises networks that are built around transit gateways.
 -module(aws_networkmanager).
 
 -export([associate_customer_gateway/3,
@@ -62,6 +58,23 @@
          get_links/2,
          get_links/4,
          get_links/5,
+         get_network_resource_counts/2,
+         get_network_resource_counts/4,
+         get_network_resource_counts/5,
+         get_network_resource_relationships/2,
+         get_network_resource_relationships/4,
+         get_network_resource_relationships/5,
+         get_network_resources/2,
+         get_network_resources/4,
+         get_network_resources/5,
+         get_network_routes/3,
+         get_network_routes/4,
+         get_network_telemetry/2,
+         get_network_telemetry/4,
+         get_network_telemetry/5,
+         get_route_analysis/3,
+         get_route_analysis/5,
+         get_route_analysis/6,
          get_sites/2,
          get_sites/4,
          get_sites/5,
@@ -76,6 +89,8 @@
          list_tags_for_resource/5,
          register_transit_gateway/3,
          register_transit_gateway/4,
+         start_route_analysis/3,
+         start_route_analysis/4,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
@@ -88,6 +103,8 @@
          update_global_network/4,
          update_link/4,
          update_link/5,
+         update_network_resource_metadata/4,
+         update_network_resource_metadata/5,
          update_site/4,
          update_site/5]).
 
@@ -735,6 +752,185 @@ get_links(Client, GlobalNetworkId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets the count of network resources, by resource type, for the
+%% specified global network.
+get_network_resource_counts(Client, GlobalNetworkId)
+  when is_map(Client) ->
+    get_network_resource_counts(Client, GlobalNetworkId, #{}, #{}).
+
+get_network_resource_counts(Client, GlobalNetworkId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_network_resource_counts(Client, GlobalNetworkId, QueryMap, HeadersMap, []).
+
+get_network_resource_counts(Client, GlobalNetworkId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-resource-count"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"resourceType">>, maps:get(<<"resourceType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the network resource relationships for the specified global
+%% network.
+get_network_resource_relationships(Client, GlobalNetworkId)
+  when is_map(Client) ->
+    get_network_resource_relationships(Client, GlobalNetworkId, #{}, #{}).
+
+get_network_resource_relationships(Client, GlobalNetworkId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_network_resource_relationships(Client, GlobalNetworkId, QueryMap, HeadersMap, []).
+
+get_network_resource_relationships(Client, GlobalNetworkId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-resource-relationships"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"accountId">>, maps:get(<<"accountId">>, QueryMap, undefined)},
+        {<<"awsRegion">>, maps:get(<<"awsRegion">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"registeredGatewayArn">>, maps:get(<<"registeredGatewayArn">>, QueryMap, undefined)},
+        {<<"resourceArn">>, maps:get(<<"resourceArn">>, QueryMap, undefined)},
+        {<<"resourceType">>, maps:get(<<"resourceType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describes the network resources for the specified global network.
+%%
+%% The results include information from the corresponding Describe call for
+%% the resource, minus any sensitive information such as pre-shared keys.
+get_network_resources(Client, GlobalNetworkId)
+  when is_map(Client) ->
+    get_network_resources(Client, GlobalNetworkId, #{}, #{}).
+
+get_network_resources(Client, GlobalNetworkId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_network_resources(Client, GlobalNetworkId, QueryMap, HeadersMap, []).
+
+get_network_resources(Client, GlobalNetworkId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-resources"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"accountId">>, maps:get(<<"accountId">>, QueryMap, undefined)},
+        {<<"awsRegion">>, maps:get(<<"awsRegion">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"registeredGatewayArn">>, maps:get(<<"registeredGatewayArn">>, QueryMap, undefined)},
+        {<<"resourceArn">>, maps:get(<<"resourceArn">>, QueryMap, undefined)},
+        {<<"resourceType">>, maps:get(<<"resourceType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the network routes of the specified global network.
+get_network_routes(Client, GlobalNetworkId, Input) ->
+    get_network_routes(Client, GlobalNetworkId, Input, []).
+get_network_routes(Client, GlobalNetworkId, Input0, Options0) ->
+    Method = post,
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-routes"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Gets the network telemetry of the specified global network.
+get_network_telemetry(Client, GlobalNetworkId)
+  when is_map(Client) ->
+    get_network_telemetry(Client, GlobalNetworkId, #{}, #{}).
+
+get_network_telemetry(Client, GlobalNetworkId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_network_telemetry(Client, GlobalNetworkId, QueryMap, HeadersMap, []).
+
+get_network_telemetry(Client, GlobalNetworkId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-telemetry"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"accountId">>, maps:get(<<"accountId">>, QueryMap, undefined)},
+        {<<"awsRegion">>, maps:get(<<"awsRegion">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"registeredGatewayArn">>, maps:get(<<"registeredGatewayArn">>, QueryMap, undefined)},
+        {<<"resourceArn">>, maps:get(<<"resourceArn">>, QueryMap, undefined)},
+        {<<"resourceType">>, maps:get(<<"resourceType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets information about the specified route analysis.
+get_route_analysis(Client, GlobalNetworkId, RouteAnalysisId)
+  when is_map(Client) ->
+    get_route_analysis(Client, GlobalNetworkId, RouteAnalysisId, #{}, #{}).
+
+get_route_analysis(Client, GlobalNetworkId, RouteAnalysisId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_route_analysis(Client, GlobalNetworkId, RouteAnalysisId, QueryMap, HeadersMap, []).
+
+get_route_analysis(Client, GlobalNetworkId, RouteAnalysisId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/route-analyses/", aws_util:encode_uri(RouteAnalysisId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets information about one or more of your sites in a global network.
 get_sites(Client, GlobalNetworkId)
   when is_map(Client) ->
@@ -849,14 +1045,41 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
 %% @doc Registers a transit gateway in your global network.
 %%
-%% The transit gateway can be in any AWS Region, but it must be owned by the
-%% same AWS account that owns the global network. You cannot register a
-%% transit gateway in more than one global network.
+%% The transit gateway can be in any Amazon Web Services Region, but it must
+%% be owned by the same Amazon Web Services account that owns the global
+%% network. You cannot register a transit gateway in more than one global
+%% network.
 register_transit_gateway(Client, GlobalNetworkId, Input) ->
     register_transit_gateway(Client, GlobalNetworkId, Input, []).
 register_transit_gateway(Client, GlobalNetworkId, Input0, Options0) ->
     Method = post,
     Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/transit-gateway-registrations"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Starts analyzing the routing path between the specified source and
+%% destination.
+%%
+%% For more information, see Route Analyzer.
+start_route_analysis(Client, GlobalNetworkId, Input) ->
+    start_route_analysis(Client, GlobalNetworkId, Input, []).
+start_route_analysis(Client, GlobalNetworkId, Input0, Options0) ->
+    Method = post,
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/route-analyses"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1021,6 +1244,29 @@ update_link(Client, GlobalNetworkId, LinkId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates the resource metadata for the specified global network.
+update_network_resource_metadata(Client, GlobalNetworkId, ResourceArn, Input) ->
+    update_network_resource_metadata(Client, GlobalNetworkId, ResourceArn, Input, []).
+update_network_resource_metadata(Client, GlobalNetworkId, ResourceArn, Input0, Options0) ->
+    Method = patch,
+    Path = ["/global-networks/", aws_util:encode_uri(GlobalNetworkId), "/network-resources/", aws_util:encode_uri(ResourceArn), "/metadata"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates the information for an existing site.
 %%
 %% To remove information for any of the parameters, specify an empty string.
@@ -1058,7 +1304,8 @@ update_site(Client, GlobalNetworkId, SiteId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
-    Client1 = Client#{service => <<"networkmanager">>},
+    Client1 = Client#{service => <<"networkmanager">>,
+                      region => <<"us-west-2">>},
     Host = build_host(<<"networkmanager">>, Client1),
     URL0 = build_url(Host, Path, Client1),
     URL = aws_request:add_query(URL0, Query),
@@ -1081,6 +1328,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;
@@ -1108,8 +1363,8 @@ build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
     Endpoint;
 build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
-    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
 
 build_url(Host, Path0, Client) ->
     Proto = maps:get(proto, Client),

--- a/src/aws_nimble.erl
+++ b/src/aws_nimble.erl
@@ -1,0 +1,1491 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Welcome to the Amazon Nimble Studio API reference.
+%%
+%% This API reference provides methods, schema, resources, parameters, and
+%% more to help you get the most out of Nimble Studio.
+%%
+%% Nimble Studio is a virtual studio that empowers visual effects, animation,
+%% and interactive content teams to create content securely within a
+%% scalable, private cloud service.
+-module(aws_nimble).
+
+-export([accept_eulas/3,
+         accept_eulas/4,
+         create_launch_profile/3,
+         create_launch_profile/4,
+         create_streaming_image/3,
+         create_streaming_image/4,
+         create_streaming_session/3,
+         create_streaming_session/4,
+         create_streaming_session_stream/4,
+         create_streaming_session_stream/5,
+         create_studio/2,
+         create_studio/3,
+         create_studio_component/3,
+         create_studio_component/4,
+         delete_launch_profile/4,
+         delete_launch_profile/5,
+         delete_launch_profile_member/5,
+         delete_launch_profile_member/6,
+         delete_streaming_image/4,
+         delete_streaming_image/5,
+         delete_streaming_session/4,
+         delete_streaming_session/5,
+         delete_studio/3,
+         delete_studio/4,
+         delete_studio_component/4,
+         delete_studio_component/5,
+         delete_studio_member/4,
+         delete_studio_member/5,
+         get_eula/2,
+         get_eula/4,
+         get_eula/5,
+         get_launch_profile/3,
+         get_launch_profile/5,
+         get_launch_profile/6,
+         get_launch_profile_details/3,
+         get_launch_profile_details/5,
+         get_launch_profile_details/6,
+         get_launch_profile_initialization/6,
+         get_launch_profile_initialization/8,
+         get_launch_profile_initialization/9,
+         get_launch_profile_member/4,
+         get_launch_profile_member/6,
+         get_launch_profile_member/7,
+         get_streaming_image/3,
+         get_streaming_image/5,
+         get_streaming_image/6,
+         get_streaming_session/3,
+         get_streaming_session/5,
+         get_streaming_session/6,
+         get_streaming_session_stream/4,
+         get_streaming_session_stream/6,
+         get_streaming_session_stream/7,
+         get_studio/2,
+         get_studio/4,
+         get_studio/5,
+         get_studio_component/3,
+         get_studio_component/5,
+         get_studio_component/6,
+         get_studio_member/3,
+         get_studio_member/5,
+         get_studio_member/6,
+         list_eula_acceptances/2,
+         list_eula_acceptances/4,
+         list_eula_acceptances/5,
+         list_eulas/1,
+         list_eulas/3,
+         list_eulas/4,
+         list_launch_profile_members/3,
+         list_launch_profile_members/5,
+         list_launch_profile_members/6,
+         list_launch_profiles/2,
+         list_launch_profiles/4,
+         list_launch_profiles/5,
+         list_streaming_images/2,
+         list_streaming_images/4,
+         list_streaming_images/5,
+         list_streaming_sessions/2,
+         list_streaming_sessions/4,
+         list_streaming_sessions/5,
+         list_studio_components/2,
+         list_studio_components/4,
+         list_studio_components/5,
+         list_studio_members/2,
+         list_studio_members/4,
+         list_studio_members/5,
+         list_studios/1,
+         list_studios/3,
+         list_studios/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         put_launch_profile_members/4,
+         put_launch_profile_members/5,
+         put_studio_members/3,
+         put_studio_members/4,
+         start_streaming_session/4,
+         start_streaming_session/5,
+         start_studio_s_s_o_configuration_repair/3,
+         start_studio_s_s_o_configuration_repair/4,
+         stop_streaming_session/4,
+         stop_streaming_session/5,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_launch_profile/4,
+         update_launch_profile/5,
+         update_launch_profile_member/5,
+         update_launch_profile_member/6,
+         update_streaming_image/4,
+         update_streaming_image/5,
+         update_studio/3,
+         update_studio/4,
+         update_studio_component/4,
+         update_studio_component/5]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Accept EULAs.
+accept_eulas(Client, StudioId, Input) ->
+    accept_eulas(Client, StudioId, Input, []).
+accept_eulas(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/eula-acceptances"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Create a launch profile.
+create_launch_profile(Client, StudioId, Input) ->
+    create_launch_profile(Client, StudioId, Input, []).
+create_launch_profile(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a streaming image resource in a studio.
+create_streaming_image(Client, StudioId, Input) ->
+    create_streaming_image(Client, StudioId, Input, []).
+create_streaming_image(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-images"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a streaming session in a studio.
+%%
+%% After invoking this operation, you must poll GetStreamingSession until the
+%% streaming session is in state READY.
+create_streaming_session(Client, StudioId, Input) ->
+    create_streaming_session(Client, StudioId, Input, []).
+create_streaming_session(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a streaming session stream for a streaming session.
+%%
+%% After invoking this API, invoke GetStreamingSessionStream with the
+%% returned streamId to poll the resource until it is in state READY.
+create_streaming_session_stream(Client, SessionId, StudioId, Input) ->
+    create_streaming_session_stream(Client, SessionId, StudioId, Input, []).
+create_streaming_session_stream(Client, SessionId, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), "/streams"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Create a new Studio.
+%%
+%% When creating a Studio, two IAM roles must be provided: the admin role and
+%% the user Role. These roles are assumed by your users when they log in to
+%% the Nimble Studio portal.
+%%
+%% The user role must have the AmazonNimbleStudio-StudioUser managed policy
+%% attached for the portal to function properly.
+%%
+%% The Admin Role must have the AmazonNimbleStudio-StudioAdmin managed policy
+%% attached for the portal to function properly.
+%%
+%% You may optionally specify a KMS key in the StudioEncryptionConfiguration.
+%%
+%% In Nimble Studio, resource names, descriptions, initialization scripts,
+%% and other data you provide are always encrypted at rest using an KMS key.
+%% By default, this key is owned by Amazon Web Services and managed on your
+%% behalf. You may provide your own KMS key when calling CreateStudio to
+%% encrypt this data using a key you own and manage.
+%%
+%% When providing an KMS key during studio creation, Nimble Studio creates
+%% KMS grants in your account to provide your studio user and admin roles
+%% access to these KMS keys.
+%%
+%% If you delete this grant, the studio will no longer be accessible to your
+%% portal users.
+%%
+%% If you delete the studio KMS key, your studio will no longer be
+%% accessible.
+create_studio(Client, Input) ->
+    create_studio(Client, Input, []).
+create_studio(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a studio component resource.
+create_studio_component(Client, StudioId, Input) ->
+    create_studio_component(Client, StudioId, Input, []).
+create_studio_component(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/studio-components"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Permanently delete a launch profile.
+delete_launch_profile(Client, LaunchProfileId, StudioId, Input) ->
+    delete_launch_profile(Client, LaunchProfileId, StudioId, Input, []).
+delete_launch_profile(Client, LaunchProfileId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete a user from launch profile membership.
+delete_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input) ->
+    delete_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input, []).
+delete_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/membership/", aws_util:encode_uri(PrincipalId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete streaming image.
+delete_streaming_image(Client, StreamingImageId, StudioId, Input) ->
+    delete_streaming_image(Client, StreamingImageId, StudioId, Input, []).
+delete_streaming_image(Client, StreamingImageId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-images/", aws_util:encode_uri(StreamingImageId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes streaming session resource.
+%%
+%% After invoking this operation, use GetStreamingSession to poll the
+%% resource until it transitions to a DELETED state.
+%%
+%% A streaming session will count against your streaming session quota until
+%% it is marked DELETED.
+delete_streaming_session(Client, SessionId, StudioId, Input) ->
+    delete_streaming_session(Client, SessionId, StudioId, Input, []).
+delete_streaming_session(Client, SessionId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete a studio resource.
+delete_studio(Client, StudioId, Input) ->
+    delete_studio(Client, StudioId, Input, []).
+delete_studio(Client, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a studio component resource.
+delete_studio_component(Client, StudioComponentId, StudioId, Input) ->
+    delete_studio_component(Client, StudioComponentId, StudioId, Input, []).
+delete_studio_component(Client, StudioComponentId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/studio-components/", aws_util:encode_uri(StudioComponentId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete a user from studio membership.
+delete_studio_member(Client, PrincipalId, StudioId, Input) ->
+    delete_studio_member(Client, PrincipalId, StudioId, Input, []).
+delete_studio_member(Client, PrincipalId, StudioId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/membership/", aws_util:encode_uri(PrincipalId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Get Eula.
+get_eula(Client, EulaId)
+  when is_map(Client) ->
+    get_eula(Client, EulaId, #{}, #{}).
+
+get_eula(Client, EulaId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_eula(Client, EulaId, QueryMap, HeadersMap, []).
+
+get_eula(Client, EulaId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/eulas/", aws_util:encode_uri(EulaId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get a launch profile.
+get_launch_profile(Client, LaunchProfileId, StudioId)
+  when is_map(Client) ->
+    get_launch_profile(Client, LaunchProfileId, StudioId, #{}, #{}).
+
+get_launch_profile(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_launch_profile(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, []).
+
+get_launch_profile(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Launch profile details include the launch profile resource and
+%% summary information of resources that are used by, or available to, the
+%% launch profile.
+%%
+%% This includes the name and description of all studio components used by
+%% the launch profiles, and the name and description of streaming images that
+%% can be used with this launch profile.
+get_launch_profile_details(Client, LaunchProfileId, StudioId)
+  when is_map(Client) ->
+    get_launch_profile_details(Client, LaunchProfileId, StudioId, #{}, #{}).
+
+get_launch_profile_details(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_launch_profile_details(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, []).
+
+get_launch_profile_details(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/details"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get a launch profile initialization.
+get_launch_profile_initialization(Client, LaunchProfileId, StudioId, LaunchProfileProtocolVersions, LaunchPurpose, Platform)
+  when is_map(Client) ->
+    get_launch_profile_initialization(Client, LaunchProfileId, StudioId, LaunchProfileProtocolVersions, LaunchPurpose, Platform, #{}, #{}).
+
+get_launch_profile_initialization(Client, LaunchProfileId, StudioId, LaunchProfileProtocolVersions, LaunchPurpose, Platform, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_launch_profile_initialization(Client, LaunchProfileId, StudioId, LaunchProfileProtocolVersions, LaunchPurpose, Platform, QueryMap, HeadersMap, []).
+
+get_launch_profile_initialization(Client, LaunchProfileId, StudioId, LaunchProfileProtocolVersions, LaunchPurpose, Platform, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/init"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"launchProfileProtocolVersions">>, LaunchProfileProtocolVersions},
+        {<<"launchPurpose">>, LaunchPurpose},
+        {<<"platform">>, Platform}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get a user persona in launch profile membership.
+get_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId)
+  when is_map(Client) ->
+    get_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, #{}, #{}).
+
+get_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, QueryMap, HeadersMap, []).
+
+get_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/membership/", aws_util:encode_uri(PrincipalId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get streaming image.
+get_streaming_image(Client, StreamingImageId, StudioId)
+  when is_map(Client) ->
+    get_streaming_image(Client, StreamingImageId, StudioId, #{}, #{}).
+
+get_streaming_image(Client, StreamingImageId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_streaming_image(Client, StreamingImageId, StudioId, QueryMap, HeadersMap, []).
+
+get_streaming_image(Client, StreamingImageId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-images/", aws_util:encode_uri(StreamingImageId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets StreamingSession resource.
+%%
+%% anvoke this operation to poll for a streaming session state while creating
+%% or deleting a session.
+get_streaming_session(Client, SessionId, StudioId)
+  when is_map(Client) ->
+    get_streaming_session(Client, SessionId, StudioId, #{}, #{}).
+
+get_streaming_session(Client, SessionId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_streaming_session(Client, SessionId, StudioId, QueryMap, HeadersMap, []).
+
+get_streaming_session(Client, SessionId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets a StreamingSessionStream for a streaming session.
+%%
+%% Invoke this operation to poll the resource after invoking
+%% CreateStreamingSessionStream.
+%%
+%% After the StreamingSessionStream changes to the state READY, the url
+%% property will contain a stream to be used with the DCV streaming client.
+get_streaming_session_stream(Client, SessionId, StreamId, StudioId)
+  when is_map(Client) ->
+    get_streaming_session_stream(Client, SessionId, StreamId, StudioId, #{}, #{}).
+
+get_streaming_session_stream(Client, SessionId, StreamId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_streaming_session_stream(Client, SessionId, StreamId, StudioId, QueryMap, HeadersMap, []).
+
+get_streaming_session_stream(Client, SessionId, StreamId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), "/streams/", aws_util:encode_uri(StreamId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get a Studio resource.
+get_studio(Client, StudioId)
+  when is_map(Client) ->
+    get_studio(Client, StudioId, #{}, #{}).
+
+get_studio(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_studio(Client, StudioId, QueryMap, HeadersMap, []).
+
+get_studio(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets a studio component resource.
+get_studio_component(Client, StudioComponentId, StudioId)
+  when is_map(Client) ->
+    get_studio_component(Client, StudioComponentId, StudioId, #{}, #{}).
+
+get_studio_component(Client, StudioComponentId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_studio_component(Client, StudioComponentId, StudioId, QueryMap, HeadersMap, []).
+
+get_studio_component(Client, StudioComponentId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/studio-components/", aws_util:encode_uri(StudioComponentId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get a user's membership in a studio.
+get_studio_member(Client, PrincipalId, StudioId)
+  when is_map(Client) ->
+    get_studio_member(Client, PrincipalId, StudioId, #{}, #{}).
+
+get_studio_member(Client, PrincipalId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_studio_member(Client, PrincipalId, StudioId, QueryMap, HeadersMap, []).
+
+get_studio_member(Client, PrincipalId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/membership/", aws_util:encode_uri(PrincipalId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List Eula Acceptances.
+list_eula_acceptances(Client, StudioId)
+  when is_map(Client) ->
+    list_eula_acceptances(Client, StudioId, #{}, #{}).
+
+list_eula_acceptances(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_eula_acceptances(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_eula_acceptances(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/eula-acceptances"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"eulaIds">>, maps:get(<<"eulaIds">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List Eulas.
+list_eulas(Client)
+  when is_map(Client) ->
+    list_eulas(Client, #{}, #{}).
+
+list_eulas(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_eulas(Client, QueryMap, HeadersMap, []).
+
+list_eulas(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/eulas"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"eulaIds">>, maps:get(<<"eulaIds">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get all users in a given launch profile membership.
+list_launch_profile_members(Client, LaunchProfileId, StudioId)
+  when is_map(Client) ->
+    list_launch_profile_members(Client, LaunchProfileId, StudioId, #{}, #{}).
+
+list_launch_profile_members(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_launch_profile_members(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, []).
+
+list_launch_profile_members(Client, LaunchProfileId, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/membership"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all the launch profiles a studio.
+list_launch_profiles(Client, StudioId)
+  when is_map(Client) ->
+    list_launch_profiles(Client, StudioId, #{}, #{}).
+
+list_launch_profiles(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_launch_profiles(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_launch_profiles(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"principalId">>, maps:get(<<"principalId">>, QueryMap, undefined)},
+        {<<"states">>, maps:get(<<"states">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List the streaming image resources available to this studio.
+%%
+%% This list will contain both images provided by Amazon Web Services, as
+%% well as streaming images that you have created in your studio.
+list_streaming_images(Client, StudioId)
+  when is_map(Client) ->
+    list_streaming_images(Client, StudioId, #{}, #{}).
+
+list_streaming_images(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_streaming_images(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_streaming_images(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-images"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"owner">>, maps:get(<<"owner">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the streaming image resources in a studio.
+list_streaming_sessions(Client, StudioId)
+  when is_map(Client) ->
+    list_streaming_sessions(Client, StudioId, #{}, #{}).
+
+list_streaming_sessions(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_streaming_sessions(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_streaming_sessions(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"createdBy">>, maps:get(<<"createdBy">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"ownedBy">>, maps:get(<<"ownedBy">>, QueryMap, undefined)},
+        {<<"sessionIds">>, maps:get(<<"sessionIds">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the StudioComponents in a studio.
+list_studio_components(Client, StudioId)
+  when is_map(Client) ->
+    list_studio_components(Client, StudioId, #{}, #{}).
+
+list_studio_components(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_studio_components(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_studio_components(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/studio-components"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"states">>, maps:get(<<"states">>, QueryMap, undefined)},
+        {<<"types">>, maps:get(<<"types">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Get all users in a given studio membership.
+list_studio_members(Client, StudioId)
+  when is_map(Client) ->
+    list_studio_members(Client, StudioId, #{}, #{}).
+
+list_studio_members(Client, StudioId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_studio_members(Client, StudioId, QueryMap, HeadersMap, []).
+
+list_studio_members(Client, StudioId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/membership"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List studios in your Amazon Web Services account in the requested
+%% Amazon Web Services Region.
+list_studios(Client)
+  when is_map(Client) ->
+    list_studios(Client, #{}, #{}).
+
+list_studios(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_studios(Client, QueryMap, HeadersMap, []).
+
+list_studios(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/studios"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Gets the tags for a resource, given its Amazon Resource Names (ARN).
+%%
+%% This operation supports ARNs for all resource types in Nimble Studio that
+%% support tags, including studio, studio component, launch profile,
+%% streaming image, and streaming session. All resources that can be tagged
+%% will contain an ARN property, so you do not have to create this ARN
+%% yourself.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2020-08-01/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Add/update users with given persona to launch profile membership.
+put_launch_profile_members(Client, LaunchProfileId, StudioId, Input) ->
+    put_launch_profile_members(Client, LaunchProfileId, StudioId, Input, []).
+put_launch_profile_members(Client, LaunchProfileId, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/membership"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Add/update users with given persona to studio membership.
+put_studio_members(Client, StudioId, Input) ->
+    put_studio_members(Client, StudioId, Input, []).
+put_studio_members(Client, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/membership"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Transitions sessions from the STOPPED state into the READY state.
+%%
+%% The START_IN_PROGRESS state is the intermediate state between the STOPPED
+%% and READY states.
+start_streaming_session(Client, SessionId, StudioId, Input) ->
+    start_streaming_session(Client, SessionId, StudioId, Input, []).
+start_streaming_session(Client, SessionId, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), "/start"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Repairs the Amazon Web Services SSO configuration for a given studio.
+%%
+%% If the studio has a valid Amazon Web Services SSO configuration currently
+%% associated with it, this operation will fail with a validation error.
+%%
+%% If the studio does not have a valid Amazon Web Services SSO configuration
+%% currently associated with it, then a new Amazon Web Services SSO
+%% application is created for the studio and the studio is changed to the
+%% READY state.
+%%
+%% After the Amazon Web Services SSO application is repaired, you must use
+%% the Amazon Nimble Studio console to add administrators and users to your
+%% studio.
+start_studio_s_s_o_configuration_repair(Client, StudioId, Input) ->
+    start_studio_s_s_o_configuration_repair(Client, StudioId, Input, []).
+start_studio_s_s_o_configuration_repair(Client, StudioId, Input0, Options0) ->
+    Method = put,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/sso-configuration"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Transitions sessions from the READY state into the STOPPED state.
+%%
+%% The STOP_IN_PROGRESS state is the intermediate state between the READY and
+%% STOPPED states.
+stop_streaming_session(Client, SessionId, StudioId, Input) ->
+    stop_streaming_session(Client, SessionId, StudioId, Input, []).
+stop_streaming_session(Client, SessionId, StudioId, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-sessions/", aws_util:encode_uri(SessionId), "/stop"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates tags for a resource, given its ARN.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/2020-08-01/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the tags for a resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2020-08-01/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a launch profile.
+update_launch_profile(Client, LaunchProfileId, StudioId, Input) ->
+    update_launch_profile(Client, LaunchProfileId, StudioId, Input, []).
+update_launch_profile(Client, LaunchProfileId, StudioId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a user persona in launch profile membership.
+update_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input) ->
+    update_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input, []).
+update_launch_profile_member(Client, LaunchProfileId, PrincipalId, StudioId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/launch-profiles/", aws_util:encode_uri(LaunchProfileId), "/membership/", aws_util:encode_uri(PrincipalId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update streaming image.
+update_streaming_image(Client, StreamingImageId, StudioId, Input) ->
+    update_streaming_image(Client, StreamingImageId, StudioId, Input, []).
+update_streaming_image(Client, StreamingImageId, StudioId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/streaming-images/", aws_util:encode_uri(StreamingImageId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a Studio resource.
+%%
+%% Currently, this operation only supports updating the displayName of your
+%% studio.
+update_studio(Client, StudioId, Input) ->
+    update_studio(Client, StudioId, Input, []).
+update_studio(Client, StudioId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a studio component resource.
+update_studio_component(Client, StudioComponentId, StudioId, Input) ->
+    update_studio_component(Client, StudioComponentId, StudioId, Input, []).
+update_studio_component(Client, StudioComponentId, StudioId, Input0, Options0) ->
+    Method = patch,
+    Path = ["/2020-08-01/studios/", aws_util:encode_uri(StudioId), "/studio-components/", aws_util:encode_uri(StudioComponentId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"X-Amz-Client-Token">>, <<"clientToken">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"nimble">>},
+    Host = build_host(<<"nimble">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_opensearch.erl
+++ b/src/aws_opensearch.erl
@@ -1,0 +1,1203 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon OpenSearch Configuration Service
+%%
+%% Use the Amazon OpenSearch configuration API to create, configure, and
+%% manage Amazon OpenSearch Service domains.
+%%
+%% For sample code that uses the configuration API, see the Amazon OpenSearch
+%% Service Developer Guide. The guide also contains sample code for sending
+%% signed HTTP requests to the OpenSearch APIs.
+%%
+%% The endpoint for configuration service requests is region-specific:
+%% es.region.amazonaws.com. For example, es.us-east-1.amazonaws.com. For a
+%% current list of supported regions and endpoints, see Regions and
+%% Endpoints.
+-module(aws_opensearch).
+
+-export([accept_inbound_connection/3,
+         accept_inbound_connection/4,
+         add_tags/2,
+         add_tags/3,
+         associate_package/4,
+         associate_package/5,
+         cancel_service_software_update/2,
+         cancel_service_software_update/3,
+         create_domain/2,
+         create_domain/3,
+         create_outbound_connection/2,
+         create_outbound_connection/3,
+         create_package/2,
+         create_package/3,
+         delete_domain/3,
+         delete_domain/4,
+         delete_inbound_connection/3,
+         delete_inbound_connection/4,
+         delete_outbound_connection/3,
+         delete_outbound_connection/4,
+         delete_package/3,
+         delete_package/4,
+         describe_domain/2,
+         describe_domain/4,
+         describe_domain/5,
+         describe_domain_auto_tunes/2,
+         describe_domain_auto_tunes/4,
+         describe_domain_auto_tunes/5,
+         describe_domain_config/2,
+         describe_domain_config/4,
+         describe_domain_config/5,
+         describe_domains/2,
+         describe_domains/3,
+         describe_inbound_connections/2,
+         describe_inbound_connections/3,
+         describe_instance_type_limits/3,
+         describe_instance_type_limits/5,
+         describe_instance_type_limits/6,
+         describe_outbound_connections/2,
+         describe_outbound_connections/3,
+         describe_packages/2,
+         describe_packages/3,
+         describe_reserved_instance_offerings/1,
+         describe_reserved_instance_offerings/3,
+         describe_reserved_instance_offerings/4,
+         describe_reserved_instances/1,
+         describe_reserved_instances/3,
+         describe_reserved_instances/4,
+         dissociate_package/4,
+         dissociate_package/5,
+         get_compatible_versions/1,
+         get_compatible_versions/3,
+         get_compatible_versions/4,
+         get_package_version_history/2,
+         get_package_version_history/4,
+         get_package_version_history/5,
+         get_upgrade_history/2,
+         get_upgrade_history/4,
+         get_upgrade_history/5,
+         get_upgrade_status/2,
+         get_upgrade_status/4,
+         get_upgrade_status/5,
+         list_domain_names/1,
+         list_domain_names/3,
+         list_domain_names/4,
+         list_domains_for_package/2,
+         list_domains_for_package/4,
+         list_domains_for_package/5,
+         list_instance_type_details/2,
+         list_instance_type_details/4,
+         list_instance_type_details/5,
+         list_packages_for_domain/2,
+         list_packages_for_domain/4,
+         list_packages_for_domain/5,
+         list_tags/2,
+         list_tags/4,
+         list_tags/5,
+         list_versions/1,
+         list_versions/3,
+         list_versions/4,
+         purchase_reserved_instance_offering/2,
+         purchase_reserved_instance_offering/3,
+         reject_inbound_connection/3,
+         reject_inbound_connection/4,
+         remove_tags/2,
+         remove_tags/3,
+         start_service_software_update/2,
+         start_service_software_update/3,
+         update_domain_config/3,
+         update_domain_config/4,
+         update_package/2,
+         update_package/3,
+         upgrade_domain/2,
+         upgrade_domain/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Allows the remote domain owner to accept an inbound cross-cluster
+%% connection request.
+accept_inbound_connection(Client, ConnectionId, Input) ->
+    accept_inbound_connection(Client, ConnectionId, Input, []).
+accept_inbound_connection(Client, ConnectionId, Input0, Options0) ->
+    Method = put,
+    Path = ["/2021-01-01/opensearch/cc/inboundConnection/", aws_util:encode_uri(ConnectionId), "/accept"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Attaches tags to an existing domain.
+%%
+%% Tags are a set of case-sensitive key value pairs. An domain can have up to
+%% 10 tags. See Tagging Amazon OpenSearch Service domains for more
+%% information.
+add_tags(Client, Input) ->
+    add_tags(Client, Input, []).
+add_tags(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/tags"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Associates a package with an Amazon OpenSearch Service domain.
+associate_package(Client, DomainName, PackageID, Input) ->
+    associate_package(Client, DomainName, PackageID, Input, []).
+associate_package(Client, DomainName, PackageID, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/packages/associate/", aws_util:encode_uri(PackageID), "/", aws_util:encode_uri(DomainName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Cancels a scheduled service software update for an Amazon OpenSearch
+%% Service domain.
+%%
+%% You can only perform this operation before the `AutomatedUpdateDate' and
+%% when the `UpdateStatus' is in the `PENDING_UPDATE' state.
+cancel_service_software_update(Client, Input) ->
+    cancel_service_software_update(Client, Input, []).
+cancel_service_software_update(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/serviceSoftwareUpdate/cancel"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Amazon OpenSearch Service domain.
+%%
+%% For more information, see Creating and managing Amazon OpenSearch Service
+%% domains in the Amazon OpenSearch Service Developer Guide.
+create_domain(Client, Input) ->
+    create_domain(Client, Input, []).
+create_domain(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/domain"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new cross-cluster connection from a local OpenSearch domain
+%% to a remote OpenSearch domain.
+create_outbound_connection(Client, Input) ->
+    create_outbound_connection(Client, Input, []).
+create_outbound_connection(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/cc/outboundConnection"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Create a package for use with Amazon OpenSearch Service domains.
+create_package(Client, Input) ->
+    create_package(Client, Input, []).
+create_package(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/packages"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Permanently deletes the specified domain and all of its data.
+%%
+%% Once a domain is deleted, it cannot be recovered.
+delete_domain(Client, DomainName, Input) ->
+    delete_domain(Client, DomainName, Input, []).
+delete_domain(Client, DomainName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2021-01-01/opensearch/domain/", aws_util:encode_uri(DomainName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows the remote domain owner to delete an existing inbound
+%% cross-cluster connection.
+delete_inbound_connection(Client, ConnectionId, Input) ->
+    delete_inbound_connection(Client, ConnectionId, Input, []).
+delete_inbound_connection(Client, ConnectionId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2021-01-01/opensearch/cc/inboundConnection/", aws_util:encode_uri(ConnectionId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows the local domain owner to delete an existing outbound
+%% cross-cluster connection.
+delete_outbound_connection(Client, ConnectionId, Input) ->
+    delete_outbound_connection(Client, ConnectionId, Input, []).
+delete_outbound_connection(Client, ConnectionId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2021-01-01/opensearch/cc/outboundConnection/", aws_util:encode_uri(ConnectionId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the package.
+delete_package(Client, PackageID, Input) ->
+    delete_package(Client, PackageID, Input, []).
+delete_package(Client, PackageID, Input0, Options0) ->
+    Method = delete,
+    Path = ["/2021-01-01/packages/", aws_util:encode_uri(PackageID), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns domain configuration information about the specified domain,
+%% including the domain ID, domain endpoint, and domain ARN.
+describe_domain(Client, DomainName)
+  when is_map(Client) ->
+    describe_domain(Client, DomainName, #{}, #{}).
+
+describe_domain(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_domain(Client, DomainName, QueryMap, HeadersMap, []).
+
+describe_domain(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/domain/", aws_util:encode_uri(DomainName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Provides scheduled Auto-Tune action details for the domain, such as
+%% Auto-Tune action type, description, severity, and scheduled date.
+describe_domain_auto_tunes(Client, DomainName)
+  when is_map(Client) ->
+    describe_domain_auto_tunes(Client, DomainName, #{}, #{}).
+
+describe_domain_auto_tunes(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_domain_auto_tunes(Client, DomainName, QueryMap, HeadersMap, []).
+
+describe_domain_auto_tunes(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/domain/", aws_util:encode_uri(DomainName), "/autoTunes"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Provides cluster configuration information about the specified
+%% domain, such as the state, creation date, update version, and update date
+%% for cluster options.
+describe_domain_config(Client, DomainName)
+  when is_map(Client) ->
+    describe_domain_config(Client, DomainName, #{}, #{}).
+
+describe_domain_config(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_domain_config(Client, DomainName, QueryMap, HeadersMap, []).
+
+describe_domain_config(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/domain/", aws_util:encode_uri(DomainName), "/config"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns domain configuration information about the specified domains,
+%% including the domain ID, domain endpoint, and domain ARN.
+describe_domains(Client, Input) ->
+    describe_domains(Client, Input, []).
+describe_domains(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/domain-info"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all the inbound cross-cluster connections for a remote domain.
+describe_inbound_connections(Client, Input) ->
+    describe_inbound_connections(Client, Input, []).
+describe_inbound_connections(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/cc/inboundConnection/search"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describe the limits for a given instance type and OpenSearch or
+%% Elasticsearch version.
+%%
+%% When modifying an existing domain, specify the ` `DomainName' ' to see
+%% which limits you can modify.
+describe_instance_type_limits(Client, EngineVersion, InstanceType)
+  when is_map(Client) ->
+    describe_instance_type_limits(Client, EngineVersion, InstanceType, #{}, #{}).
+
+describe_instance_type_limits(Client, EngineVersion, InstanceType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_instance_type_limits(Client, EngineVersion, InstanceType, QueryMap, HeadersMap, []).
+
+describe_instance_type_limits(Client, EngineVersion, InstanceType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/instanceTypeLimits/", aws_util:encode_uri(EngineVersion), "/", aws_util:encode_uri(InstanceType), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"domainName">>, maps:get(<<"domainName">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all the outbound cross-cluster connections for a local domain.
+describe_outbound_connections(Client, Input) ->
+    describe_outbound_connections(Client, Input, []).
+describe_outbound_connections(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/cc/outboundConnection/search"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes all packages available to Amazon OpenSearch Service
+%% domains.
+%%
+%% Includes options for filtering, limiting the number of results, and
+%% pagination.
+describe_packages(Client, Input) ->
+    describe_packages(Client, Input, []).
+describe_packages(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/packages/describe"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists available reserved OpenSearch instance offerings.
+describe_reserved_instance_offerings(Client)
+  when is_map(Client) ->
+    describe_reserved_instance_offerings(Client, #{}, #{}).
+
+describe_reserved_instance_offerings(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_reserved_instance_offerings(Client, QueryMap, HeadersMap, []).
+
+describe_reserved_instance_offerings(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/reservedInstanceOfferings"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"offeringId">>, maps:get(<<"offeringId">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about reserved OpenSearch instances for this
+%% account.
+describe_reserved_instances(Client)
+  when is_map(Client) ->
+    describe_reserved_instances(Client, #{}, #{}).
+
+describe_reserved_instances(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_reserved_instances(Client, QueryMap, HeadersMap, []).
+
+describe_reserved_instances(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/reservedInstances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"reservationId">>, maps:get(<<"reservationId">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Dissociates a package from the Amazon OpenSearch Service domain.
+dissociate_package(Client, DomainName, PackageID, Input) ->
+    dissociate_package(Client, DomainName, PackageID, Input, []).
+dissociate_package(Client, DomainName, PackageID, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/packages/dissociate/", aws_util:encode_uri(PackageID), "/", aws_util:encode_uri(DomainName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a list of upgrade-compatible versions of
+%% OpenSearch/Elasticsearch.
+%%
+%% You can optionally pass a ` `DomainName' ' to get all upgrade-compatible
+%% versions of OpenSearch/Elasticsearch for that specific domain.
+get_compatible_versions(Client)
+  when is_map(Client) ->
+    get_compatible_versions(Client, #{}, #{}).
+
+get_compatible_versions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_compatible_versions(Client, QueryMap, HeadersMap, []).
+
+get_compatible_versions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/compatibleVersions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"domainName">>, maps:get(<<"domainName">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of package versions, along with their creation time
+%% and commit message.
+get_package_version_history(Client, PackageID)
+  when is_map(Client) ->
+    get_package_version_history(Client, PackageID, #{}, #{}).
+
+get_package_version_history(Client, PackageID, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_package_version_history(Client, PackageID, QueryMap, HeadersMap, []).
+
+get_package_version_history(Client, PackageID, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/packages/", aws_util:encode_uri(PackageID), "/history"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the complete history of the last 10 upgrades performed on
+%% the domain.
+get_upgrade_history(Client, DomainName)
+  when is_map(Client) ->
+    get_upgrade_history(Client, DomainName, #{}, #{}).
+
+get_upgrade_history(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_upgrade_history(Client, DomainName, QueryMap, HeadersMap, []).
+
+get_upgrade_history(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/upgradeDomain/", aws_util:encode_uri(DomainName), "/history"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the latest status of the last upgrade or upgrade
+%% eligibility check performed on the domain.
+get_upgrade_status(Client, DomainName)
+  when is_map(Client) ->
+    get_upgrade_status(Client, DomainName, #{}, #{}).
+
+get_upgrade_status(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_upgrade_status(Client, DomainName, QueryMap, HeadersMap, []).
+
+get_upgrade_status(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/upgradeDomain/", aws_util:encode_uri(DomainName), "/status"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the names of all domains owned by the current user's account.
+list_domain_names(Client)
+  when is_map(Client) ->
+    list_domain_names(Client, #{}, #{}).
+
+list_domain_names(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_domain_names(Client, QueryMap, HeadersMap, []).
+
+list_domain_names(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/domain"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"engineType">>, maps:get(<<"engineType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all Amazon OpenSearch Service domains associated with the
+%% package.
+list_domains_for_package(Client, PackageID)
+  when is_map(Client) ->
+    list_domains_for_package(Client, PackageID, #{}, #{}).
+
+list_domains_for_package(Client, PackageID, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_domains_for_package(Client, PackageID, QueryMap, HeadersMap, []).
+
+list_domains_for_package(Client, PackageID, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/packages/", aws_util:encode_uri(PackageID), "/domains"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+
+list_instance_type_details(Client, EngineVersion)
+  when is_map(Client) ->
+    list_instance_type_details(Client, EngineVersion, #{}, #{}).
+
+list_instance_type_details(Client, EngineVersion, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_instance_type_details(Client, EngineVersion, QueryMap, HeadersMap, []).
+
+list_instance_type_details(Client, EngineVersion, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/instanceTypeDetails/", aws_util:encode_uri(EngineVersion), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"domainName">>, maps:get(<<"domainName">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all packages associated with the Amazon OpenSearch Service
+%% domain.
+list_packages_for_domain(Client, DomainName)
+  when is_map(Client) ->
+    list_packages_for_domain(Client, DomainName, #{}, #{}).
+
+list_packages_for_domain(Client, DomainName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_packages_for_domain(Client, DomainName, QueryMap, HeadersMap, []).
+
+list_packages_for_domain(Client, DomainName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/domain/", aws_util:encode_uri(DomainName), "/packages"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns all tags for the given domain.
+list_tags(Client, ARN)
+  when is_map(Client) ->
+    list_tags(Client, ARN, #{}, #{}).
+
+list_tags(Client, ARN, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags(Client, ARN, QueryMap, HeadersMap, []).
+
+list_tags(Client, ARN, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/tags/"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, ARN}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all supported versions of OpenSearch and Elasticsearch.
+list_versions(Client)
+  when is_map(Client) ->
+    list_versions(Client, #{}, #{}).
+
+list_versions(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_versions(Client, QueryMap, HeadersMap, []).
+
+list_versions(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/2021-01-01/opensearch/versions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Allows you to purchase reserved OpenSearch instances.
+purchase_reserved_instance_offering(Client, Input) ->
+    purchase_reserved_instance_offering(Client, Input, []).
+purchase_reserved_instance_offering(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/purchaseReservedInstanceOffering"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows the remote domain owner to reject an inbound cross-cluster
+%% connection request.
+reject_inbound_connection(Client, ConnectionId, Input) ->
+    reject_inbound_connection(Client, ConnectionId, Input, []).
+reject_inbound_connection(Client, ConnectionId, Input0, Options0) ->
+    Method = put,
+    Path = ["/2021-01-01/opensearch/cc/inboundConnection/", aws_util:encode_uri(ConnectionId), "/reject"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the specified set of tags from the given domain.
+remove_tags(Client, Input) ->
+    remove_tags(Client, Input, []).
+remove_tags(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/tags-removal"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Schedules a service software update for an Amazon OpenSearch Service
+%% domain.
+start_service_software_update(Client, Input) ->
+    start_service_software_update(Client, Input, []).
+start_service_software_update(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/serviceSoftwareUpdate/start"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Modifies the cluster configuration of the specified domain, such as
+%% setting the instance type and the number of instances.
+update_domain_config(Client, DomainName, Input) ->
+    update_domain_config(Client, DomainName, Input, []).
+update_domain_config(Client, DomainName, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/domain/", aws_util:encode_uri(DomainName), "/config"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a package for use with Amazon OpenSearch Service domains.
+update_package(Client, Input) ->
+    update_package(Client, Input, []).
+update_package(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/packages/update"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Allows you to either upgrade your domain or perform an upgrade
+%% eligibility check to a compatible version of OpenSearch or Elasticsearch.
+upgrade_domain(Client, Input) ->
+    upgrade_domain(Client, Input, []).
+upgrade_domain(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/2021-01-01/opensearch/upgradeDomain"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"es">>},
+    Host = build_host(<<"es">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_organizations.erl
+++ b/src/aws_organizations.erl
@@ -1,7 +1,71 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Organizations
+%% @doc AWS Organizations is a web service that enables you to consolidate
+%% your multiple AWS accounts into an organization and centrally manage your
+%% accounts and their resources.
+%%
+%% This guide provides descriptions of the Organizations operations. For more
+%% information about using this service, see the AWS Organizations User
+%% Guide.
+%%
+%% Support and feedback for AWS Organizations
+%%
+%% We welcome your feedback. Send your comments to
+%% feedback-awsorganizations@amazon.com or post your feedback and questions
+%% in the AWS Organizations support forum. For more information about the AWS
+%% support forums, see Forums Help.
+%%
+%% Endpoint to call When using the AWS CLI or the AWS SDK
+%%
+%% For the current release of Organizations, specify the `us-east-1' region
+%% for all AWS API and AWS CLI calls made from the commercial AWS Regions
+%% outside of China. If calling from one of the AWS Regions in China, then
+%% specify `cn-northwest-1'. You can do this in the AWS CLI by using these
+%% parameters and commands:
+%%
+%% <ul> <li> Use the following parameter with each command to specify both
+%% the endpoint and its region:
+%%
+%% `--endpoint-url https://organizations.us-east-1.amazonaws.com' (from
+%% commercial AWS Regions outside of China)
+%%
+%% or
+%%
+%% `--endpoint-url https://organizations.cn-northwest-1.amazonaws.com.cn'
+%% (from AWS Regions in China)
+%%
+%% </li> <li> Use the default endpoint, but configure your default region
+%% with this command:
+%%
+%% `aws configure set default.region us-east-1' (from commercial AWS Regions
+%% outside of China)
+%%
+%% or
+%%
+%% `aws configure set default.region cn-northwest-1' (from AWS Regions in
+%% China)
+%%
+%% </li> <li> Use the following parameter with each command to specify the
+%% endpoint:
+%%
+%% `--region us-east-1' (from commercial AWS Regions outside of China)
+%%
+%% or
+%%
+%% `--region cn-northwest-1' (from AWS Regions in China)
+%%
+%% </li> </ul> Recording API Requests
+%%
+%% AWS Organizations supports AWS CloudTrail, a service that records AWS API
+%% calls for your AWS account and delivers log files to an Amazon S3 bucket.
+%% By using information collected by AWS CloudTrail, you can determine which
+%% requests the Organizations service received, who made the request and
+%% when, and so on. For more about AWS Organizations and its support for AWS
+%% CloudTrail, see Logging AWS Organizations Events with AWS CloudTrail in
+%% the AWS Organizations User Guide. To learn more about AWS CloudTrail,
+%% including how to turn it on and find your log files, see the AWS
+%% CloudTrail User Guide.
 -module(aws_organizations).
 
 -export([accept_handshake/2,
@@ -206,7 +270,7 @@ cancel_handshake(Client, Input, Options)
 %%
 %% </li> <li> Check the AWS CloudTrail log for the `CreateAccountResult'
 %% event. For information on using AWS CloudTrail with AWS Organizations, see
-%% Monitoring the Activity in Your Organization in the AWS Organizations User
+%% Logging and monitoring in AWS Organizations in the AWS Organizations User
 %% Guide.
 %%
 %% </li> </ul> The user who calls the API to create an account must have the
@@ -924,6 +988,10 @@ invite_account_to_organization(Client, Input, Options)
 %% After the account leaves the organization, all tags that were attached to
 %% the account object in the organization are deleted. AWS accounts outside
 %% of an organization do not support tags.
+%%
+%% A newly created account has a waiting period before it can be removed from
+%% its organization. If you get an error that indicates that a wait period is
+%% required, then try again in a few days.
 leave_organization(Client, Input)
   when is_map(Client), is_map(Input) ->
     leave_organization(Client, Input, []).

--- a/src/aws_panorama.erl
+++ b/src/aws_panorama.erl
@@ -1,0 +1,1020 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc AWS Panorama
+%%
+%% Overview
+%%
+%% This is the AWS Panorama API Reference.
+%%
+%% For an introduction to the service, see What is AWS Panorama? in the AWS
+%% Panorama Developer Guide.
+-module(aws_panorama).
+
+-export([create_application_instance/2,
+         create_application_instance/3,
+         create_job_for_devices/2,
+         create_job_for_devices/3,
+         create_node_from_template_job/2,
+         create_node_from_template_job/3,
+         create_package/2,
+         create_package/3,
+         create_package_import_job/2,
+         create_package_import_job/3,
+         delete_device/3,
+         delete_device/4,
+         delete_package/3,
+         delete_package/4,
+         deregister_package_version/5,
+         deregister_package_version/6,
+         describe_application_instance/2,
+         describe_application_instance/4,
+         describe_application_instance/5,
+         describe_application_instance_details/2,
+         describe_application_instance_details/4,
+         describe_application_instance_details/5,
+         describe_device/2,
+         describe_device/4,
+         describe_device/5,
+         describe_device_job/2,
+         describe_device_job/4,
+         describe_device_job/5,
+         describe_node/2,
+         describe_node/4,
+         describe_node/5,
+         describe_node_from_template_job/2,
+         describe_node_from_template_job/4,
+         describe_node_from_template_job/5,
+         describe_package/2,
+         describe_package/4,
+         describe_package/5,
+         describe_package_import_job/2,
+         describe_package_import_job/4,
+         describe_package_import_job/5,
+         describe_package_version/3,
+         describe_package_version/5,
+         describe_package_version/6,
+         list_application_instance_dependencies/2,
+         list_application_instance_dependencies/4,
+         list_application_instance_dependencies/5,
+         list_application_instance_node_instances/2,
+         list_application_instance_node_instances/4,
+         list_application_instance_node_instances/5,
+         list_application_instances/1,
+         list_application_instances/3,
+         list_application_instances/4,
+         list_devices/1,
+         list_devices/3,
+         list_devices/4,
+         list_devices_jobs/1,
+         list_devices_jobs/3,
+         list_devices_jobs/4,
+         list_node_from_template_jobs/1,
+         list_node_from_template_jobs/3,
+         list_node_from_template_jobs/4,
+         list_nodes/1,
+         list_nodes/3,
+         list_nodes/4,
+         list_package_import_jobs/1,
+         list_package_import_jobs/3,
+         list_package_import_jobs/4,
+         list_packages/1,
+         list_packages/3,
+         list_packages/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         provision_device/2,
+         provision_device/3,
+         register_package_version/5,
+         register_package_version/6,
+         remove_application_instance/3,
+         remove_application_instance/4,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_device_metadata/3,
+         update_device_metadata/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates an application instance and deploys it to a device.
+create_application_instance(Client, Input) ->
+    create_application_instance(Client, Input, []).
+create_application_instance(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/application-instances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a job to run on one or more devices.
+create_job_for_devices(Client, Input) ->
+    create_job_for_devices(Client, Input, []).
+create_job_for_devices(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a camera stream node.
+create_node_from_template_job(Client, Input) ->
+    create_node_from_template_job(Client, Input, []).
+create_node_from_template_job(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/packages/template-job"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a package and storage location in an Amazon S3 access point.
+create_package(Client, Input) ->
+    create_package(Client, Input, []).
+create_package(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/packages"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Imports a node package.
+create_package_import_job(Client, Input) ->
+    create_package_import_job(Client, Input, []).
+create_package_import_job(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/packages/import-jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a device.
+delete_device(Client, DeviceId, Input) ->
+    delete_device(Client, DeviceId, Input, []).
+delete_device(Client, DeviceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/devices/", aws_util:encode_uri(DeviceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a package.
+delete_package(Client, PackageId, Input) ->
+    delete_package(Client, PackageId, Input, []).
+delete_package(Client, PackageId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/packages/", aws_util:encode_uri(PackageId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"ForceDelete">>, <<"ForceDelete">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deregisters a package version.
+deregister_package_version(Client, PackageId, PackageVersion, PatchVersion, Input) ->
+    deregister_package_version(Client, PackageId, PackageVersion, PatchVersion, Input, []).
+deregister_package_version(Client, PackageId, PackageVersion, PatchVersion, Input0, Options0) ->
+    Method = delete,
+    Path = ["/packages/", aws_util:encode_uri(PackageId), "/versions/", aws_util:encode_uri(PackageVersion), "/patch/", aws_util:encode_uri(PatchVersion), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"OwnerAccount">>, <<"OwnerAccount">>},
+                     {<<"UpdatedLatestPatchVersion">>, <<"UpdatedLatestPatchVersion">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns information about an application instance on a device.
+describe_application_instance(Client, ApplicationInstanceId)
+  when is_map(Client) ->
+    describe_application_instance(Client, ApplicationInstanceId, #{}, #{}).
+
+describe_application_instance(Client, ApplicationInstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_application_instance(Client, ApplicationInstanceId, QueryMap, HeadersMap, []).
+
+describe_application_instance(Client, ApplicationInstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/application-instances/", aws_util:encode_uri(ApplicationInstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about an application instance's configuration
+%% manifest.
+describe_application_instance_details(Client, ApplicationInstanceId)
+  when is_map(Client) ->
+    describe_application_instance_details(Client, ApplicationInstanceId, #{}, #{}).
+
+describe_application_instance_details(Client, ApplicationInstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_application_instance_details(Client, ApplicationInstanceId, QueryMap, HeadersMap, []).
+
+describe_application_instance_details(Client, ApplicationInstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/application-instances/", aws_util:encode_uri(ApplicationInstanceId), "/details"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a device.
+describe_device(Client, DeviceId)
+  when is_map(Client) ->
+    describe_device(Client, DeviceId, #{}, #{}).
+
+describe_device(Client, DeviceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_device(Client, DeviceId, QueryMap, HeadersMap, []).
+
+describe_device(Client, DeviceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/devices/", aws_util:encode_uri(DeviceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a device job.
+describe_device_job(Client, JobId)
+  when is_map(Client) ->
+    describe_device_job(Client, JobId, #{}, #{}).
+
+describe_device_job(Client, JobId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_device_job(Client, JobId, QueryMap, HeadersMap, []).
+
+describe_device_job(Client, JobId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/jobs/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a node.
+describe_node(Client, NodeId)
+  when is_map(Client) ->
+    describe_node(Client, NodeId, #{}, #{}).
+
+describe_node(Client, NodeId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_node(Client, NodeId, QueryMap, HeadersMap, []).
+
+describe_node(Client, NodeId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/nodes/", aws_util:encode_uri(NodeId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"OwnerAccount">>, maps:get(<<"OwnerAccount">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a job to create a camera stream node.
+describe_node_from_template_job(Client, JobId)
+  when is_map(Client) ->
+    describe_node_from_template_job(Client, JobId, #{}, #{}).
+
+describe_node_from_template_job(Client, JobId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_node_from_template_job(Client, JobId, QueryMap, HeadersMap, []).
+
+describe_node_from_template_job(Client, JobId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/template-job/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a package.
+describe_package(Client, PackageId)
+  when is_map(Client) ->
+    describe_package(Client, PackageId, #{}, #{}).
+
+describe_package(Client, PackageId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_package(Client, PackageId, QueryMap, HeadersMap, []).
+
+describe_package(Client, PackageId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/metadata/", aws_util:encode_uri(PackageId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a package import job.
+describe_package_import_job(Client, JobId)
+  when is_map(Client) ->
+    describe_package_import_job(Client, JobId, #{}, #{}).
+
+describe_package_import_job(Client, JobId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_package_import_job(Client, JobId, QueryMap, HeadersMap, []).
+
+describe_package_import_job(Client, JobId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/import-jobs/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a package version.
+describe_package_version(Client, PackageId, PackageVersion)
+  when is_map(Client) ->
+    describe_package_version(Client, PackageId, PackageVersion, #{}, #{}).
+
+describe_package_version(Client, PackageId, PackageVersion, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_package_version(Client, PackageId, PackageVersion, QueryMap, HeadersMap, []).
+
+describe_package_version(Client, PackageId, PackageVersion, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/metadata/", aws_util:encode_uri(PackageId), "/versions/", aws_util:encode_uri(PackageVersion), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"OwnerAccount">>, maps:get(<<"OwnerAccount">>, QueryMap, undefined)},
+        {<<"PatchVersion">>, maps:get(<<"PatchVersion">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of application instance dependencies.
+list_application_instance_dependencies(Client, ApplicationInstanceId)
+  when is_map(Client) ->
+    list_application_instance_dependencies(Client, ApplicationInstanceId, #{}, #{}).
+
+list_application_instance_dependencies(Client, ApplicationInstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_application_instance_dependencies(Client, ApplicationInstanceId, QueryMap, HeadersMap, []).
+
+list_application_instance_dependencies(Client, ApplicationInstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/application-instances/", aws_util:encode_uri(ApplicationInstanceId), "/package-dependencies"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of application node instances.
+list_application_instance_node_instances(Client, ApplicationInstanceId)
+  when is_map(Client) ->
+    list_application_instance_node_instances(Client, ApplicationInstanceId, #{}, #{}).
+
+list_application_instance_node_instances(Client, ApplicationInstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_application_instance_node_instances(Client, ApplicationInstanceId, QueryMap, HeadersMap, []).
+
+list_application_instance_node_instances(Client, ApplicationInstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/application-instances/", aws_util:encode_uri(ApplicationInstanceId), "/node-instances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of application instances.
+list_application_instances(Client)
+  when is_map(Client) ->
+    list_application_instances(Client, #{}, #{}).
+
+list_application_instances(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_application_instances(Client, QueryMap, HeadersMap, []).
+
+list_application_instances(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/application-instances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"deviceId">>, maps:get(<<"deviceId">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"statusFilter">>, maps:get(<<"statusFilter">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of devices.
+list_devices(Client)
+  when is_map(Client) ->
+    list_devices(Client, #{}, #{}).
+
+list_devices(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_devices(Client, QueryMap, HeadersMap, []).
+
+list_devices(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/devices"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of jobs.
+list_devices_jobs(Client)
+  when is_map(Client) ->
+    list_devices_jobs(Client, #{}, #{}).
+
+list_devices_jobs(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_devices_jobs(Client, QueryMap, HeadersMap, []).
+
+list_devices_jobs(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"DeviceId">>, maps:get(<<"DeviceId">>, QueryMap, undefined)},
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of camera stream node jobs.
+list_node_from_template_jobs(Client)
+  when is_map(Client) ->
+    list_node_from_template_jobs(Client, #{}, #{}).
+
+list_node_from_template_jobs(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_node_from_template_jobs(Client, QueryMap, HeadersMap, []).
+
+list_node_from_template_jobs(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/template-job"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of nodes.
+list_nodes(Client)
+  when is_map(Client) ->
+    list_nodes(Client, #{}, #{}).
+
+list_nodes(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_nodes(Client, QueryMap, HeadersMap, []).
+
+list_nodes(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/nodes"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"category">>, maps:get(<<"category">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"ownerAccount">>, maps:get(<<"ownerAccount">>, QueryMap, undefined)},
+        {<<"packageName">>, maps:get(<<"packageName">>, QueryMap, undefined)},
+        {<<"packageVersion">>, maps:get(<<"packageVersion">>, QueryMap, undefined)},
+        {<<"patchVersion">>, maps:get(<<"patchVersion">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of package import jobs.
+list_package_import_jobs(Client)
+  when is_map(Client) ->
+    list_package_import_jobs(Client, #{}, #{}).
+
+list_package_import_jobs(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_package_import_jobs(Client, QueryMap, HeadersMap, []).
+
+list_package_import_jobs(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages/import-jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of packages.
+list_packages(Client)
+  when is_map(Client) ->
+    list_packages(Client, #{}, #{}).
+
+list_packages(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_packages(Client, QueryMap, HeadersMap, []).
+
+list_packages(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/packages"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of tags for a resource.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Creates a device and returns a configuration archive.
+%%
+%% The configuration archive is a ZIP file that contains a provisioning
+%% certificate that is valid for 5 minutes. Transfer the configuration
+%% archive to the device with the included USB storage device within 5
+%% minutes.
+provision_device(Client, Input) ->
+    provision_device(Client, Input, []).
+provision_device(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/devices"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Registers a package version.
+register_package_version(Client, PackageId, PackageVersion, PatchVersion, Input) ->
+    register_package_version(Client, PackageId, PackageVersion, PatchVersion, Input, []).
+register_package_version(Client, PackageId, PackageVersion, PatchVersion, Input0, Options0) ->
+    Method = put,
+    Path = ["/packages/", aws_util:encode_uri(PackageId), "/versions/", aws_util:encode_uri(PackageVersion), "/patch/", aws_util:encode_uri(PatchVersion), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes an application instance.
+remove_application_instance(Client, ApplicationInstanceId, Input) ->
+    remove_application_instance(Client, ApplicationInstanceId, Input, []).
+remove_application_instance(Client, ApplicationInstanceId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/application-instances/", aws_util:encode_uri(ApplicationInstanceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Tags a resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes tags from a resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"TagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a device's metadata.
+update_device_metadata(Client, DeviceId, Input) ->
+    update_device_metadata(Client, DeviceId, Input, []).
+update_device_metadata(Client, DeviceId, Input0, Options0) ->
+    Method = put,
+    Path = ["/devices/", aws_util:encode_uri(DeviceId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"panorama">>},
+    Host = build_host(<<"panorama">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_personalize.erl
+++ b/src/aws_personalize.erl
@@ -11,6 +11,8 @@
          create_campaign/3,
          create_dataset/2,
          create_dataset/3,
+         create_dataset_export_job/2,
+         create_dataset_export_job/3,
          create_dataset_group/2,
          create_dataset_group/3,
          create_dataset_import_job/2,
@@ -47,6 +49,8 @@
          describe_campaign/3,
          describe_dataset/2,
          describe_dataset/3,
+         describe_dataset_export_job/2,
+         describe_dataset_export_job/3,
          describe_dataset_group/2,
          describe_dataset_group/3,
          describe_dataset_import_job/2,
@@ -71,6 +75,8 @@
          list_batch_inference_jobs/3,
          list_campaigns/2,
          list_campaigns/3,
+         list_dataset_export_jobs/2,
+         list_dataset_export_jobs/3,
          list_dataset_groups/2,
          list_dataset_groups/3,
          list_dataset_import_jobs/2,
@@ -89,6 +95,8 @@
          list_solution_versions/3,
          list_solutions/2,
          list_solutions/3,
+         stop_solution_version_creation/2,
+         stop_solution_version_creation/3,
          update_campaign/2,
          update_campaign/3]).
 
@@ -206,6 +214,32 @@ create_dataset(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateDataset">>, Input, Options).
 
+%% @doc Creates a job that exports data from your dataset to an Amazon S3
+%% bucket.
+%%
+%% To allow Amazon Personalize to export the training data, you must specify
+%% an service-linked IAM role that gives Amazon Personalize `PutObject'
+%% permissions for your Amazon S3 bucket. For information, see Exporting a
+%% dataset in the Amazon Personalize developer guide.
+%%
+%% Status
+%%
+%% A dataset export job can be in one of the following states:
+%%
+%% <ul> <li> CREATE PENDING > CREATE IN_PROGRESS > ACTIVE -or- CREATE FAILED
+%%
+%% </li> </ul> To get the status of the export job, call
+%% `DescribeDatasetExportJob', and specify the Amazon Resource Name (ARN) of
+%% the dataset export job. The dataset export is complete when the status
+%% shows as ACTIVE. If the status shows as CREATE FAILED, the response
+%% includes a `failureReason' key, which describes why the job failed.
+create_dataset_export_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_dataset_export_job(Client, Input, []).
+create_dataset_export_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDatasetExportJob">>, Input, Options).
+
 %% @doc Creates an empty dataset group.
 %%
 %% A dataset group contains related datasets that supply data for training a
@@ -235,10 +269,10 @@ create_dataset(Client, Input, Options)
 %% You must wait until the `status' of the dataset group is `ACTIVE' before
 %% adding a dataset to the group.
 %%
-%% You can specify an AWS Key Management Service (KMS) key to encrypt the
+%% You can specify an Key Management Service (KMS) key to encrypt the
 %% datasets in the group. If you specify a KMS key, you must also include an
-%% AWS Identity and Access Management (IAM) role that has permission to
-%% access the key.
+%% Identity and Access Management (IAM) role that has permission to access
+%% the key.
 %%
 %% == APIs that require a dataset group ARN in the request ==
 %%
@@ -268,9 +302,10 @@ create_dataset_group(Client, Input, Options)
 %% Amazon S3 bucket) to an Amazon Personalize dataset.
 %%
 %% To allow Amazon Personalize to import the training data, you must specify
-%% an AWS Identity and Access Management (IAM) role that has permission to
-%% read from the data source, as Amazon Personalize makes a copy of your data
-%% and processes it in an internal AWS system.
+%% an IAM service role that has permission to read from the data source, as
+%% Amazon Personalize makes a copy of your data and processes it internally.
+%% For information on granting access to your Amazon S3 bucket, see Giving
+%% Amazon Personalize Access to Amazon S3 Resources.
 %%
 %% The dataset import job replaces any existing data in the dataset that you
 %% imported in bulk.
@@ -446,7 +481,17 @@ create_solution(Client, Input, Options)
 %%
 %% A solution version can be in one of the following states:
 %%
-%% <ul> <li> CREATE PENDING > CREATE IN_PROGRESS > ACTIVE -or- CREATE FAILED
+%% <ul> <li> CREATE PENDING
+%%
+%% </li> <li> CREATE IN_PROGRESS
+%%
+%% </li> <li> ACTIVE
+%%
+%% </li> <li> CREATE FAILED
+%%
+%% </li> <li> CREATE STOPPING
+%%
+%% </li> <li> CREATE STOPPED
 %%
 %% </li> </ul> To get the status of the version, call
 %% `DescribeSolutionVersion'. Wait until the status shows as ACTIVE before
@@ -612,6 +657,15 @@ describe_dataset(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDataset">>, Input, Options).
 
+%% @doc Describes the dataset export job created by `CreateDatasetExportJob',
+%% including the export job status.
+describe_dataset_export_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_dataset_export_job(Client, Input, []).
+describe_dataset_export_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDatasetExportJob">>, Input, Options).
+
 %% @doc Describes the given dataset group.
 %%
 %% For more information on dataset groups, see `CreateDatasetGroup'.
@@ -741,6 +795,20 @@ list_campaigns(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListCampaigns">>, Input, Options).
 
+%% @doc Returns a list of dataset export jobs that use the given dataset.
+%%
+%% When a dataset is not specified, all the dataset export jobs associated
+%% with the account are listed. The response provides the properties for each
+%% dataset export job, including the Amazon Resource Name (ARN). For more
+%% information on dataset export jobs, see `CreateDatasetExportJob'. For more
+%% information on datasets, see `CreateDataset'.
+list_dataset_export_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_dataset_export_jobs(Client, Input, []).
+list_dataset_export_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDatasetExportJobs">>, Input, Options).
+
 %% @doc Returns a list of dataset groups.
 %%
 %% The response provides the properties for each dataset group, including the
@@ -846,6 +914,28 @@ list_solutions(Client, Input)
 list_solutions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListSolutions">>, Input, Options).
+
+%% @doc Stops creating a solution version that is in a state of
+%% CREATE_PENDING or CREATE IN_PROGRESS.
+%%
+%% Depending on the current state of the solution version, the solution
+%% version state changes as follows:
+%%
+%% <ul> <li> CREATE_PENDING > CREATE_STOPPED
+%%
+%% or
+%%
+%% </li> <li> CREATE_IN_PROGRESS > CREATE_STOPPING > CREATE_STOPPED
+%%
+%% </li> </ul> You are billed for all of the training completed up until you
+%% stop the solution version creation. You cannot resume creating a solution
+%% version once it has been stopped.
+stop_solution_version_creation(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    stop_solution_version_creation(Client, Input, []).
+stop_solution_version_creation(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StopSolutionVersionCreation">>, Input, Options).
 
 %% @doc Updates a campaign by either deploying a new solution or changing the
 %% value of the campaign's `minProvisionedTPS' parameter.

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -131,6 +131,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -112,6 +112,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_pi.erl
+++ b/src/aws_pi.erl
@@ -34,6 +34,8 @@
 
 -export([describe_dimension_keys/2,
          describe_dimension_keys/3,
+         get_dimension_key_details/2,
+         get_dimension_key_details/3,
          get_resource_metrics/2,
          get_resource_metrics/3]).
 
@@ -54,6 +56,21 @@ describe_dimension_keys(Client, Input)
 describe_dimension_keys(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDimensionKeys">>, Input, Options).
+
+%% @doc Get the attributes of the specified dimension group for a DB instance
+%% or data source.
+%%
+%% For example, if you specify a SQL ID, `GetDimensionKeyDetails' retrieves
+%% the full text of the dimension `db.sql.statement' associated with this ID.
+%% This operation is useful because `GetResourceMetrics' and
+%% `DescribeDimensionKeys' don't support retrieval of large SQL statement
+%% text.
+get_dimension_key_details(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_dimension_key_details(Client, Input, []).
+get_dimension_key_details(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetDimensionKeyDetails">>, Input, Options).
 
 %% @doc Retrieve Performance Insights metrics for a set of data sources, over
 %% a time period.

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -14,6 +14,8 @@
          create_export_job/4,
          create_import_job/3,
          create_import_job/4,
+         create_in_app_template/3,
+         create_in_app_template/4,
          create_journey/3,
          create_journey/4,
          create_push_template/3,
@@ -52,6 +54,8 @@
          delete_event_stream/4,
          delete_gcm_channel/3,
          delete_gcm_channel/4,
+         delete_in_app_template/3,
+         delete_in_app_template/4,
          delete_journey/4,
          delete_journey/5,
          delete_push_template/3,
@@ -148,6 +152,12 @@
          get_import_jobs/2,
          get_import_jobs/4,
          get_import_jobs/5,
+         get_in_app_messages/3,
+         get_in_app_messages/5,
+         get_in_app_messages/6,
+         get_in_app_template/2,
+         get_in_app_template/4,
+         get_in_app_template/5,
          get_journey/3,
          get_journey/5,
          get_journey/6,
@@ -256,6 +266,8 @@
          update_endpoints_batch/4,
          update_gcm_channel/3,
          update_gcm_channel/4,
+         update_in_app_template/3,
+         update_in_app_template/4,
          update_journey/4,
          update_journey/5,
          update_journey_state/4,
@@ -383,6 +395,30 @@ create_import_job(Client, ApplicationId, Input) ->
 create_import_job(Client, ApplicationId, Input0, Options0) ->
     Method = post,
     Path = ["/v1/apps/", aws_util:encode_uri(ApplicationId), "/jobs/import"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new message template for messages using the in-app message
+%% channel.
+create_in_app_template(Client, TemplateName, Input) ->
+    create_in_app_template(Client, TemplateName, Input, []).
+create_in_app_template(Client, TemplateName, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/templates/", aws_util:encode_uri(TemplateName), "/inapp"],
     SuccessStatusCode = 201,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -850,6 +886,31 @@ delete_gcm_channel(Client, ApplicationId, Input0, Options0) ->
     Query_ = [],
     Input = Input2,
 
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a message template for messages sent using the in-app message
+%% channel.
+delete_in_app_template(Client, TemplateName, Input) ->
+    delete_in_app_template(Client, TemplateName, Input, []).
+delete_in_app_template(Client, TemplateName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v1/templates/", aws_util:encode_uri(TemplateName), "/inapp"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"version">>, <<"Version">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a journey from an application.
@@ -1732,6 +1793,57 @@ get_import_jobs(Client, ApplicationId, QueryMap, HeadersMap, Options0)
       [
         {<<"page-size">>, maps:get(<<"page-size">>, QueryMap, undefined)},
         {<<"token">>, maps:get(<<"token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the in-app messages targeted for the provided endpoint ID.
+get_in_app_messages(Client, ApplicationId, EndpointId)
+  when is_map(Client) ->
+    get_in_app_messages(Client, ApplicationId, EndpointId, #{}, #{}).
+
+get_in_app_messages(Client, ApplicationId, EndpointId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_in_app_messages(Client, ApplicationId, EndpointId, QueryMap, HeadersMap, []).
+
+get_in_app_messages(Client, ApplicationId, EndpointId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/apps/", aws_util:encode_uri(ApplicationId), "/endpoints/", aws_util:encode_uri(EndpointId), "/inappmessages"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the content and settings of a message template for messages
+%% sent through the in-app channel.
+get_in_app_template(Client, TemplateName)
+  when is_map(Client) ->
+    get_in_app_template(Client, TemplateName, #{}, #{}).
+
+get_in_app_template(Client, TemplateName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_in_app_template(Client, TemplateName, QueryMap, HeadersMap, []).
+
+get_in_app_template(Client, TemplateName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v1/templates/", aws_util:encode_uri(TemplateName), "/inapp"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"version">>, maps:get(<<"version">>, QueryMap, undefined)}
       ],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
@@ -2852,6 +2964,32 @@ update_gcm_channel(Client, ApplicationId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates an existing message template for messages sent through the
+%% in-app message channel.
+update_in_app_template(Client, TemplateName, Input) ->
+    update_in_app_template(Client, TemplateName, Input, []).
+update_in_app_template(Client, TemplateName, Input0, Options0) ->
+    Method = put,
+    Path = ["/v1/templates/", aws_util:encode_uri(TemplateName), "/inapp"],
+    SuccessStatusCode = 202,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"create-new-version">>, <<"CreateNewVersion">>},
+                     {<<"version">>, <<"Version">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Updates the configuration and other settings for a journey.
 update_journey(Client, ApplicationId, JourneyId, Input) ->
     update_journey(Client, ApplicationId, JourneyId, Input, []).
@@ -2875,7 +3013,7 @@ update_journey(Client, ApplicationId, JourneyId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Cancels (stops) an active journey.
+%% @doc Pause, resume or cancels (stops) a journey.
 update_journey_state(Client, ApplicationId, JourneyId, Input) ->
     update_journey_state(Client, ApplicationId, JourneyId, Input, []).
 update_journey_state(Client, ApplicationId, JourneyId, Input0, Options0) ->
@@ -3131,6 +3269,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -1399,6 +1399,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -263,6 +263,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -40,7 +40,8 @@
 %% API
 %%====================================================================
 
-%% @doc Deletes the specified pronunciation lexicon stored in an AWS Region.
+%% @doc Deletes the specified pronunciation lexicon stored in an Amazon Web
+%% Services Region.
 %%
 %% A lexicon which has been deleted is not available for speech synthesis,
 %% nor is it possible to retrieve it using either the `GetLexicon' or
@@ -120,7 +121,7 @@ describe_voices(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns the content of the specified pronunciation lexicon stored in
-%% an AWS Region.
+%% an Amazon Web Services Region.
 %%
 %% For more information, see Managing Lexicons.
 get_lexicon(Client, Name)
@@ -172,7 +173,8 @@ get_speech_synthesis_task(Client, TaskId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns a list of pronunciation lexicons stored in an AWS Region.
+%% @doc Returns a list of pronunciation lexicons stored in an Amazon Web
+%% Services Region.
 %%
 %% For more information, see Managing Lexicons.
 list_lexicons(Client)
@@ -234,7 +236,7 @@ list_speech_synthesis_tasks(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Stores a pronunciation lexicon in an AWS Region.
+%% @doc Stores a pronunciation lexicon in an Amazon Web Services Region.
 %%
 %% If a lexicon with the same name already exists in the region, it is
 %% overwritten by the new lexicon. Lexicon operations have eventual
@@ -270,9 +272,11 @@ put_lexicon(Client, Name, Input0, Options0) ->
 %% This operation requires all the standard information needed for speech
 %% synthesis, plus the name of an Amazon S3 bucket for the service to store
 %% the output of the synthesis task and two optional parameters
-%% (OutputS3KeyPrefix and SnsTopicArn). Once the synthesis task is created,
-%% this operation will return a SpeechSynthesisTask object, which will
-%% include an identifier of this task as well as the current status.
+%% (`OutputS3KeyPrefix' and `SnsTopicArn'). Once the synthesis task is
+%% created, this operation will return a `SpeechSynthesisTask' object, which
+%% will include an identifier of this task as well as the current status. The
+%% `SpeechSynthesisTask' object is available for 72 hours after starting the
+%% asynchronous synthesis task.
 start_speech_synthesis_task(Client, Input) ->
     start_speech_synthesis_task(Client, Input, []).
 start_speech_synthesis_task(Client, Input0, Options0) ->
@@ -375,6 +379,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_pricing.erl
+++ b/src/aws_pricing.erl
@@ -1,0 +1,138 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Web Services Price List Service API (Amazon Web Services Price
+%% List Service) is a centralized and convenient way to programmatically
+%% query Amazon Web Services for services, products, and pricing information.
+%%
+%% The Amazon Web Services Price List Service uses standardized product
+%% attributes such as `Location', `Storage Class', and `Operating System',
+%% and provides prices at the SKU level. You can use the Amazon Web Services
+%% Price List Service to build cost control and scenario planning tools,
+%% reconcile billing data, forecast future spend for budgeting purposes, and
+%% provide cost benefit analysis that compare your internal workloads with
+%% Amazon Web Services.
+%%
+%% Use `GetServices' without a service code to retrieve the service codes for
+%% all AWS services, then `GetServices' with a service code to retreive the
+%% attribute names for that service. After you have the service code and
+%% attribute names, you can use `GetAttributeValues' to see what values are
+%% available for an attribute. With the service code and an attribute name
+%% and value, you can use `GetProducts' to find specific products that you're
+%% interested in, such as an `AmazonEC2' instance, with a `Provisioned IOPS'
+%% `volumeType'.
+%%
+%% Service Endpoint
+%%
+%% Amazon Web Services Price List Service API provides the following two
+%% endpoints:
+%%
+%% <ul> <li> https://api.pricing.us-east-1.amazonaws.com
+%%
+%% </li> <li> https://api.pricing.ap-south-1.amazonaws.com
+%%
+%% </li> </ul>
+-module(aws_pricing).
+
+-export([describe_services/2,
+         describe_services/3,
+         get_attribute_values/2,
+         get_attribute_values/3,
+         get_products/2,
+         get_products/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Returns the metadata for one service or a list of the metadata for
+%% all services.
+%%
+%% Use this without a service code to get the service codes for all services.
+%% Use it with a service code, such as `AmazonEC2', to get information
+%% specific to that service, such as the attribute names available for that
+%% service. For example, some of the attribute names available for EC2 are
+%% `volumeType', `maxIopsVolume', `operation', `locationType', and
+%% `instanceCapacity10xlarge'.
+describe_services(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_services(Client, Input, []).
+describe_services(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeServices">>, Input, Options).
+
+%% @doc Returns a list of attribute values.
+%%
+%% Attibutes are similar to the details in a Price List API offer file. For a
+%% list of available attributes, see Offer File Definitions in the Amazon Web
+%% Services Billing and Cost Management User Guide.
+get_attribute_values(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_attribute_values(Client, Input, []).
+get_attribute_values(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetAttributeValues">>, Input, Options).
+
+%% @doc Returns a list of all products that match the filter criteria.
+get_products(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_products(Client, Input, []).
+get_products(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetProducts">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"pricing">>},
+    Host = build_host(<<"api.pricing">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
+        {<<"X-Amz-Target">>, <<"AWSPriceListService.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_proton.erl
+++ b/src/aws_proton.erl
@@ -1,0 +1,1012 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc This is the AWS Proton Service API Reference.
+%%
+%% It provides descriptions, syntax and usage examples for each of the
+%% actions and data types for the AWS Proton service.
+%%
+%% The documentation for each action shows the Query API request parameters
+%% and the XML response.
+%%
+%% Alternatively, you can use the AWS CLI to access an API. For more
+%% information, see the AWS Command Line Interface User Guide.
+%%
+%% The AWS Proton service is a two-pronged automation framework.
+%% Administrators create service templates to provide standardized
+%% infrastructure and deployment tooling for serverless and container based
+%% applications. Developers, in turn, select from the available service
+%% templates to automate their application or service deployments.
+%%
+%% Because administrators define the infrastructure and tooling that AWS
+%% Proton deploys and manages, they need permissions to use all of the listed
+%% API operations.
+%%
+%% When developers select a specific infrastructure and tooling set, AWS
+%% Proton deploys their applications. To monitor their applications that are
+%% running on AWS Proton, developers need permissions to the service create,
+%% list, update and delete API operations and the service instance list and
+%% update API operations.
+%%
+%% To learn more about AWS Proton administration, see the AWS Proton
+%% Administrator Guide.
+%%
+%% To learn more about deploying serverless and containerized applications on
+%% AWS Proton, see the AWS Proton User Guide.
+%%
+%% Ensuring Idempotency
+%%
+%% When you make a mutating API request, the request typically returns a
+%% result before the asynchronous workflows of the operation are complete.
+%% Operations might also time out or encounter other server issues before
+%% they're complete, even if the request already returned a result. This
+%% might make it difficult to determine whether the request succeeded.
+%% Moreover, you might need to retry the request multiple times to ensure
+%% that the operation completes successfully. However, if the original
+%% request and the subsequent retries are successful, the operation occurs
+%% multiple times. This means that you might create more resources than you
+%% intended.
+%%
+%% Idempotency ensures that an API request action completes no more than one
+%% time. With an idempotent request, if the original request action completes
+%% successfully, any subsequent retries complete successfully without
+%% performing any further actions. However, the result might contain updated
+%% information, such as the current creation status.
+%%
+%% The following lists of APIs are grouped according to methods that ensure
+%% idempotency.
+%%
+%% Idempotent create APIs with a client token
+%%
+%% The API actions in this list support idempotency with the use of a client
+%% token. The corresponding AWS CLI commands also support idempotency using a
+%% client token. A client token is a unique, case-sensitive string of up to
+%% 64 ASCII characters. To make an idempotent API request using one of these
+%% actions, specify a client token in the request. We recommend that you
+%% don't reuse the same client token for other API requests. If you don’t
+%% provide a client token for these APIs, a default client token is
+%% automatically provided by SDKs.
+%%
+%% Given a request action that has succeeded:
+%%
+%% If you retry the request using the same client token and the same
+%% parameters, the retry succeeds without performing any further actions
+%% other than returning the original resource detail data in the response.
+%%
+%% If you retry the request using the same client token, but one or more of
+%% the parameters are different, the retry throws a `ValidationException'
+%% with an `IdempotentParameterMismatch' error.
+%%
+%% Client tokens expire eight hours after a request is made. If you retry the
+%% request with the expired token, a new resource is created.
+%%
+%% If the original resource is deleted and you retry the request, a new
+%% resource is created.
+%%
+%% Idempotent create APIs with a client token:
+%%
+%% <ul> <li> CreateEnvironmentTemplateVersion
+%%
+%% </li> <li> CreateServiceTemplateVersion
+%%
+%% </li> <li> CreateEnvironmentAccountConnection
+%%
+%% </li> </ul> Idempotent create APIs
+%%
+%% Given a request action that has succeeded:
+%%
+%% If you retry the request with an API from this group, and the original
+%% resource hasn't been modified, the retry succeeds without performing any
+%% further actions other than returning the original resource detail data in
+%% the response.
+%%
+%% If the original resource has been modified, the retry throws a
+%% `ConflictException'.
+%%
+%% If you retry with different input parameters, the retry throws a
+%% `ValidationException' with an `IdempotentParameterMismatch' error.
+%%
+%% Idempotent create APIs:
+%%
+%% <ul> <li> CreateEnvironmentTemplate
+%%
+%% </li> <li> CreateServiceTemplate
+%%
+%% </li> <li> CreateEnvironment
+%%
+%% </li> <li> CreateService
+%%
+%% </li> </ul> Idempotent delete APIs
+%%
+%% Given a request action that has succeeded:
+%%
+%% When you retry the request with an API from this group and the resource
+%% was deleted, its metadata is returned in the response.
+%%
+%% If you retry and the resource doesn't exist, the response is empty.
+%%
+%% In both cases, the retry succeeds.
+%%
+%% Idempotent delete APIs:
+%%
+%% <ul> <li> DeleteEnvironmentTemplate
+%%
+%% </li> <li> DeleteEnvironmentTemplateVersion
+%%
+%% </li> <li> DeleteServiceTemplate
+%%
+%% </li> <li> DeleteServiceTemplateVersion
+%%
+%% </li> <li> DeleteEnvironmentAccountConnection
+%%
+%% </li> </ul> Asynchronous idempotent delete APIs
+%%
+%% Given a request action that has succeeded:
+%%
+%% If you retry the request with an API from this group, if the original
+%% request delete operation status is `DELETE_IN_PROGRESS', the retry returns
+%% the resource detail data in the response without performing any further
+%% actions.
+%%
+%% If the original request delete operation is complete, a retry returns an
+%% empty response.
+%%
+%% Asynchronous idempotent delete APIs:
+%%
+%% <ul> <li> DeleteEnvironment
+%%
+%% </li> <li> DeleteService
+%%
+%% </li> </ul>
+-module(aws_proton).
+
+-export([accept_environment_account_connection/2,
+         accept_environment_account_connection/3,
+         cancel_environment_deployment/2,
+         cancel_environment_deployment/3,
+         cancel_service_instance_deployment/2,
+         cancel_service_instance_deployment/3,
+         cancel_service_pipeline_deployment/2,
+         cancel_service_pipeline_deployment/3,
+         create_environment/2,
+         create_environment/3,
+         create_environment_account_connection/2,
+         create_environment_account_connection/3,
+         create_environment_template/2,
+         create_environment_template/3,
+         create_environment_template_version/2,
+         create_environment_template_version/3,
+         create_service/2,
+         create_service/3,
+         create_service_template/2,
+         create_service_template/3,
+         create_service_template_version/2,
+         create_service_template_version/3,
+         delete_environment/2,
+         delete_environment/3,
+         delete_environment_account_connection/2,
+         delete_environment_account_connection/3,
+         delete_environment_template/2,
+         delete_environment_template/3,
+         delete_environment_template_version/2,
+         delete_environment_template_version/3,
+         delete_service/2,
+         delete_service/3,
+         delete_service_template/2,
+         delete_service_template/3,
+         delete_service_template_version/2,
+         delete_service_template_version/3,
+         get_account_settings/2,
+         get_account_settings/3,
+         get_environment/2,
+         get_environment/3,
+         get_environment_account_connection/2,
+         get_environment_account_connection/3,
+         get_environment_template/2,
+         get_environment_template/3,
+         get_environment_template_version/2,
+         get_environment_template_version/3,
+         get_service/2,
+         get_service/3,
+         get_service_instance/2,
+         get_service_instance/3,
+         get_service_template/2,
+         get_service_template/3,
+         get_service_template_version/2,
+         get_service_template_version/3,
+         list_environment_account_connections/2,
+         list_environment_account_connections/3,
+         list_environment_template_versions/2,
+         list_environment_template_versions/3,
+         list_environment_templates/2,
+         list_environment_templates/3,
+         list_environments/2,
+         list_environments/3,
+         list_service_instances/2,
+         list_service_instances/3,
+         list_service_template_versions/2,
+         list_service_template_versions/3,
+         list_service_templates/2,
+         list_service_templates/3,
+         list_services/2,
+         list_services/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         reject_environment_account_connection/2,
+         reject_environment_account_connection/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_account_settings/2,
+         update_account_settings/3,
+         update_environment/2,
+         update_environment/3,
+         update_environment_account_connection/2,
+         update_environment_account_connection/3,
+         update_environment_template/2,
+         update_environment_template/3,
+         update_environment_template_version/2,
+         update_environment_template_version/3,
+         update_service/2,
+         update_service/3,
+         update_service_instance/2,
+         update_service_instance/3,
+         update_service_pipeline/2,
+         update_service_pipeline/3,
+         update_service_template/2,
+         update_service_template/3,
+         update_service_template_version/2,
+         update_service_template_version/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc In a management account, an environment account connection request is
+%% accepted.
+%%
+%% When the environment account connection request is accepted, AWS Proton
+%% can use the associated IAM role to provision environment infrastructure
+%% resources in the associated environment account.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+accept_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    accept_environment_account_connection(Client, Input, []).
+accept_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AcceptEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc Attempts to cancel an environment deployment on an
+%% `UpdateEnvironment' action, if the deployment is `IN_PROGRESS'.
+%%
+%% For more information, see Update an environment in the AWS Proton
+%% Administrator guide.
+%%
+%% The following list includes potential cancellation scenarios.
+%%
+%% <ul> <li> If the cancellation attempt succeeds, the resulting deployment
+%% state is `CANCELLED'.
+%%
+%% </li> <li> If the cancellation attempt fails, the resulting deployment
+%% state is `FAILED'.
+%%
+%% </li> <li> If the current `UpdateEnvironment' action succeeds before the
+%% cancellation attempt starts, the resulting deployment state is `SUCCEEDED'
+%% and the cancellation attempt has no effect.
+%%
+%% </li> </ul>
+cancel_environment_deployment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_environment_deployment(Client, Input, []).
+cancel_environment_deployment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelEnvironmentDeployment">>, Input, Options).
+
+%% @doc Attempts to cancel a service instance deployment on an
+%% `UpdateServiceInstance' action, if the deployment is `IN_PROGRESS'.
+%%
+%% For more information, see Update a service instance in the AWS Proton
+%% Administrator guide or the AWS Proton User guide.
+%%
+%% The following list includes potential cancellation scenarios.
+%%
+%% <ul> <li> If the cancellation attempt succeeds, the resulting deployment
+%% state is `CANCELLED'.
+%%
+%% </li> <li> If the cancellation attempt fails, the resulting deployment
+%% state is `FAILED'.
+%%
+%% </li> <li> If the current `UpdateServiceInstance' action succeeds before
+%% the cancellation attempt starts, the resulting deployment state is
+%% `SUCCEEDED' and the cancellation attempt has no effect.
+%%
+%% </li> </ul>
+cancel_service_instance_deployment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_service_instance_deployment(Client, Input, []).
+cancel_service_instance_deployment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelServiceInstanceDeployment">>, Input, Options).
+
+%% @doc Attempts to cancel a service pipeline deployment on an
+%% `UpdateServicePipeline' action, if the deployment is `IN_PROGRESS'.
+%%
+%% For more information, see Update a service pipeline in the AWS Proton
+%% Administrator guide or the AWS Proton User guide.
+%%
+%% The following list includes potential cancellation scenarios.
+%%
+%% <ul> <li> If the cancellation attempt succeeds, the resulting deployment
+%% state is `CANCELLED'.
+%%
+%% </li> <li> If the cancellation attempt fails, the resulting deployment
+%% state is `FAILED'.
+%%
+%% </li> <li> If the current `UpdateServicePipeline' action succeeds before
+%% the cancellation attempt starts, the resulting deployment state is
+%% `SUCCEEDED' and the cancellation attempt has no effect.
+%%
+%% </li> </ul>
+cancel_service_pipeline_deployment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    cancel_service_pipeline_deployment(Client, Input, []).
+cancel_service_pipeline_deployment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CancelServicePipelineDeployment">>, Input, Options).
+
+%% @doc Deploy a new environment.
+%%
+%% An AWS Proton environment is created from an environment template that
+%% defines infrastructure and resources that can be shared across services.
+%% For more information, see the Environments in the AWS Proton Administrator
+%% Guide.
+create_environment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_environment(Client, Input, []).
+create_environment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEnvironment">>, Input, Options).
+
+%% @doc Create an environment account connection in an environment account so
+%% that environment infrastructure resources can be provisioned in the
+%% environment account from a management account.
+%%
+%% An environment account connection is a secure bi-directional connection
+%% between a management account and an environment account that maintains
+%% authorization and permissions. For more information, see Environment
+%% account connections in the AWS Proton Administrator guide.
+create_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_environment_account_connection(Client, Input, []).
+create_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc Create an environment template for AWS Proton.
+%%
+%% For more information, see Environment Templates in the AWS Proton
+%% Administrator Guide.
+%%
+%% You can create an environment template in one of the two following ways:
+%%
+%% <ul> <li> Register and publish a standard environment template that
+%% instructs AWS Proton to deploy and manage environment infrastructure.
+%%
+%% </li> <li> Register and publish a customer managed environment template
+%% that connects AWS Proton to your existing provisioned infrastructure that
+%% you manage. AWS Proton doesn't manage your existing provisioned
+%% infrastructure. To create an environment template for customer provisioned
+%% and managed infrastructure, include the `provisioning' parameter and set
+%% the value to `CUSTOMER_MANAGED'. For more information, see Register and
+%% publish an environment template in the AWS Proton Administrator Guide.
+%%
+%% </li> </ul>
+create_environment_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_environment_template(Client, Input, []).
+create_environment_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEnvironmentTemplate">>, Input, Options).
+
+%% @doc Create a new major or minor version of an environment template.
+%%
+%% A major version of an environment template is a version that isn't
+%% backwards compatible. A minor version of an environment template is a
+%% version that's backwards compatible within its major version.
+create_environment_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_environment_template_version(Client, Input, []).
+create_environment_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEnvironmentTemplateVersion">>, Input, Options).
+
+%% @doc Create an AWS Proton service.
+%%
+%% An AWS Proton service is an instantiation of a service template and often
+%% includes several service instances and pipeline. For more information, see
+%% Services in the AWS Proton Administrator Guide and Services in the AWS
+%% Proton User Guide.
+create_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_service(Client, Input, []).
+create_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateService">>, Input, Options).
+
+%% @doc Create a service template.
+%%
+%% The administrator creates a service template to define standardized
+%% infrastructure and an optional CICD service pipeline. Developers, in turn,
+%% select the service template from AWS Proton. If the selected service
+%% template includes a service pipeline definition, they provide a link to
+%% their source code repository. AWS Proton then deploys and manages the
+%% infrastructure defined by the selected service template. For more
+%% information, see Service Templates in the AWS Proton Administrator Guide.
+create_service_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_service_template(Client, Input, []).
+create_service_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateServiceTemplate">>, Input, Options).
+
+%% @doc Create a new major or minor version of a service template.
+%%
+%% A major version of a service template is a version that isn't backwards
+%% compatible. A minor version of a service template is a version that's
+%% backwards compatible within its major version.
+create_service_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_service_template_version(Client, Input, []).
+create_service_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateServiceTemplateVersion">>, Input, Options).
+
+%% @doc Delete an environment.
+delete_environment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_environment(Client, Input, []).
+delete_environment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEnvironment">>, Input, Options).
+
+%% @doc In an environment account, delete an environment account connection.
+%%
+%% After you delete an environment account connection that’s in use by an AWS
+%% Proton environment, AWS Proton can’t manage the environment infrastructure
+%% resources until a new environment account connection is accepted for the
+%% environment account and associated environment. You're responsible for
+%% cleaning up provisioned resources that remain without an environment
+%% connection.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+delete_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_environment_account_connection(Client, Input, []).
+delete_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc If no other major or minor versions of an environment template exist,
+%% delete the environment template.
+delete_environment_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_environment_template(Client, Input, []).
+delete_environment_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEnvironmentTemplate">>, Input, Options).
+
+%% @doc If no other minor versions of an environment template exist, delete a
+%% major version of the environment template if it's not the `Recommended'
+%% version.
+%%
+%% Delete the `Recommended' version of the environment template if no other
+%% major versions or minor versions of the environment template exist. A
+%% major version of an environment template is a version that's not backwards
+%% compatible.
+%%
+%% Delete a minor version of an environment template if it isn't the
+%% `Recommended' version. Delete a `Recommended' minor version of the
+%% environment template if no other minor versions of the environment
+%% template exist. A minor version of an environment template is a version
+%% that's backwards compatible.
+delete_environment_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_environment_template_version(Client, Input, []).
+delete_environment_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEnvironmentTemplateVersion">>, Input, Options).
+
+%% @doc Delete a service.
+delete_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_service(Client, Input, []).
+delete_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteService">>, Input, Options).
+
+%% @doc If no other major or minor versions of the service template exist,
+%% delete the service template.
+delete_service_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_service_template(Client, Input, []).
+delete_service_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteServiceTemplate">>, Input, Options).
+
+%% @doc If no other minor versions of a service template exist, delete a
+%% major version of the service template if it's not the `Recommended'
+%% version.
+%%
+%% Delete the `Recommended' version of the service template if no other major
+%% versions or minor versions of the service template exist. A major version
+%% of a service template is a version that isn't backwards compatible.
+%%
+%% Delete a minor version of a service template if it's not the `Recommended'
+%% version. Delete a `Recommended' minor version of the service template if
+%% no other minor versions of the service template exist. A minor version of
+%% a service template is a version that's backwards compatible.
+delete_service_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_service_template_version(Client, Input, []).
+delete_service_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteServiceTemplateVersion">>, Input, Options).
+
+%% @doc Get detail data for the AWS Proton pipeline service role.
+get_account_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_account_settings(Client, Input, []).
+get_account_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetAccountSettings">>, Input, Options).
+
+%% @doc Get detail data for an environment.
+get_environment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_environment(Client, Input, []).
+get_environment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEnvironment">>, Input, Options).
+
+%% @doc In an environment account, view the detail data for an environment
+%% account connection.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+get_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_environment_account_connection(Client, Input, []).
+get_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc Get detail data for an environment template.
+get_environment_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_environment_template(Client, Input, []).
+get_environment_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEnvironmentTemplate">>, Input, Options).
+
+%% @doc View detail data for a major or minor version of an environment
+%% template.
+get_environment_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_environment_template_version(Client, Input, []).
+get_environment_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetEnvironmentTemplateVersion">>, Input, Options).
+
+%% @doc Get detail data for a service.
+get_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_service(Client, Input, []).
+get_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetService">>, Input, Options).
+
+%% @doc Get detail data for a service instance.
+%%
+%% A service instance is an instantiation of service template, which is
+%% running in a specific environment.
+get_service_instance(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_service_instance(Client, Input, []).
+get_service_instance(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetServiceInstance">>, Input, Options).
+
+%% @doc Get detail data for a service template.
+get_service_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_service_template(Client, Input, []).
+get_service_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetServiceTemplate">>, Input, Options).
+
+%% @doc View detail data for a major or minor version of a service template.
+get_service_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_service_template_version(Client, Input, []).
+get_service_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetServiceTemplateVersion">>, Input, Options).
+
+%% @doc View a list of environment account connections.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+list_environment_account_connections(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_environment_account_connections(Client, Input, []).
+list_environment_account_connections(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEnvironmentAccountConnections">>, Input, Options).
+
+%% @doc List major or minor versions of an environment template with detail
+%% data.
+list_environment_template_versions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_environment_template_versions(Client, Input, []).
+list_environment_template_versions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEnvironmentTemplateVersions">>, Input, Options).
+
+%% @doc List environment templates.
+list_environment_templates(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_environment_templates(Client, Input, []).
+list_environment_templates(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEnvironmentTemplates">>, Input, Options).
+
+%% @doc List environments with detail data summaries.
+list_environments(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_environments(Client, Input, []).
+list_environments(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEnvironments">>, Input, Options).
+
+%% @doc List service instances with summaries of detail data.
+list_service_instances(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_service_instances(Client, Input, []).
+list_service_instances(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListServiceInstances">>, Input, Options).
+
+%% @doc List major or minor versions of a service template with detail data.
+list_service_template_versions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_service_template_versions(Client, Input, []).
+list_service_template_versions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListServiceTemplateVersions">>, Input, Options).
+
+%% @doc List service templates with detail data.
+list_service_templates(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_service_templates(Client, Input, []).
+list_service_templates(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListServiceTemplates">>, Input, Options).
+
+%% @doc List services with summaries of detail data.
+list_services(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_services(Client, Input, []).
+list_services(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListServices">>, Input, Options).
+
+%% @doc List tags for a resource.
+%%
+%% For more information, see AWS Proton resources and tagging in the AWS
+%% Proton Administrator Guide or AWS Proton User Guide.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc In a management account, reject an environment account connection
+%% from another environment account.
+%%
+%% After you reject an environment account connection request, you won’t be
+%% able to accept or use the rejected environment account connection.
+%%
+%% You can’t reject an environment account connection that is connected to an
+%% environment.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+reject_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    reject_environment_account_connection(Client, Input, []).
+reject_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RejectEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc Tag a resource.
+%%
+%% For more information, see AWS Proton resources and tagging in the AWS
+%% Proton Administrator Guide or AWS Proton User Guide.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Remove a tag from a resource.
+%%
+%% For more information, see AWS Proton resources and tagging in the AWS
+%% Proton Administrator Guide or AWS Proton User Guide.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Update the AWS Proton pipeline service account settings.
+update_account_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_account_settings(Client, Input, []).
+update_account_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateAccountSettings">>, Input, Options).
+
+%% @doc Update an environment.
+%%
+%% If the environment is associated with an environment account connection,
+%% don't update or include the `protonServiceRoleArn' parameter to update or
+%% connect to an environment account connection.
+%%
+%% You can only update to a new environment account connection if it was
+%% created in the same environment account that the current environment
+%% account connection was created in and is associated with the current
+%% environment.
+%%
+%% If the environment isn't associated with an environment account
+%% connection, don't update or include the `environmentAccountConnectionId'
+%% parameter to update or connect to an environment account connection.
+%%
+%% You can update either the `environmentAccountConnectionId' or
+%% `protonServiceRoleArn' parameter and value. You can’t update both.
+%%
+%% There are four modes for updating an environment as described in the
+%% following. The `deploymentType' field defines the mode.
+%%
+%% <dl> <dt> </dt><dd> `NONE'
+%%
+%% In this mode, a deployment doesn't occur. Only the requested metadata
+%% parameters are updated.
+%%
+%% </dd> <dt> </dt><dd> `CURRENT_VERSION'
+%%
+%% In this mode, the environment is deployed and updated with the new spec
+%% that you provide. Only requested parameters are updated. Don’t include
+%% minor or major version parameters when you use this `deployment-type'.
+%%
+%% </dd> <dt> </dt><dd> `MINOR_VERSION'
+%%
+%% In this mode, the environment is deployed and updated with the published,
+%% recommended (latest) minor version of the current major version in use, by
+%% default. You can also specify a different minor version of the current
+%% major version in use.
+%%
+%% </dd> <dt> </dt><dd> `MAJOR_VERSION'
+%%
+%% In this mode, the environment is deployed and updated with the published,
+%% recommended (latest) major and minor version of the current template, by
+%% default. You can also specify a different major version that's higher than
+%% the major version in use and a minor version (optional).
+%%
+%% </dd> </dl>
+update_environment(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_environment(Client, Input, []).
+update_environment(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEnvironment">>, Input, Options).
+
+%% @doc In an environment account, update an environment account connection
+%% to use a new IAM role.
+%%
+%% For more information, see Environment account connections in the AWS
+%% Proton Administrator guide.
+update_environment_account_connection(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_environment_account_connection(Client, Input, []).
+update_environment_account_connection(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEnvironmentAccountConnection">>, Input, Options).
+
+%% @doc Update an environment template.
+update_environment_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_environment_template(Client, Input, []).
+update_environment_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEnvironmentTemplate">>, Input, Options).
+
+%% @doc Update a major or minor version of an environment template.
+update_environment_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_environment_template_version(Client, Input, []).
+update_environment_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateEnvironmentTemplateVersion">>, Input, Options).
+
+%% @doc Edit a service description or use a spec to add and delete service
+%% instances.
+%%
+%% Existing service instances and the service pipeline can't be edited using
+%% this API. They can only be deleted.
+%%
+%% Use the `description' parameter to modify the description.
+%%
+%% Edit the `spec' parameter to add or delete instances.
+update_service(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service(Client, Input, []).
+update_service(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateService">>, Input, Options).
+
+%% @doc Update a service instance.
+%%
+%% There are four modes for updating a service instance as described in the
+%% following. The `deploymentType' field defines the mode.
+%%
+%% <dl> <dt> </dt><dd> `NONE'
+%%
+%% In this mode, a deployment doesn't occur. Only the requested metadata
+%% parameters are updated.
+%%
+%% </dd> <dt> </dt><dd> `CURRENT_VERSION'
+%%
+%% In this mode, the service instance is deployed and updated with the new
+%% spec that you provide. Only requested parameters are updated. Don’t
+%% include minor or major version parameters when you use this
+%% `deployment-type'.
+%%
+%% </dd> <dt> </dt><dd> `MINOR_VERSION'
+%%
+%% In this mode, the service instance is deployed and updated with the
+%% published, recommended (latest) minor version of the current major version
+%% in use, by default. You can also specify a different minor version of the
+%% current major version in use.
+%%
+%% </dd> <dt> </dt><dd> `MAJOR_VERSION'
+%%
+%% In this mode, the service instance is deployed and updated with the
+%% published, recommended (latest) major and minor version of the current
+%% template, by default. You can also specify a different major version that
+%% is higher than the major version in use and a minor version (optional).
+%%
+%% </dd> </dl>
+update_service_instance(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service_instance(Client, Input, []).
+update_service_instance(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateServiceInstance">>, Input, Options).
+
+%% @doc Update the service pipeline.
+%%
+%% There are four modes for updating a service pipeline as described in the
+%% following. The `deploymentType' field defines the mode.
+%%
+%% <dl> <dt> </dt><dd> `NONE'
+%%
+%% In this mode, a deployment doesn't occur. Only the requested metadata
+%% parameters are updated.
+%%
+%% </dd> <dt> </dt><dd> `CURRENT_VERSION'
+%%
+%% In this mode, the service pipeline is deployed and updated with the new
+%% spec that you provide. Only requested parameters are updated. Don’t
+%% include minor or major version parameters when you use this
+%% `deployment-type'.
+%%
+%% </dd> <dt> </dt><dd> `MINOR_VERSION'
+%%
+%% In this mode, the service pipeline is deployed and updated with the
+%% published, recommended (latest) minor version of the current major version
+%% in use, by default. You can also specify a different minor version of the
+%% current major version in use.
+%%
+%% </dd> <dt> </dt><dd> `MAJOR_VERSION'
+%%
+%% In this mode, the service pipeline is deployed and updated with the
+%% published, recommended (latest) major and minor version of the current
+%% template by default. You can also specify a different major version that
+%% is higher than the major version in use and a minor version (optional).
+%%
+%% </dd> </dl>
+update_service_pipeline(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service_pipeline(Client, Input, []).
+update_service_pipeline(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateServicePipeline">>, Input, Options).
+
+%% @doc Update a service template.
+update_service_template(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service_template(Client, Input, []).
+update_service_template(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateServiceTemplate">>, Input, Options).
+
+%% @doc Update a major or minor version of a service template.
+update_service_template_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_service_template_version(Client, Input, []).
+update_service_template_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateServiceTemplateVersion">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"proton">>},
+    Host = build_host(<<"proton">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"AwsProton20200720.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -4,8 +4,8 @@
 %% @doc Amazon QuickSight API Reference
 %%
 %% Amazon QuickSight is a fully managed, serverless business intelligence
-%% service for the AWS Cloud that makes it easy to extend data and insights
-%% to every user in your organization.
+%% service for the Amazon Web Services Cloud that makes it easy to extend
+%% data and insights to every user in your organization.
 %%
 %% This API reference contains documentation for a programming interface that
 %% you can use to manage Amazon QuickSight.
@@ -23,6 +23,10 @@
          create_data_set/4,
          create_data_source/3,
          create_data_source/4,
+         create_folder/4,
+         create_folder/5,
+         create_folder_membership/6,
+         create_folder_membership/7,
          create_group/4,
          create_group/5,
          create_group_membership/6,
@@ -51,6 +55,10 @@
          delete_data_set/5,
          delete_data_source/4,
          delete_data_source/5,
+         delete_folder/4,
+         delete_folder/5,
+         delete_folder_membership/6,
+         delete_folder_membership/7,
          delete_group/5,
          delete_group/6,
          delete_group_membership/6,
@@ -101,6 +109,15 @@
          describe_data_source_permissions/3,
          describe_data_source_permissions/5,
          describe_data_source_permissions/6,
+         describe_folder/3,
+         describe_folder/5,
+         describe_folder/6,
+         describe_folder_permissions/3,
+         describe_folder_permissions/5,
+         describe_folder_permissions/6,
+         describe_folder_resolved_permissions/3,
+         describe_folder_resolved_permissions/5,
+         describe_folder_resolved_permissions/6,
          describe_group/4,
          describe_group/6,
          describe_group/7,
@@ -110,6 +127,9 @@
          describe_ingestion/4,
          describe_ingestion/6,
          describe_ingestion/7,
+         describe_ip_restriction/2,
+         describe_ip_restriction/4,
+         describe_ip_restriction/5,
          describe_namespace/3,
          describe_namespace/5,
          describe_namespace/6,
@@ -134,6 +154,10 @@
          describe_user/4,
          describe_user/6,
          describe_user/7,
+         generate_embed_url_for_anonymous_user/3,
+         generate_embed_url_for_anonymous_user/4,
+         generate_embed_url_for_registered_user/3,
+         generate_embed_url_for_registered_user/4,
          get_dashboard_embed_url/4,
          get_dashboard_embed_url/6,
          get_dashboard_embed_url/7,
@@ -155,6 +179,12 @@
          list_data_sources/2,
          list_data_sources/4,
          list_data_sources/5,
+         list_folder_members/3,
+         list_folder_members/5,
+         list_folder_members/6,
+         list_folders/2,
+         list_folders/4,
+         list_folders/5,
          list_group_memberships/4,
          list_group_memberships/6,
          list_group_memberships/7,
@@ -208,6 +238,8 @@
          search_analyses/4,
          search_dashboards/3,
          search_dashboards/4,
+         search_folders/3,
+         search_folders/4,
          tag_resource/3,
          tag_resource/4,
          untag_resource/3,
@@ -234,10 +266,16 @@
          update_data_source/5,
          update_data_source_permissions/4,
          update_data_source_permissions/5,
+         update_folder/4,
+         update_folder/5,
+         update_folder_permissions/4,
+         update_folder_permissions/5,
          update_group/5,
          update_group/6,
          update_iam_policy_assignment/5,
          update_iam_policy_assignment/6,
+         update_ip_restriction/3,
+         update_ip_restriction/4,
          update_template/4,
          update_template/5,
          update_template_alias/5,
@@ -282,19 +320,21 @@ cancel_ingestion(Client, AwsAccountId, DataSetId, IngestionId, Input0, Options0)
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates Amazon QuickSight customizations the current AWS Region.
+%% @doc Creates Amazon QuickSight customizations the current Amazon Web
+%% Services Region.
 %%
 %% Currently, you can add a custom default theme by using the
 %% `CreateAccountCustomization' or `UpdateAccountCustomization' API
-%% operation. To further customize QuickSight by removing QuickSight sample
-%% assets and videos for all new users, see Customizing QuickSight in the
-%% Amazon QuickSight User Guide.
+%% operation. To further customize Amazon QuickSight by removing Amazon
+%% QuickSight sample assets and videos for all new users, see Customizing
+%% Amazon QuickSight in the Amazon QuickSight User Guide.
 %%
-%% You can create customizations for your AWS account or, if you specify a
-%% namespace, for a QuickSight namespace instead. Customizations that apply
-%% to a namespace always override customizations that apply to an AWS
-%% account. To find out which customizations apply, use the
-%% `DescribeAccountCustomization' API operation.
+%% You can create customizations for your Amazon Web Services account or, if
+%% you specify a namespace, for a Amazon QuickSight namespace instead.
+%% Customizations that apply to a namespace always override customizations
+%% that apply to an Amazon Web Services account. To find out which
+%% customizations apply, use the `DescribeAccountCustomization' API
+%% operation.
 %%
 %% Before you use the `CreateAccountCustomization' API operation to add a
 %% theme as the namespace default, make sure that you first share the theme
@@ -353,11 +393,12 @@ create_analysis(Client, AnalysisId, AwsAccountId, Input0, Options0) ->
 %%
 %% To first create a template, see the ` `CreateTemplate' ' API operation.
 %%
-%% A dashboard is an entity in QuickSight that identifies QuickSight reports,
-%% created from analyses. You can share QuickSight dashboards. With the right
-%% permissions, you can create scheduled email reports from them. If you have
-%% the correct permissions, you can create a dashboard from a template that
-%% exists in a different AWS account.
+%% A dashboard is an entity in Amazon QuickSight that identifies Amazon
+%% QuickSight reports, created from analyses. You can share Amazon QuickSight
+%% dashboards. With the right permissions, you can create scheduled email
+%% reports from them. If you have the correct permissions, you can create a
+%% dashboard from a template that exists in a different Amazon Web Services
+%% account.
 create_dashboard(Client, AwsAccountId, DashboardId, Input) ->
     create_dashboard(Client, AwsAccountId, DashboardId, Input, []).
 create_dashboard(Client, AwsAccountId, DashboardId, Input0, Options0) ->
@@ -409,6 +450,53 @@ create_data_source(Client, AwsAccountId, Input) ->
 create_data_source(Client, AwsAccountId, Input0, Options0) ->
     Method = post,
     Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/data-sources"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an empty shared folder.
+create_folder(Client, AwsAccountId, FolderId, Input) ->
+    create_folder(Client, AwsAccountId, FolderId, Input, []).
+create_folder(Client, AwsAccountId, FolderId, Input0, Options0) ->
+    Method = post,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds an asset, such as a dashboard, analysis, or dataset into a
+%% folder.
+create_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input) ->
+    create_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input, []).
+create_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input0, Options0) ->
+    Method = put,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/members/", aws_util:encode_uri(MemberType), "/", aws_util:encode_uri(MemberId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -478,13 +566,13 @@ create_group_membership(Client, AwsAccountId, GroupName, MemberName, Namespace, 
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an assignment with one specified IAM policy, identified by
-%% its Amazon Resource Name (ARN).
+%% @doc Creates an assignment with one specified IAMpolicy, identified by its
+%% Amazon Resource Name (ARN).
 %%
 %% This policy assignment is attached to the specified groups or users of
-%% Amazon QuickSight. Assignment names are unique per AWS account. To avoid
-%% overwriting rules in other namespaces, use assignment names that are
-%% unique.
+%% Amazon QuickSight. Assignment names are unique per Amazon Web Services
+%% account. To avoid overwriting rules in other namespaces, use assignment
+%% names that are unique.
 create_iam_policy_assignment(Client, AwsAccountId, Namespace, Input) ->
     create_iam_policy_assignment(Client, AwsAccountId, Namespace, Input, []).
 create_iam_policy_assignment(Client, AwsAccountId, Namespace, Input0, Options0) ->
@@ -513,8 +601,9 @@ create_iam_policy_assignment(Client, AwsAccountId, Namespace, Input0, Options0) 
 %% automatically for use in access control.
 %%
 %% For an example, see How do I create an IAM policy to control access to
-%% Amazon EC2 resources using tags? in the AWS Knowledge Center. Tags are
-%% visible on the tagged dataset, but not on the ingestion resource.
+%% Amazon EC2 resources using tags? in the Amazon Web Services Knowledge
+%% Center. Tags are visible on the tagged dataset, but not on the ingestion
+%% resource.
 create_ingestion(Client, AwsAccountId, DataSetId, IngestionId, Input) ->
     create_ingestion(Client, AwsAccountId, DataSetId, IngestionId, Input, []).
 create_ingestion(Client, AwsAccountId, DataSetId, IngestionId, Input0, Options0) ->
@@ -540,13 +629,15 @@ create_ingestion(Client, AwsAccountId, DataSetId, IngestionId, Input0, Options0)
 %% @doc (Enterprise edition only) Creates a new namespace for you to use with
 %% Amazon QuickSight.
 %%
-%% A namespace allows you to isolate the QuickSight users and groups that are
-%% registered for that namespace. Users that access the namespace can share
-%% assets only with other users or groups in the same namespace. They can't
-%% see users and groups in other namespaces. You can create a namespace after
-%% your AWS account is subscribed to QuickSight. The namespace must be unique
-%% within the AWS account. By default, there is a limit of 100 namespaces per
-%% AWS account. To increase your limit, create a ticket with AWS Support.
+%% A namespace allows you to isolate the Amazon QuickSight users and groups
+%% that are registered for that namespace. Users that access the namespace
+%% can share assets only with other users or groups in the same namespace.
+%% They can't see users and groups in other namespaces. You can create a
+%% namespace after your Amazon Web Services account is subscribed to Amazon
+%% QuickSight. The namespace must be unique within the Amazon Web Services
+%% account. By default, there is a limit of 100 namespaces per Amazon Web
+%% Services account. To increase your limit, create a ticket with Amazon Web
+%% Services Support.
 create_namespace(Client, AwsAccountId, Input) ->
     create_namespace(Client, AwsAccountId, Input, []).
 create_namespace(Client, AwsAccountId, Input0, Options0) ->
@@ -569,16 +660,18 @@ create_namespace(Client, AwsAccountId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates a template from an existing QuickSight analysis or template.
+%% @doc Creates a template from an existing Amazon QuickSight analysis or
+%% template.
 %%
 %% You can use the resulting template to create a dashboard.
 %%
-%% A template is an entity in QuickSight that encapsulates the metadata
-%% required to create an analysis and that you can use to create s dashboard.
-%% A template adds a layer of abstraction by using placeholders to replace
-%% the dataset associated with the analysis. You can use templates to create
-%% dashboards by replacing dataset placeholders with datasets that follow the
-%% same schema that was used to create the source analysis and template.
+%% A template is an entity in Amazon QuickSight that encapsulates the
+%% metadata required to create an analysis and that you can use to create s
+%% dashboard. A template adds a layer of abstraction by using placeholders to
+%% replace the dataset associated with the analysis. You can use templates to
+%% create dashboards by replacing dataset placeholders with datasets that
+%% follow the same schema that was used to create the source analysis and
+%% template.
 create_template(Client, AwsAccountId, TemplateId, Input) ->
     create_template(Client, AwsAccountId, TemplateId, Input, []).
 create_template(Client, AwsAccountId, TemplateId, Input0, Options0) ->
@@ -674,8 +767,9 @@ create_theme_alias(Client, AliasName, AwsAccountId, ThemeId, Input0, Options0) -
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes all Amazon QuickSight customizations in this AWS Region for
-%% the specified AWS account and QuickSight namespace.
+%% @doc Deletes all Amazon QuickSight customizations in this Amazon Web
+%% Services Region for the specified Amazon Web Services account and Amazon
+%% QuickSight namespace.
 delete_account_customization(Client, AwsAccountId, Input) ->
     delete_account_customization(Client, AwsAccountId, Input, []).
 delete_account_customization(Client, AwsAccountId, Input0, Options0) ->
@@ -703,16 +797,16 @@ delete_account_customization(Client, AwsAccountId, Input0, Options0) ->
 %%
 %% You can optionally include a recovery window during which you can restore
 %% the analysis. If you don't specify a recovery window value, the operation
-%% defaults to 30 days. QuickSight attaches a `DeletionTime' stamp to the
-%% response that specifies the end of the recovery window. At the end of the
-%% recovery window, QuickSight deletes the analysis permanently.
+%% defaults to 30 days. Amazon QuickSight attaches a `DeletionTime' stamp to
+%% the response that specifies the end of the recovery window. At the end of
+%% the recovery window, Amazon QuickSight deletes the analysis permanently.
 %%
 %% At any time before recovery window ends, you can use the `RestoreAnalysis'
 %% API operation to remove the `DeletionTime' stamp and cancel the deletion
 %% of the analysis. The analysis remains visible in the API until it's
 %% deleted, so you can describe it but you can't make a template from it.
 %%
-%% An analysis that's scheduled for deletion isn't accessible in the
+%% An analysis that's scheduled for deletion isn't accessible in the Amazon
 %% QuickSight console. To access it in the console, restore it. Deleting an
 %% analysis doesn't delete the dashboards that you publish from it.
 delete_analysis(Client, AnalysisId, AwsAccountId, Input) ->
@@ -812,6 +906,53 @@ delete_data_source(Client, AwsAccountId, DataSourceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes an empty folder.
+delete_folder(Client, AwsAccountId, FolderId, Input) ->
+    delete_folder(Client, AwsAccountId, FolderId, Input, []).
+delete_folder(Client, AwsAccountId, FolderId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes an asset, such as a dashboard, analysis, or dataset, from a
+%% folder.
+delete_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input) ->
+    delete_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input, []).
+delete_folder_membership(Client, AwsAccountId, FolderId, MemberId, MemberType, Input0, Options0) ->
+    Method = delete,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/members/", aws_util:encode_uri(MemberType), "/", aws_util:encode_uri(MemberId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Removes a user group from Amazon QuickSight.
 delete_group(Client, AwsAccountId, GroupName, Namespace, Input) ->
     delete_group(Client, AwsAccountId, GroupName, Namespace, Input, []).
@@ -859,7 +1000,7 @@ delete_group_membership(Client, AwsAccountId, GroupName, MemberName, Namespace, 
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an existing IAM policy assignment.
+%% @doc Deletes an existing IAMpolicy assignment.
 delete_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace, Input) ->
     delete_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace, Input, []).
 delete_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace, Input0, Options0) ->
@@ -1012,8 +1153,8 @@ delete_theme_alias(Client, AliasName, AwsAccountId, ThemeId, Input0, Options0) -
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes the Amazon QuickSight user that is associated with the
-%% identity of the AWS Identity and Access Management (IAM) user or role
-%% that's making the call.
+%% identity of the Identity and Access Management (IAM) user or role that's
+%% making the call.
 %%
 %% The IAM user isn't deleted as a result of this call.
 delete_user(Client, AwsAccountId, Namespace, UserName, Input) ->
@@ -1061,53 +1202,59 @@ delete_user_by_principal_id(Client, AwsAccountId, Namespace, PrincipalId, Input0
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Describes the customizations associated with the provided AWS account
-%% and Amazon QuickSight namespace in an AWS Region.
+%% @doc Describes the customizations associated with the provided Amazon Web
+%% Services account and Amazon Amazon QuickSight namespace in an Amazon Web
+%% Services Region.
 %%
-%% The QuickSight console evaluates which customizations to apply by running
-%% this API operation with the `Resolved' flag included.
+%% The Amazon QuickSight console evaluates which customizations to apply by
+%% running this API operation with the `Resolved' flag included.
 %%
 %% To determine what customizations display when you run this command, it can
 %% help to visualize the relationship of the entities involved.
 %%
-%% <ul> <li> `AWS Account' - The AWS account exists at the top of the
-%% hierarchy. It has the potential to use all of the AWS Regions and AWS
-%% Services. When you subscribe to QuickSight, you choose one AWS Region to
-%% use as your home Region. That's where your free SPICE capacity is located.
-%% You can use QuickSight in any supported AWS Region.
+%% <ul> <li> `Amazon Web Services account' - The Amazon Web Services account
+%% exists at the top of the hierarchy. It has the potential to use all of the
+%% Amazon Web Services Regions and AWS Services. When you subscribe to Amazon
+%% QuickSight, you choose one Amazon Web Services Region to use as your home
+%% Region. That's where your free SPICE capacity is located. You can use
+%% Amazon QuickSight in any supported Amazon Web Services Region.
 %%
-%% </li> <li> `AWS Region' - In each AWS Region where you sign in to
-%% QuickSight at least once, QuickSight acts as a separate instance of the
-%% same service. If you have a user directory, it resides in us-east-1, which
-%% is the US East (N. Virginia). Generally speaking, these users have access
-%% to QuickSight in any AWS Region, unless they are constrained to a
-%% namespace.
+%% </li> <li> `Amazon Web Services Region' - In each Amazon Web Services
+%% Region where you sign in to Amazon QuickSight at least once, Amazon
+%% QuickSight acts as a separate instance of the same service. If you have a
+%% user directory, it resides in us-east-1, which is the US East (N.
+%% Virginia). Generally speaking, these users have access to Amazon
+%% QuickSight in any Amazon Web Services Region, unless they are constrained
+%% to a namespace.
 %%
-%% To run the command in a different AWS Region, you change your Region
-%% settings. If you're using the AWS CLI, you can use one of the following
-%% options:
+%% To run the command in a different Amazon Web Services Region, you change
+%% your Region settings. If you're using the AWS CLI, you can use one of the
+%% following options:
 %%
 %% <ul> <li> Use command line options.
 %%
 %% </li> <li> Use named profiles.
 %%
-%% </li> <li> Run `aws configure' to change your default AWS Region. Use
-%% Enter to key the same settings for your keys. For more information, see
-%% Configuring the AWS CLI.
+%% </li> <li> Run `aws configure' to change your default Amazon Web Services
+%% Region. Use Enter to key the same settings for your keys. For more
+%% information, see Configuring the AWS CLI.
 %%
-%% </li> </ul> </li> <li> `Namespace' - A QuickSight namespace is a partition
-%% that contains users and assets (data sources, datasets, dashboards, and so
-%% on). To access assets that are in a specific namespace, users and groups
-%% must also be part of the same namespace. People who share a namespace are
-%% completely isolated from users and assets in other namespaces, even if
-%% they are in the same AWS account and AWS Region.
+%% </li> </ul> </li> <li> `Namespace' - A Amazon QuickSight namespace is a
+%% partition that contains users and assets (data sources, datasets,
+%% dashboards, and so on). To access assets that are in a specific namespace,
+%% users and groups must also be part of the same namespace. People who share
+%% a namespace are completely isolated from users and assets in other
+%% namespaces, even if they are in the same Amazon Web Services account and
+%% Amazon Web Services Region.
 %%
-%% </li> <li> `Applied customizations' - Within an AWS Region, a set of
-%% QuickSight customizations can apply to an AWS account or to a namespace.
-%% Settings that you apply to a namespace override settings that you apply to
-%% an AWS account. All settings are isolated to a single AWS Region. To apply
-%% them in other AWS Regions, run the `CreateAccountCustomization' command in
-%% each AWS Region where you want to apply the same customizations.
+%% </li> <li> `Applied customizations' - Within an Amazon Web Services
+%% Region, a set of Amazon QuickSight customizations can apply to an Amazon
+%% Web Services account or to a namespace. Settings that you apply to a
+%% namespace override settings that you apply to an Amazon Web Services
+%% account. All settings are isolated to a single Amazon Web Services Region.
+%% To apply them in other Amazon Web Services Regions, run the
+%% `CreateAccountCustomization' command in each Amazon Web Services Region
+%% where you want to apply the same customizations.
 %%
 %% </li> </ul>
 describe_account_customization(Client, AwsAccountId)
@@ -1137,8 +1284,8 @@ describe_account_customization(Client, AwsAccountId, QueryMap, HeadersMap, Optio
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Describes the settings that were used when your QuickSight
-%% subscription was first created in this AWS account.
+%% @doc Describes the settings that were used when your Amazon QuickSight
+%% subscription was first created in this Amazon Web Services account.
 describe_account_settings(Client, AwsAccountId)
   when is_map(Client) ->
     describe_account_settings(Client, AwsAccountId, #{}, #{}).
@@ -1353,6 +1500,78 @@ describe_data_source_permissions(Client, AwsAccountId, DataSourceId, QueryMap, H
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Describes a folder.
+describe_folder(Client, AwsAccountId, FolderId)
+  when is_map(Client) ->
+    describe_folder(Client, AwsAccountId, FolderId, #{}, #{}).
+
+describe_folder(Client, AwsAccountId, FolderId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_folder(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, []).
+
+describe_folder(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describes permissions for a folder.
+describe_folder_permissions(Client, AwsAccountId, FolderId)
+  when is_map(Client) ->
+    describe_folder_permissions(Client, AwsAccountId, FolderId, #{}, #{}).
+
+describe_folder_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_folder_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, []).
+
+describe_folder_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/permissions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describes the folder resolved permissions.
+%%
+%% Permissions consists of both folder direct permissions and the inherited
+%% permissions from the ancestor folders.
+describe_folder_resolved_permissions(Client, AwsAccountId, FolderId)
+  when is_map(Client) ->
+    describe_folder_resolved_permissions(Client, AwsAccountId, FolderId, #{}, #{}).
+
+describe_folder_resolved_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_folder_resolved_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, []).
+
+describe_folder_resolved_permissions(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/resolved-permissions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns an Amazon QuickSight group's description and Amazon Resource
 %% Name (ARN).
 describe_group(Client, AwsAccountId, GroupName, Namespace)
@@ -1377,7 +1596,7 @@ describe_group(Client, AwsAccountId, GroupName, Namespace, QueryMap, HeadersMap,
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Describes an existing IAM policy assignment, as specified by the
+%% @doc Describes an existing IAMpolicy assignment, as specified by the
 %% assignment name.
 describe_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace)
   when is_map(Client) ->
@@ -1413,6 +1632,29 @@ describe_ingestion(Client, AwsAccountId, DataSetId, IngestionId, QueryMap, Heade
 describe_ingestion(Client, AwsAccountId, DataSetId, IngestionId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/data-sets/", aws_util:encode_uri(DataSetId), "/ingestions/", aws_util:encode_uri(IngestionId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Provides a summary and status of IP Rules.
+describe_ip_restriction(Client, AwsAccountId)
+  when is_map(Client) ->
+    describe_ip_restriction(Client, AwsAccountId, #{}, #{}).
+
+describe_ip_restriction(Client, AwsAccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_ip_restriction(Client, AwsAccountId, QueryMap, HeadersMap, []).
+
+describe_ip_restriction(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/ip-restriction"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1618,8 +1860,110 @@ describe_user(Client, AwsAccountId, Namespace, UserName, QueryMap, HeadersMap, O
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Generates an embed URL that you can use to embed an Amazon QuickSight
+%% dashboard in your website, without having to register any reader users.
+%%
+%% Before you use this action, make sure that you have configured the
+%% dashboards and permissions.
+%%
+%% The following rules apply to the generated URL:
+%%
+%% <ul> <li> It contains a temporary bearer token. It is valid for 5 minutes
+%% after it is generated. Once redeemed within this period, it cannot be
+%% re-used again.
+%%
+%% </li> <li> The URL validity period should not be confused with the actual
+%% session lifetime that can be customized using the `
+%% SessionLifetimeInMinutes ' parameter.
+%%
+%% The resulting user session is valid for 15 minutes (default) to 10 hours
+%% (maximum).
+%%
+%% </li> <li> You are charged only when the URL is used or there is
+%% interaction with Amazon QuickSight.
+%%
+%% </li> </ul> For more information, see Embedded Analytics in the Amazon
+%% QuickSight User Guide.
+%%
+%% For more information about the high-level steps for embedding and for an
+%% interactive demo of the ways you can customize embedding, visit the Amazon
+%% QuickSight Developer Portal.
+generate_embed_url_for_anonymous_user(Client, AwsAccountId, Input) ->
+    generate_embed_url_for_anonymous_user(Client, AwsAccountId, Input, []).
+generate_embed_url_for_anonymous_user(Client, AwsAccountId, Input0, Options0) ->
+    Method = post,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/embed-url/anonymous-user"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Generates an embed URL that you can use to embed an Amazon QuickSight
+%% experience in your website.
+%%
+%% This action can be used for any type of user registered in an Amazon
+%% QuickSight account. Before you use this action, make sure that you have
+%% configured the relevant Amazon QuickSight resource and permissions.
+%%
+%% The following rules apply to the generated URL:
+%%
+%% <ul> <li> It contains a temporary bearer token. It is valid for 5 minutes
+%% after it is generated. Once redeemed within this period, it cannot be
+%% re-used again.
+%%
+%% </li> <li> The URL validity period should not be confused with the actual
+%% session lifetime that can be customized using the `
+%% SessionLifetimeInMinutes ' parameter.
+%%
+%% The resulting user session is valid for 15 minutes (default) to 10 hours
+%% (maximum).
+%%
+%% </li> <li> You are charged only when the URL is used or there is
+%% interaction with Amazon QuickSight.
+%%
+%% </li> </ul> For more information, see Embedded Analytics in the Amazon
+%% QuickSight User Guide.
+%%
+%% For more information about the high-level steps for embedding and for an
+%% interactive demo of the ways you can customize embedding, visit the Amazon
+%% QuickSight Developer Portal.
+generate_embed_url_for_registered_user(Client, AwsAccountId, Input) ->
+    generate_embed_url_for_registered_user(Client, AwsAccountId, Input, []).
+generate_embed_url_for_registered_user(Client, AwsAccountId, Input0, Options0) ->
+    Method = post,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/embed-url/registered-user"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Generates a session URL and authorization code that you can use to
-%% embed an Amazon QuickSight read-only dashboard in your web server code.
+%% embed an Amazon Amazon QuickSight read-only dashboard in your web server
+%% code.
 %%
 %% Before you use this command, make sure that you have configured the
 %% dashboards and permissions.
@@ -1636,8 +1980,12 @@ describe_user(Client, AwsAccountId, Namespace, UserName, QueryMap, HeadersMap, O
 %%
 %% </li> <li> The resulting user session is valid for 10 hours.
 %%
-%% </li> </ul> For more information, see Embedded Analytics in the Amazon
-%% QuickSight User Guide.
+%% </li> </ul> For more information, see Embedding Analytics Using
+%% GetDashboardEmbedUrl in the Amazon QuickSight User Guide.
+%%
+%% For more information about the high-level steps for embedding and for an
+%% interactive demo of the ways you can customize embedding, visit the Amazon
+%% QuickSight Developer Portal.
 get_dashboard_embed_url(Client, AwsAccountId, DashboardId, IdentityType)
   when is_map(Client) ->
     get_dashboard_embed_url(Client, AwsAccountId, DashboardId, IdentityType, #{}, #{}).
@@ -1672,19 +2020,19 @@ get_dashboard_embed_url(Client, AwsAccountId, DashboardId, IdentityType, QueryMa
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Generates a session URL and authorization code that you can use to
-%% embed the Amazon QuickSight console in your web server code.
+%% embed the Amazon Amazon QuickSight console in your web server code.
 %%
 %% Use `GetSessionEmbedUrl' where you want to provide an authoring portal
 %% that allows users to create data sources, datasets, analyses, and
-%% dashboards. The users who access an embedded QuickSight console need
-%% belong to the author or admin security cohort. If you want to restrict
-%% permissions to some of these features, add a custom permissions profile to
-%% the user with the ` `UpdateUser' ' API operation. Use ` `RegisterUser' '
-%% API operation to add a new user with a custom permission profile attached.
-%% For more information, see the following sections in the Amazon QuickSight
-%% User Guide:
+%% dashboards. The users who access an embedded Amazon QuickSight console
+%% need belong to the author or admin security cohort. If you want to
+%% restrict permissions to some of these features, add a custom permissions
+%% profile to the user with the ` `UpdateUser' ' API operation. Use `
+%% `RegisterUser' ' API operation to add a new user with a custom permission
+%% profile attached. For more information, see the following sections in the
+%% Amazon QuickSight User Guide:
 %%
-%% <ul> <li> Embedding the Amazon QuickSight Console
+%% <ul> <li> Embedding Analytics
 %%
 %% </li> <li> Customizing Access to the Amazon QuickSight Console
 %%
@@ -1717,8 +2065,8 @@ get_session_embed_url(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists Amazon QuickSight analyses that exist in the specified AWS
-%% account.
+%% @doc Lists Amazon QuickSight analyses that exist in the specified Amazon
+%% Web Services account.
 list_analyses(Client, AwsAccountId)
   when is_map(Client) ->
     list_analyses(Client, AwsAccountId, #{}, #{}).
@@ -1746,7 +2094,7 @@ list_analyses(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the versions of the dashboards in the QuickSight
+%% @doc Lists all the versions of the dashboards in the Amazon QuickSight
 %% subscription.
 list_dashboard_versions(Client, AwsAccountId, DashboardId)
   when is_map(Client) ->
@@ -1775,7 +2123,7 @@ list_dashboard_versions(Client, AwsAccountId, DashboardId, QueryMap, HeadersMap,
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists dashboards in an AWS account.
+%% @doc Lists dashboards in an Amazon Web Services account.
 list_dashboards(Client, AwsAccountId)
   when is_map(Client) ->
     list_dashboards(Client, AwsAccountId, #{}, #{}).
@@ -1803,8 +2151,8 @@ list_dashboards(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all of the datasets belonging to the current AWS account in an
-%% AWS Region.
+%% @doc Lists all of the datasets belonging to the current Amazon Web
+%% Services account in an Amazon Web Services Region.
 %%
 %% The permissions resource is
 %% `arn:aws:quicksight:region:aws-account-id:dataset/*'.
@@ -1835,8 +2183,8 @@ list_data_sets(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists data sources in current AWS Region that belong to this AWS
-%% account.
+%% @doc Lists data sources in current Amazon Web Services Region that belong
+%% to this Amazon Web Services account.
 list_data_sources(Client, AwsAccountId)
   when is_map(Client) ->
     list_data_sources(Client, AwsAccountId, #{}, #{}).
@@ -1848,6 +2196,62 @@ list_data_sources(Client, AwsAccountId, QueryMap, HeadersMap)
 list_data_sources(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/data-sources"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List all assets (`DASHBOARD', `ANALYSIS', and `DATASET') in a folder.
+list_folder_members(Client, AwsAccountId, FolderId)
+  when is_map(Client) ->
+    list_folder_members(Client, AwsAccountId, FolderId, #{}, #{}).
+
+list_folder_members(Client, AwsAccountId, FolderId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_folder_members(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, []).
+
+list_folder_members(Client, AwsAccountId, FolderId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/members"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"max-results">>, maps:get(<<"max-results">>, QueryMap, undefined)},
+        {<<"next-token">>, maps:get(<<"next-token">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all folders in an account.
+list_folders(Client, AwsAccountId)
+  when is_map(Client) ->
+    list_folders(Client, AwsAccountId, #{}, #{}).
+
+list_folders(Client, AwsAccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_folders(Client, AwsAccountId, QueryMap, HeadersMap, []).
+
+list_folders(Client, AwsAccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1920,8 +2324,7 @@ list_groups(Client, AwsAccountId, Namespace, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists IAM policy assignments in the current Amazon QuickSight
-%% account.
+%% @doc Lists IAMpolicy assignments in the current Amazon QuickSight account.
 list_iam_policy_assignments(Client, AwsAccountId, Namespace)
   when is_map(Client) ->
     list_iam_policy_assignments(Client, AwsAccountId, Namespace, #{}, #{}).
@@ -1949,7 +2352,7 @@ list_iam_policy_assignments(Client, AwsAccountId, Namespace, QueryMap, HeadersMa
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the IAM policy assignments, including the Amazon Resource
+%% @doc Lists all the IAMpolicy assignments, including the Amazon Resource
 %% Names (ARNs) for the IAM policies assigned to the specified user and group
 %% or groups that the user belongs to.
 list_iam_policy_assignments_for_user(Client, AwsAccountId, Namespace, UserName)
@@ -2007,7 +2410,7 @@ list_ingestions(Client, AwsAccountId, DataSetId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists the namespaces for the specified AWS account.
+%% @doc Lists the namespaces for the specified Amazon Web Services account.
 list_namespaces(Client, AwsAccountId)
   when is_map(Client) ->
     list_namespaces(Client, AwsAccountId, #{}, #{}).
@@ -2171,7 +2574,8 @@ list_theme_aliases(Client, AwsAccountId, ThemeId, QueryMap, HeadersMap, Options0
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the versions of the themes in the current AWS account.
+%% @doc Lists all the versions of the themes in the current Amazon Web
+%% Services account.
 list_theme_versions(Client, AwsAccountId, ThemeId)
   when is_map(Client) ->
     list_theme_versions(Client, AwsAccountId, ThemeId, #{}, #{}).
@@ -2199,7 +2603,7 @@ list_theme_versions(Client, AwsAccountId, ThemeId, QueryMap, HeadersMap, Options
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all the themes in the current AWS account.
+%% @doc Lists all the themes in the current Amazon Web Services account.
 list_themes(Client, AwsAccountId)
   when is_map(Client) ->
     list_themes(Client, AwsAccountId, #{}, #{}).
@@ -2336,6 +2740,9 @@ restore_analysis(Client, AnalysisId, AwsAccountId, Input0, Options0) ->
 
 %% @doc Searches for analyses that belong to the user specified in the
 %% filter.
+%%
+%% This operation is eventually consistent. The results are best effort and
+%% may not reflect very recent updates and changes.
 search_analyses(Client, AwsAccountId, Input) ->
     search_analyses(Client, AwsAccountId, Input, []).
 search_analyses(Client, AwsAccountId, Input0, Options0) ->
@@ -2359,6 +2766,9 @@ search_analyses(Client, AwsAccountId, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Searches for dashboards that belong to a user.
+%%
+%% This operation is eventually consistent. The results are best effort and
+%% may not reflect very recent updates and changes.
 search_dashboards(Client, AwsAccountId, Input) ->
     search_dashboards(Client, AwsAccountId, Input, []).
 search_dashboards(Client, AwsAccountId, Input0, Options0) ->
@@ -2381,7 +2791,30 @@ search_dashboards(Client, AwsAccountId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Assigns one or more tags (key-value pairs) to the specified
+%% @doc Searches the subfolders in a folder.
+search_folders(Client, AwsAccountId, Input) ->
+    search_folders(Client, AwsAccountId, Input, []).
+search_folders(Client, AwsAccountId, Input0, Options0) ->
+    Method = post,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/search/folders"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Assigns one or more tags (key-value pairs) to the specified Amazon
 %% QuickSight resource.
 %%
 %% Tags can help you organize and categorize your resources. You can also use
@@ -2393,17 +2826,17 @@ search_dashboards(Client, AwsAccountId, Input0, Options0) ->
 %% already associated with the resource, the new tag value that you specify
 %% replaces the previous value for that tag.
 %%
-%% You can associate as many as 50 tags with a resource. QuickSight supports
-%% tagging on data set, data source, dashboard, and template.
+%% You can associate as many as 50 tags with a resource. Amazon QuickSight
+%% supports tagging on data set, data source, dashboard, and template.
 %%
-%% Tagging for QuickSight works in a similar way to tagging for other AWS
-%% services, except for the following:
+%% Tagging for Amazon QuickSight works in a similar way to tagging for other
+%% AWS services, except for the following:
 %%
-%% <ul> <li> You can't use tags to track AWS costs for QuickSight. This
-%% restriction is because QuickSight costs are based on users and SPICE
-%% capacity, which aren't taggable resources.
+%% <ul> <li> You can't use tags to track AWS costs for Amazon QuickSight.
+%% This restriction is because Amazon QuickSight costs are based on users and
+%% SPICE capacity, which aren't taggable resources.
 %%
-%% </li> <li> QuickSight doesn't currently support the Tag Editor for AWS
+%% </li> <li> Amazon QuickSight doesn't currently support the Tag Editor for
 %% Resource Groups.
 %%
 %% </li> </ul>
@@ -2453,15 +2886,16 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates Amazon QuickSight customizations the current AWS Region.
+%% @doc Updates Amazon QuickSight customizations the current Amazon Web
+%% Services Region.
 %%
 %% Currently, the only customization you can use is a theme.
 %%
-%% You can use customizations for your AWS account or, if you specify a
-%% namespace, for a QuickSight namespace instead. Customizations that apply
-%% to a namespace override customizations that apply to an AWS account. To
-%% find out which customizations apply, use the
-%% `DescribeAccountCustomization' API operation.
+%% You can use customizations for your Amazon Web Services account or, if you
+%% specify a namespace, for a Amazon QuickSight namespace instead.
+%% Customizations that apply to a namespace override customizations that
+%% apply to an Amazon Web Services account. To find out which customizations
+%% apply, use the `DescribeAccountCustomization' API operation.
 update_account_customization(Client, AwsAccountId, Input) ->
     update_account_customization(Client, AwsAccountId, Input, []).
 update_account_customization(Client, AwsAccountId, Input0, Options0) ->
@@ -2485,7 +2919,8 @@ update_account_customization(Client, AwsAccountId, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates the Amazon QuickSight settings in your AWS account.
+%% @doc Updates the Amazon QuickSight settings in your Amazon Web Services
+%% account.
 update_account_settings(Client, AwsAccountId, Input) ->
     update_account_settings(Client, AwsAccountId, Input, []).
 update_account_settings(Client, AwsAccountId, Input0, Options0) ->
@@ -2554,7 +2989,12 @@ update_analysis_permissions(Client, AnalysisId, AwsAccountId, Input0, Options0) 
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates a dashboard in an AWS account.
+%% @doc Updates a dashboard in an Amazon Web Services account.
+%%
+%% Updating a Dashboard creates a new dashboard version but does not
+%% immediately publish the new version. You can update the published version
+%% of a dashboard by using the `UpdateDashboardPublishedVersion' API
+%% operation.
 update_dashboard(Client, AwsAccountId, DashboardId, Input) ->
     update_dashboard(Client, AwsAccountId, DashboardId, Input, []).
 update_dashboard(Client, AwsAccountId, DashboardId, Input0, Options0) ->
@@ -2718,6 +3158,52 @@ update_data_source_permissions(Client, AwsAccountId, DataSourceId, Input0, Optio
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates the name of a folder.
+update_folder(Client, AwsAccountId, FolderId, Input) ->
+    update_folder(Client, AwsAccountId, FolderId, Input, []).
+update_folder(Client, AwsAccountId, FolderId, Input0, Options0) ->
+    Method = put,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates permissions of a folder.
+update_folder_permissions(Client, AwsAccountId, FolderId, Input) ->
+    update_folder_permissions(Client, AwsAccountId, FolderId, Input, []).
+update_folder_permissions(Client, AwsAccountId, FolderId, Input0, Options0) ->
+    Method = put,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/folders/", aws_util:encode_uri(FolderId), "/permissions"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Changes a group description.
 update_group(Client, AwsAccountId, GroupName, Namespace, Input) ->
     update_group(Client, AwsAccountId, GroupName, Namespace, Input, []).
@@ -2741,7 +3227,7 @@ update_group(Client, AwsAccountId, GroupName, Namespace, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Updates an existing IAM policy assignment.
+%% @doc Updates an existing IAMpolicy assignment.
 %%
 %% This operation updates only the optional parameter or parameters that are
 %% specified in the request. This overwrites all of the users included in
@@ -2751,6 +3237,29 @@ update_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace, In
 update_iam_policy_assignment(Client, AssignmentName, AwsAccountId, Namespace, Input0, Options0) ->
     Method = put,
     Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/namespaces/", aws_util:encode_uri(Namespace), "/iam-policy-assignments/", aws_util:encode_uri(AssignmentName), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates content and status of IP Rules.
+update_ip_restriction(Client, AwsAccountId, Input) ->
+    update_ip_restriction(Client, AwsAccountId, Input, []).
+update_ip_restriction(Client, AwsAccountId, Input0, Options0) ->
+    Method = post,
+    Path = ["/accounts/", aws_util:encode_uri(AwsAccountId), "/ip-restriction"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -3011,6 +3520,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -1,16 +1,23 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Use AWS Resource Access Manager to share AWS resources between AWS
-%% accounts.
+%% @doc This is the Resource Access Manager API Reference.
 %%
-%% To share a resource, you create a resource share, associate the resource
-%% with the resource share, and specify the principals that can access the
-%% resources associated with the resource share. The following principals are
-%% supported: AWS accounts, organizational units (OU) from AWS Organizations,
-%% and organizations from AWS Organizations.
+%% This documentation provides descriptions and syntax for each of the
+%% actions and data types in RAM. RAM is a service that helps you securely
+%% share your Amazon Web Services resources across Amazon Web Services
+%% accounts and within your organization or organizational units (OUs) in
+%% Organizations. For supported resource types, you can also share resources
+%% with IAM roles and IAM users. If you have multiple Amazon Web Services
+%% accounts, you can use RAM to share those resources with other accounts.
 %%
-%% For more information, see the AWS Resource Access Manager User Guide.
+%% To learn more about RAM, see the following resources:
+%%
+%% <ul> <li> Resource Access Manager product page
+%%
+%% </li> <li> Resource Access Manager User Guide
+%%
+%% </li> </ul>
 -module(aws_ram).
 
 -export([accept_resource_share_invitation/2,
@@ -68,7 +75,8 @@
 %% API
 %%====================================================================
 
-%% @doc Accepts an invitation to a resource share from another AWS account.
+%% @doc Accepts an invitation to a resource share from another Amazon Web
+%% Services account.
 accept_resource_share_invitation(Client, Input) ->
     accept_resource_share_invitation(Client, Input, []).
 accept_resource_share_invitation(Client, Input0, Options0) ->
@@ -139,6 +147,15 @@ associate_resource_share_permission(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a resource share.
+%%
+%% You must provide a list of the Amazon Resource Names (ARNs) for the
+%% resources you want to share. You must also specify who you want to share
+%% the resources with, and the permissions that you grant them.
+%%
+%% Sharing a resource makes it available for use by principals outside of the
+%% Amazon Web Services account that created the resource. Sharing doesn't
+%% change any permissions or quotas that apply to the resource in the account
+%% that created it.
 create_resource_share(Client, Input) ->
     create_resource_share(Client, Input, []).
 create_resource_share(Client, Input0, Options0) ->
@@ -210,7 +227,7 @@ disassociate_resource_share(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Disassociates an AWS RAM permission from a resource share.
+%% @doc Disassociates an RAM permission from a resource share.
 disassociate_resource_share_permission(Client, Input) ->
     disassociate_resource_share_permission(Client, Input, []).
 disassociate_resource_share_permission(Client, Input0, Options0) ->
@@ -233,9 +250,9 @@ disassociate_resource_share_permission(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Enables resource sharing within your AWS Organization.
+%% @doc Enables resource sharing within your organization in Organizations.
 %%
-%% The caller must be the master account for the AWS Organization.
+%% The caller must be the master account for the organization.
 enable_sharing_with_aws_organization(Client, Input) ->
     enable_sharing_with_aws_organization(Client, Input, []).
 enable_sharing_with_aws_organization(Client, Input0, Options0) ->
@@ -258,7 +275,7 @@ enable_sharing_with_aws_organization(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Gets the contents of an AWS RAM permission in JSON format.
+%% @doc Gets the contents of an RAM permission in JSON format.
 get_permission(Client, Input) ->
     get_permission(Client, Input, []).
 get_permission(Client, Input0, Options0) ->
@@ -329,7 +346,7 @@ get_resource_share_associations(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Gets the invitations for resource sharing that you've received.
+%% @doc Gets the invitations that you have received for resource shares.
 get_resource_share_invitations(Client, Input) ->
     get_resource_share_invitations(Client, Input, []).
 get_resource_share_invitations(Client, Input0, Options0) ->
@@ -400,7 +417,7 @@ list_pending_invitation_resources(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Lists the AWS RAM permissions.
+%% @doc Lists the RAM permissions.
 list_permissions(Client, Input) ->
     list_permissions(Client, Input, []).
 list_permissions(Client, Input0, Options0) ->
@@ -447,8 +464,7 @@ list_principals(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Lists the AWS RAM permissions that are associated with a resource
-%% share.
+%% @doc Lists the RAM permissions that are associated with a resource share.
 list_resource_share_permissions(Client, Input) ->
     list_resource_share_permissions(Client, Input, []).
 list_resource_share_permissions(Client, Input0, Options0) ->
@@ -471,7 +487,7 @@ list_resource_share_permissions(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Lists the shareable resource types supported by AWS RAM.
+%% @doc Lists the shareable resource types supported by RAM.
 list_resource_types(Client, Input) ->
     list_resource_types(Client, Input, []).
 list_resource_types(Client, Input0, Options0) ->
@@ -520,14 +536,14 @@ list_resources(Client, Input0, Options0) ->
 
 %% @doc Resource shares that were created by attaching a policy to a resource
 %% are visible only to the resource share owner, and the resource share
-%% cannot be modified in AWS RAM.
+%% cannot be modified in RAM.
 %%
 %% Use this API action to promote the resource share. When you promote the
 %% resource share, it becomes:
 %%
 %% <ul> <li> Visible to all principals that it is shared with.
 %%
-%% </li> <li> Modifiable in AWS RAM.
+%% </li> <li> Modifiable in RAM.
 %%
 %% </li> </ul>
 promote_resource_share_created_from_policy(Client, Input) ->
@@ -553,7 +569,8 @@ promote_resource_share_created_from_policy(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Rejects an invitation to a resource share from another AWS account.
+%% @doc Rejects an invitation to a resource share from another Amazon Web
+%% Services account.
 reject_resource_share_invitation(Client, Input) ->
     reject_resource_share_invitation(Client, Input, []).
 reject_resource_share_invitation(Client, Input0, Options0) ->
@@ -681,6 +698,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_rds.erl
+++ b/src/aws_rds.erl
@@ -81,6 +81,8 @@
          copy_option_group/3,
          create_custom_availability_zone/2,
          create_custom_availability_zone/3,
+         create_custom_db_engine_version/2,
+         create_custom_db_engine_version/3,
          create_db_cluster/2,
          create_db_cluster/3,
          create_db_cluster_endpoint/2,
@@ -97,6 +99,8 @@
          create_db_parameter_group/3,
          create_db_proxy/2,
          create_db_proxy/3,
+         create_db_proxy_endpoint/2,
+         create_db_proxy_endpoint/3,
          create_db_security_group/2,
          create_db_security_group/3,
          create_db_snapshot/2,
@@ -111,6 +115,8 @@
          create_option_group/3,
          delete_custom_availability_zone/2,
          delete_custom_availability_zone/3,
+         delete_custom_db_engine_version/2,
+         delete_custom_db_engine_version/3,
          delete_db_cluster/2,
          delete_db_cluster/3,
          delete_db_cluster_endpoint/2,
@@ -127,6 +133,8 @@
          delete_db_parameter_group/3,
          delete_db_proxy/2,
          delete_db_proxy/3,
+         delete_db_proxy_endpoint/2,
+         delete_db_proxy_endpoint/3,
          delete_db_security_group/2,
          delete_db_security_group/3,
          delete_db_snapshot/2,
@@ -177,6 +185,8 @@
          describe_db_parameters/3,
          describe_db_proxies/2,
          describe_db_proxies/3,
+         describe_db_proxy_endpoints/2,
+         describe_db_proxy_endpoints/3,
          describe_db_proxy_target_groups/2,
          describe_db_proxy_target_groups/3,
          describe_db_proxy_targets/2,
@@ -235,6 +245,8 @@
          modify_certificates/3,
          modify_current_db_cluster_capacity/2,
          modify_current_db_cluster_capacity/3,
+         modify_custom_db_engine_version/2,
+         modify_custom_db_engine_version/3,
          modify_db_cluster/2,
          modify_db_cluster/3,
          modify_db_cluster_endpoint/2,
@@ -249,6 +261,8 @@
          modify_db_parameter_group/3,
          modify_db_proxy/2,
          modify_db_proxy/3,
+         modify_db_proxy_endpoint/2,
+         modify_db_proxy_endpoint/3,
          modify_db_proxy_target_group/2,
          modify_db_proxy_target_group/3,
          modify_db_snapshot/2,
@@ -330,7 +344,8 @@
 %% Amazon Aurora DB cluster.
 %%
 %% For more information, see Authorizing Amazon Aurora MySQL to Access Other
-%% AWS Services on Your Behalf in the Amazon Aurora User Guide.
+%% Amazon Web Services Services on Your Behalf in the Amazon Aurora User
+%% Guide.
 %%
 %% This action only applies to Aurora DB clusters.
 add_role_to_db_cluster(Client, Input)
@@ -340,11 +355,13 @@ add_role_to_db_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AddRoleToDBCluster">>, Input, Options).
 
-%% @doc Associates an AWS Identity and Access Management (IAM) role with a DB
-%% instance.
+%% @doc Associates an Amazon Web Services Identity and Access Management
+%% (IAM) role with a DB instance.
 %%
 %% To add a role to a DB instance, the status of the DB instance must be
 %% `available'.
+%%
+%% This command doesn't apply to RDS Custom.
 add_role_to_db_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_role_to_db_instance(Client, Input, []).
@@ -395,9 +412,10 @@ apply_pending_maintenance_action(Client, Input, Options)
 %% CIDR range, EC2SecurityGroupId for VPC, or (EC2SecurityGroupOwnerId and
 %% either EC2SecurityGroupName or EC2SecurityGroupId for non-VPC).
 %%
-%% You can't authorize ingress from an EC2 security group in one AWS Region
-%% to an Amazon RDS DB instance in another. You can't authorize ingress from
-%% a VPC security group in one VPC to an Amazon RDS DB instance in another.
+%% You can't authorize ingress from an EC2 security group in one Amazon Web
+%% Services Region to an Amazon RDS DB instance in another. You can't
+%% authorize ingress from a VPC security group in one VPC to an Amazon RDS DB
+%% instance in another.
 %%
 %% For an overview of CIDR ranges, go to the Wikipedia Tutorial.
 authorize_db_security_group_ingress(Client, Input)
@@ -448,60 +466,65 @@ copy_db_cluster_parameter_group(Client, Input, Options)
 %% `SourceDBClusterSnapshotIdentifier' must be the Amazon Resource Name (ARN)
 %% of the shared DB cluster snapshot.
 %%
-%% You can copy an encrypted DB cluster snapshot from another AWS Region. In
-%% that case, the AWS Region where you call the `CopyDBClusterSnapshot'
-%% action is the destination AWS Region for the encrypted DB cluster snapshot
-%% to be copied to. To copy an encrypted DB cluster snapshot from another AWS
+%% You can copy an encrypted DB cluster snapshot from another Amazon Web
+%% Services Region. In that case, the Amazon Web Services Region where you
+%% call the `CopyDBClusterSnapshot' action is the destination Amazon Web
+%% Services Region for the encrypted DB cluster snapshot to be copied to. To
+%% copy an encrypted DB cluster snapshot from another Amazon Web Services
 %% Region, you must provide the following values:
 %%
-%% <ul> <li> `KmsKeyId' - The AWS Key Management System (AWS KMS) key
-%% identifier for the key to use to encrypt the copy of the DB cluster
-%% snapshot in the destination AWS Region.
+%% <ul> <li> `KmsKeyId' - The Amazon Web Services Key Management System
+%% (Amazon Web Services KMS) key identifier for the key to use to encrypt the
+%% copy of the DB cluster snapshot in the destination Amazon Web Services
+%% Region.
 %%
 %% </li> <li> `PreSignedUrl' - A URL that contains a Signature Version 4
 %% signed request for the `CopyDBClusterSnapshot' action to be called in the
-%% source AWS Region where the DB cluster snapshot is copied from. The
-%% pre-signed URL must be a valid request for the `CopyDBClusterSnapshot' API
-%% action that can be executed in the source AWS Region that contains the
-%% encrypted DB cluster snapshot to be copied.
+%% source Amazon Web Services Region where the DB cluster snapshot is copied
+%% from. The pre-signed URL must be a valid request for the
+%% `CopyDBClusterSnapshot' API action that can be executed in the source
+%% Amazon Web Services Region that contains the encrypted DB cluster snapshot
+%% to be copied.
 %%
 %% The pre-signed URL request must contain the following parameter values:
 %%
-%% <ul> <li> `KmsKeyId' - The AWS KMS key identifier for the customer master
-%% key (CMK) to use to encrypt the copy of the DB cluster snapshot in the
-%% destination AWS Region. This is the same identifier for both the
-%% `CopyDBClusterSnapshot' action that is called in the destination AWS
-%% Region, and the action contained in the pre-signed URL.
+%% <ul> <li> `KmsKeyId' - The Amazon Web Services KMS key identifier for the
+%% KMS key to use to encrypt the copy of the DB cluster snapshot in the
+%% destination Amazon Web Services Region. This is the same identifier for
+%% both the `CopyDBClusterSnapshot' action that is called in the destination
+%% Amazon Web Services Region, and the action contained in the pre-signed
+%% URL.
 %%
-%% </li> <li> `DestinationRegion' - The name of the AWS Region that the DB
-%% cluster snapshot is to be created in.
+%% </li> <li> `DestinationRegion' - The name of the Amazon Web Services
+%% Region that the DB cluster snapshot is to be created in.
 %%
 %% </li> <li> `SourceDBClusterSnapshotIdentifier' - The DB cluster snapshot
 %% identifier for the encrypted DB cluster snapshot to be copied. This
 %% identifier must be in the Amazon Resource Name (ARN) format for the source
-%% AWS Region. For example, if you are copying an encrypted DB cluster
-%% snapshot from the us-west-2 AWS Region, then your
-%% `SourceDBClusterSnapshotIdentifier' looks like the following example:
+%% Amazon Web Services Region. For example, if you are copying an encrypted
+%% DB cluster snapshot from the us-west-2 Amazon Web Services Region, then
+%% your `SourceDBClusterSnapshotIdentifier' looks like the following example:
 %% `arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115'.
 %%
 %% </li> </ul> To learn how to generate a Signature Version 4 signed request,
-%% see Authenticating Requests: Using Query Parameters (AWS Signature Version
-%% 4) and Signature Version 4 Signing Process.
+%% see Authenticating Requests: Using Query Parameters (Amazon Web Services
+%% Signature Version 4) and Signature Version 4 Signing Process.
 %%
-%% If you are using an AWS SDK tool or the AWS CLI, you can specify
-%% `SourceRegion' (or `--source-region' for the AWS CLI) instead of
+%% If you are using an Amazon Web Services SDK tool or the CLI, you can
+%% specify `SourceRegion' (or `--source-region' for the CLI) instead of
 %% specifying `PreSignedUrl' manually. Specifying `SourceRegion'
 %% autogenerates a pre-signed URL that is a valid request for the operation
-%% that can be executed in the source AWS Region.
+%% that can be executed in the source Amazon Web Services Region.
 %%
 %% </li> <li> `TargetDBClusterSnapshotIdentifier' - The identifier for the
-%% new copy of the DB cluster snapshot in the destination AWS Region.
+%% new copy of the DB cluster snapshot in the destination Amazon Web Services
+%% Region.
 %%
 %% </li> <li> `SourceDBClusterSnapshotIdentifier' - The DB cluster snapshot
 %% identifier for the encrypted DB cluster snapshot to be copied. This
-%% identifier must be in the ARN format for the source AWS Region and is the
-%% same value as the `SourceDBClusterSnapshotIdentifier' in the pre-signed
-%% URL.
+%% identifier must be in the ARN format for the source Amazon Web Services
+%% Region and is the same value as the `SourceDBClusterSnapshotIdentifier' in
+%% the pre-signed URL.
 %%
 %% </li> </ul> To cancel the copy operation once it is in progress, delete
 %% the target DB cluster snapshot identified by
@@ -509,8 +532,8 @@ copy_db_cluster_parameter_group(Client, Input, Options)
 %% "copying" status.
 %%
 %% For more information on copying encrypted DB cluster snapshots from one
-%% AWS Region to another, see Copying a Snapshot in the Amazon Aurora User
-%% Guide.
+%% Amazon Web Services Region to another, see Copying a Snapshot in the
+%% Amazon Aurora User Guide.
 %%
 %% For more information on Amazon Aurora, see What Is Amazon Aurora? in the
 %% Amazon Aurora User Guide.
@@ -535,9 +558,12 @@ copy_db_parameter_group(Client, Input, Options)
 %%
 %% The source DB snapshot must be in the `available' state.
 %%
-%% You can copy a snapshot from one AWS Region to another. In that case, the
-%% AWS Region where you call the `CopyDBSnapshot' action is the destination
-%% AWS Region for the DB snapshot copy.
+%% You can copy a snapshot from one Amazon Web Services Region to another. In
+%% that case, the Amazon Web Services Region where you call the
+%% `CopyDBSnapshot' action is the destination Amazon Web Services Region for
+%% the DB snapshot copy.
+%%
+%% This command doesn't apply to RDS Custom.
 %%
 %% For more information about copying snapshots, see Copying a DB Snapshot in
 %% the Amazon RDS User Guide.
@@ -570,13 +596,58 @@ create_custom_availability_zone(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateCustomAvailabilityZone">>, Input, Options).
 
+%% @doc Creates a custom DB engine version (CEV).
+%%
+%% A CEV is a binary volume snapshot of a database engine and specific AMI.
+%% The only supported engine is Oracle Database 19c Enterprise Edition with
+%% the January 2021 or later RU/RUR. For more information, see Amazon RDS
+%% Custom requirements and limitations in the Amazon RDS User Guide.
+%%
+%% Amazon RDS, which is a fully managed service, supplies the Amazon Machine
+%% Image (AMI) and database software. The Amazon RDS database software is
+%% preinstalled, so you need only select a DB engine and version, and create
+%% your database. With Amazon RDS Custom, you upload your database
+%% installation files in Amazon S3. For more information, see Preparing to
+%% create a CEV in the Amazon RDS User Guide.
+%%
+%% When you create a custom engine version, you specify the files in a JSON
+%% document called a CEV manifest. This document describes installation .zip
+%% files stored in Amazon S3. RDS Custom creates your CEV from the
+%% installation files that you provided. This service model is called Bring
+%% Your Own Media (BYOM).
+%%
+%% Creation takes approximately two hours. If creation fails, RDS Custom
+%% issues `RDS-EVENT-0196' with the message `Creation failed for custom
+%% engine version', and includes details about the failure. For example, the
+%% event prints missing files.
+%%
+%% After you create the CEV, it is available for use. You can create multiple
+%% CEVs, and create multiple RDS Custom instances from any CEV. You can also
+%% change the status of a CEV to make it available or inactive.
+%%
+%% The MediaImport service that imports files from Amazon S3 to create CEVs
+%% isn't integrated with Amazon Web Services CloudTrail. If you turn on data
+%% logging for Amazon RDS in CloudTrail, calls to the
+%% `CreateCustomDbEngineVersion' event aren't logged. However, you might see
+%% calls from the API gateway that accesses your Amazon S3 bucket. These
+%% calls originate from the MediaImport service for the
+%% `CreateCustomDbEngineVersion' event.
+%%
+%% For more information, see Creating a CEV in the Amazon RDS User Guide.
+create_custom_db_engine_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_custom_db_engine_version(Client, Input, []).
+create_custom_db_engine_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateCustomDBEngineVersion">>, Input, Options).
+
 %% @doc Creates a new Amazon Aurora DB cluster.
 %%
 %% You can use the `ReplicationSourceIdentifier' parameter to create the DB
-%% cluster as a read replica of another DB cluster or Amazon RDS MySQL DB
-%% instance. For cross-region replication where the DB cluster identified by
-%% `ReplicationSourceIdentifier' is encrypted, you must also specify the
-%% `PreSignedUrl' parameter.
+%% cluster as a read replica of another DB cluster or Amazon RDS MySQL or
+%% PostgreSQL DB instance. For cross-region replication where the DB cluster
+%% identified by `ReplicationSourceIdentifier' is encrypted, you must also
+%% specify the `PreSignedUrl' parameter.
 %%
 %% For more information on Amazon Aurora, see What Is Amazon Aurora? in the
 %% Amazon Aurora User Guide.
@@ -686,11 +757,13 @@ create_db_instance_read_replica(Client, Input, Options)
 %% A DB parameter group is initially created with the default parameters for
 %% the database engine used by the DB instance. To provide custom values for
 %% any of the parameters, you must modify the group after creating it using
-%% ModifyDBParameterGroup. Once you've created a DB parameter group, you need
-%% to associate it with your DB instance using ModifyDBInstance. When you
-%% associate a new DB parameter group with a running DB instance, you need to
-%% reboot the DB instance without failover for the new DB parameter group and
-%% associated settings to take effect.
+%% `ModifyDBParameterGroup'. Once you've created a DB parameter group, you
+%% need to associate it with your DB instance using `ModifyDBInstance'. When
+%% you associate a new DB parameter group with a running DB instance, you
+%% need to reboot the DB instance without failover for the new DB parameter
+%% group and associated settings to take effect.
+%%
+%% This command doesn't apply to RDS Custom.
 %%
 %% After you create a DB parameter group, you should wait at least 5 minutes
 %% before creating your first DB instance that uses that DB parameter group
@@ -716,6 +789,19 @@ create_db_proxy(Client, Input)
 create_db_proxy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateDBProxy">>, Input, Options).
+
+%% @doc Creates a `DBProxyEndpoint'.
+%%
+%% Only applies to proxies that are associated with Aurora DB clusters. You
+%% can use DB proxy endpoints to specify read/write or read-only access to
+%% the DB cluster. You can also use DB proxy endpoints to access a DB proxy
+%% through a different VPC than the proxy's default VPC.
+create_db_proxy_endpoint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_db_proxy_endpoint(Client, Input, []).
+create_db_proxy_endpoint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDBProxyEndpoint">>, Input, Options).
 
 %% @doc Creates a new DB security group.
 %%
@@ -744,7 +830,7 @@ create_db_snapshot(Client, Input, Options)
 %% @doc Creates a new DB subnet group.
 %%
 %% DB subnet groups must contain at least one subnet in at least two AZs in
-%% the AWS Region.
+%% the Amazon Web Services Region.
 create_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_db_subnet_group(Client, Input, []).
@@ -786,7 +872,8 @@ create_event_subscription(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateEventSubscription">>, Input, Options).
 
-%% @doc Creates an Aurora global database spread across multiple AWS Regions.
+%% @doc Creates an Aurora global database spread across multiple Amazon Web
+%% Services Regions.
 %%
 %% The global database contains a single primary cluster with read-write
 %% capability, and a read-only secondary cluster that receives data from the
@@ -809,6 +896,8 @@ create_global_cluster(Client, Input, Options)
 %% @doc Creates a new option group.
 %%
 %% You can create up to 20 option groups.
+%%
+%% This command doesn't apply to RDS Custom.
 create_option_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_option_group(Client, Input, []).
@@ -829,6 +918,35 @@ delete_custom_availability_zone(Client, Input)
 delete_custom_availability_zone(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteCustomAvailabilityZone">>, Input, Options).
+
+%% @doc Deletes a custom engine version.
+%%
+%% To run this command, make sure you meet the following prerequisites:
+%%
+%% <ul> <li> The CEV must not be the default for RDS Custom. If it is, change
+%% the default before running this command.
+%%
+%% </li> <li> The CEV must not be associated with an RDS Custom DB instance,
+%% RDS Custom instance snapshot, or automated backup of your RDS Custom
+%% instance.
+%%
+%% </li> </ul> Typically, deletion takes a few minutes.
+%%
+%% The MediaImport service that imports files from Amazon S3 to create CEVs
+%% isn't integrated with Amazon Web Services CloudTrail. If you turn on data
+%% logging for Amazon RDS in CloudTrail, calls to the
+%% `DeleteCustomDbEngineVersion' event aren't logged. However, you might see
+%% calls from the API gateway that accesses your Amazon S3 bucket. These
+%% calls originate from the MediaImport service for the
+%% `DeleteCustomDbEngineVersion' event.
+%%
+%% For more information, see Deleting a CEV in the Amazon RDS User Guide.
+delete_custom_db_engine_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_custom_db_engine_version(Client, Input, []).
+delete_custom_db_engine_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteCustomDBEngineVersion">>, Input, Options).
 
 %% @doc The DeleteDBCluster action deletes a previously provisioned DB
 %% cluster.
@@ -950,13 +1068,26 @@ delete_db_parameter_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteDBParameterGroup">>, Input, Options).
 
-%% @doc Deletes an existing proxy.
+%% @doc Deletes an existing DB proxy.
 delete_db_proxy(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_db_proxy(Client, Input, []).
 delete_db_proxy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteDBProxy">>, Input, Options).
+
+%% @doc Deletes a `DBProxyEndpoint'.
+%%
+%% Doing so removes the ability to access the DB proxy using the endpoint
+%% that you defined. The endpoint that you delete might have provided
+%% capabilities such as read/write or read-only operations, or using a
+%% different VPC than the DB proxy's default VPC.
+delete_db_proxy_endpoint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_db_proxy_endpoint(Client, Input, []).
+delete_db_proxy_endpoint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteDBProxyEndpoint">>, Input, Options).
 
 %% @doc Deletes a DB security group.
 %%
@@ -1054,8 +1185,8 @@ describe_account_attributes(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAccountAttributes">>, Input, Options).
 
-%% @doc Lists the set of CA certificates provided by Amazon RDS for this AWS
-%% account.
+%% @doc Lists the set of CA certificates provided by Amazon RDS for this
+%% Amazon Web Services account.
 describe_certificates(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_certificates(Client, Input, []).
@@ -1133,16 +1264,18 @@ describe_db_cluster_parameters(Client, Input, Options)
 %% @doc Returns a list of DB cluster snapshot attribute names and values for
 %% a manual DB cluster snapshot.
 %%
-%% When sharing snapshots with other AWS accounts,
+%% When sharing snapshots with other Amazon Web Services accounts,
 %% `DescribeDBClusterSnapshotAttributes' returns the `restore' attribute and
-%% a list of IDs for the AWS accounts that are authorized to copy or restore
-%% the manual DB cluster snapshot. If `all' is included in the list of values
-%% for the `restore' attribute, then the manual DB cluster snapshot is public
-%% and can be copied or restored by all AWS accounts.
+%% a list of IDs for the Amazon Web Services accounts that are authorized to
+%% copy or restore the manual DB cluster snapshot. If `all' is included in
+%% the list of values for the `restore' attribute, then the manual DB cluster
+%% snapshot is public and can be copied or restored by all Amazon Web
+%% Services accounts.
 %%
-%% To add or remove access for an AWS account to copy or restore a manual DB
-%% cluster snapshot, or to make the manual DB cluster snapshot public or
-%% private, use the `ModifyDBClusterSnapshotAttribute' API action.
+%% To add or remove access for an Amazon Web Services account to copy or
+%% restore a manual DB cluster snapshot, or to make the manual DB cluster
+%% snapshot public or private, use the `ModifyDBClusterSnapshotAttribute' API
+%% action.
 %%
 %% This action only applies to Aurora DB clusters.
 describe_db_cluster_snapshot_attributes(Client, Input)
@@ -1220,6 +1353,8 @@ describe_db_instances(Client, Input, Options)
     request(Client, <<"DescribeDBInstances">>, Input, Options).
 
 %% @doc Returns a list of DB log files for the DB instance.
+%%
+%% This command doesn't apply to RDS Custom.
 describe_db_log_files(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_db_log_files(Client, Input, []).
@@ -1255,6 +1390,14 @@ describe_db_proxies(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDBProxies">>, Input, Options).
 
+%% @doc Returns information about DB proxy endpoints.
+describe_db_proxy_endpoints(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_db_proxy_endpoints(Client, Input, []).
+describe_db_proxy_endpoints(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDBProxyEndpoints">>, Input, Options).
+
 %% @doc Returns information about DB proxy target groups, represented by
 %% `DBProxyTargetGroup' data structures.
 describe_db_proxy_target_groups(Client, Input)
@@ -1288,16 +1431,16 @@ describe_db_security_groups(Client, Input, Options)
 %% @doc Returns a list of DB snapshot attribute names and values for a manual
 %% DB snapshot.
 %%
-%% When sharing snapshots with other AWS accounts,
+%% When sharing snapshots with other Amazon Web Services accounts,
 %% `DescribeDBSnapshotAttributes' returns the `restore' attribute and a list
-%% of IDs for the AWS accounts that are authorized to copy or restore the
-%% manual DB snapshot. If `all' is included in the list of values for the
-%% `restore' attribute, then the manual DB snapshot is public and can be
-%% copied or restored by all AWS accounts.
+%% of IDs for the Amazon Web Services accounts that are authorized to copy or
+%% restore the manual DB snapshot. If `all' is included in the list of values
+%% for the `restore' attribute, then the manual DB snapshot is public and can
+%% be copied or restored by all Amazon Web Services accounts.
 %%
-%% To add or remove access for an AWS account to copy or restore a manual DB
-%% snapshot, or to make the manual DB snapshot public or private, use the
-%% `ModifyDBSnapshotAttribute' API action.
+%% To add or remove access for an Amazon Web Services account to copy or
+%% restore a manual DB snapshot, or to make the manual DB snapshot public or
+%% private, use the `ModifyDBSnapshotAttribute' API action.
 describe_db_snapshot_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_db_snapshot_attributes(Client, Input, []).
@@ -1478,9 +1621,9 @@ describe_reserved_db_instances_offerings(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeReservedDBInstancesOfferings">>, Input, Options).
 
-%% @doc Returns a list of the source AWS Regions where the current AWS Region
-%% can create a read replica, copy a DB snapshot from, or replicate automated
-%% backups from.
+%% @doc Returns a list of the source Amazon Web Services Regions where the
+%% current Amazon Web Services Region can create a read replica, copy a DB
+%% snapshot from, or replicate automated backups from.
 %%
 %% This API action supports pagination.
 describe_source_regions(Client, Input)
@@ -1494,6 +1637,8 @@ describe_source_regions(Client, Input, Options)
 %% modifications you can make to your DB instance.
 %%
 %% You can use this information when you call `ModifyDBInstance'.
+%%
+%% This command doesn't apply to RDS Custom.
 describe_valid_db_instance_modifications(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_valid_db_instance_modifications(Client, Input, []).
@@ -1503,6 +1648,8 @@ describe_valid_db_instance_modifications(Client, Input, Options)
 
 %% @doc Downloads all or a portion of the specified log file, up to 1 MB in
 %% size.
+%%
+%% This command doesn't apply to RDS Custom.
 download_db_log_file_portion(Client, Input)
   when is_map(Client), is_map(Input) ->
     download_db_log_file_portion(Client, Input, []).
@@ -1594,12 +1741,13 @@ list_tags_for_resource(Client, Input, Options)
 %%
 %% <ul> <li> You already migrated your applications to support the latest
 %% certificate authority (CA) certificate, but the new CA certificate is not
-%% yet the RDS default CA certificate for the specified AWS Region.
+%% yet the RDS default CA certificate for the specified Amazon Web Services
+%% Region.
 %%
 %% </li> <li> RDS has already moved to a new default CA certificate for the
-%% specified AWS Region, but you are still in the process of supporting the
-%% new CA certificate. In this case, you temporarily need additional time to
-%% finish your application changes.
+%% specified Amazon Web Services Region, but you are still in the process of
+%% supporting the new CA certificate. In this case, you temporarily need
+%% additional time to finish your application changes.
 %%
 %% </li> </ul> For more information about rotating your SSL/TLS certificate
 %% for RDS DB engines, see Rotating Your SSL/TLS Certificate in the Amazon
@@ -1635,13 +1783,34 @@ modify_certificates(Client, Input, Options)
 %% scaling point might be dropped. For more information about scaling points,
 %% see Autoscaling for Aurora Serverless in the Amazon Aurora User Guide.
 %%
-%% This action only applies to Aurora DB clusters.
+%% This action only applies to Aurora Serverless DB clusters.
 modify_current_db_cluster_capacity(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_current_db_cluster_capacity(Client, Input, []).
 modify_current_db_cluster_capacity(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyCurrentDBClusterCapacity">>, Input, Options).
+
+%% @doc Modifies the status of a custom engine version (CEV).
+%%
+%% You can find CEVs to modify by calling `DescribeDBEngineVersions'.
+%%
+%% The MediaImport service that imports files from Amazon S3 to create CEVs
+%% isn't integrated with Amazon Web Services CloudTrail. If you turn on data
+%% logging for Amazon RDS in CloudTrail, calls to the
+%% `ModifyCustomDbEngineVersion' event aren't logged. However, you might see
+%% calls from the API gateway that accesses your Amazon S3 bucket. These
+%% calls originate from the MediaImport service for the
+%% `ModifyCustomDbEngineVersion' event.
+%%
+%% For more information, see Modifying CEV status in the Amazon RDS User
+%% Guide.
+modify_custom_db_engine_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_custom_db_engine_version(Client, Input, []).
+modify_custom_db_engine_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyCustomDBEngineVersion">>, Input, Options).
 
 %% @doc Modify a setting for an Amazon Aurora DB cluster.
 %%
@@ -1678,10 +1847,6 @@ modify_db_cluster_endpoint(Client, Input, Options)
 %% For more information on Amazon Aurora, see What Is Amazon Aurora? in the
 %% Amazon Aurora User Guide.
 %%
-%% Changes to dynamic parameters are applied immediately. Changes to static
-%% parameters require a reboot without failover to the DB cluster associated
-%% with the parameter group before the change can take effect.
-%%
 %% After you create a DB cluster parameter group, you should wait at least 5
 %% minutes before creating your first DB cluster that uses that DB cluster
 %% parameter group as the default parameter group. This allows Amazon RDS to
@@ -1711,24 +1876,27 @@ modify_db_cluster_parameter_group(Client, Input, Options)
 %% @doc Adds an attribute and values to, or removes an attribute and values
 %% from, a manual DB cluster snapshot.
 %%
-%% To share a manual DB cluster snapshot with other AWS accounts, specify
-%% `restore' as the `AttributeName' and use the `ValuesToAdd' parameter to
-%% add a list of IDs of the AWS accounts that are authorized to restore the
-%% manual DB cluster snapshot. Use the value `all' to make the manual DB
-%% cluster snapshot public, which means that it can be copied or restored by
-%% all AWS accounts.
+%% To share a manual DB cluster snapshot with other Amazon Web Services
+%% accounts, specify `restore' as the `AttributeName' and use the
+%% `ValuesToAdd' parameter to add a list of IDs of the Amazon Web Services
+%% accounts that are authorized to restore the manual DB cluster snapshot.
+%% Use the value `all' to make the manual DB cluster snapshot public, which
+%% means that it can be copied or restored by all Amazon Web Services
+%% accounts.
 %%
 %% Don't add the `all' value for any manual DB cluster snapshots that contain
-%% private information that you don't want available to all AWS accounts.
+%% private information that you don't want available to all Amazon Web
+%% Services accounts.
 %%
 %% If a manual DB cluster snapshot is encrypted, it can be shared, but only
-%% by specifying a list of authorized AWS account IDs for the `ValuesToAdd'
-%% parameter. You can't use `all' as a value for that parameter in this case.
+%% by specifying a list of authorized Amazon Web Services account IDs for the
+%% `ValuesToAdd' parameter. You can't use `all' as a value for that parameter
+%% in this case.
 %%
-%% To view which AWS accounts have access to copy or restore a manual DB
-%% cluster snapshot, or whether a manual DB cluster snapshot is public or
-%% private, use the `DescribeDBClusterSnapshotAttributes' API action. The
-%% accounts are returned as values for the `restore' attribute.
+%% To view which Amazon Web Services accounts have access to copy or restore
+%% a manual DB cluster snapshot, or whether a manual DB cluster snapshot is
+%% public or private, use the `DescribeDBClusterSnapshotAttributes' API
+%% action. The accounts are returned as values for the `restore' attribute.
 %%
 %% This action only applies to Aurora DB clusters.
 modify_db_cluster_snapshot_attribute(Client, Input)
@@ -1757,10 +1925,6 @@ modify_db_instance(Client, Input, Options)
 %% `ParameterName', `ParameterValue', and `ApplyMethod'. A maximum of 20
 %% parameters can be modified in a single request.
 %%
-%% Changes to dynamic parameters are applied immediately. Changes to static
-%% parameters require a reboot without failover to the DB instance associated
-%% with the parameter group before the change can take effect.
-%%
 %% After you modify a DB parameter group, you should wait at least 5 minutes
 %% before creating your first DB instance that uses that DB parameter group
 %% as the default parameter group. This allows Amazon RDS to fully complete
@@ -1786,6 +1950,14 @@ modify_db_proxy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyDBProxy">>, Input, Options).
 
+%% @doc Changes the settings for an existing DB proxy endpoint.
+modify_db_proxy_endpoint(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_db_proxy_endpoint(Client, Input, []).
+modify_db_proxy_endpoint(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyDBProxyEndpoint">>, Input, Options).
+
 %% @doc Modifies the properties of a `DBProxyTargetGroup'.
 modify_db_proxy_target_group(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1798,8 +1970,8 @@ modify_db_proxy_target_group(Client, Input, Options)
 %%
 %% The snapshot can be encrypted or unencrypted, but not shared or public.
 %%
-%% Amazon RDS supports upgrading DB snapshots for MySQL, Oracle, and
-%% PostgreSQL.
+%% Amazon RDS supports upgrading DB snapshots for MySQL, PostgreSQL, and
+%% Oracle. This command doesn't apply to RDS Custom.
 modify_db_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_snapshot(Client, Input, []).
@@ -1810,23 +1982,26 @@ modify_db_snapshot(Client, Input, Options)
 %% @doc Adds an attribute and values to, or removes an attribute and values
 %% from, a manual DB snapshot.
 %%
-%% To share a manual DB snapshot with other AWS accounts, specify `restore'
-%% as the `AttributeName' and use the `ValuesToAdd' parameter to add a list
-%% of IDs of the AWS accounts that are authorized to restore the manual DB
-%% snapshot. Uses the value `all' to make the manual DB snapshot public,
-%% which means it can be copied or restored by all AWS accounts.
+%% To share a manual DB snapshot with other Amazon Web Services accounts,
+%% specify `restore' as the `AttributeName' and use the `ValuesToAdd'
+%% parameter to add a list of IDs of the Amazon Web Services accounts that
+%% are authorized to restore the manual DB snapshot. Uses the value `all' to
+%% make the manual DB snapshot public, which means it can be copied or
+%% restored by all Amazon Web Services accounts.
 %%
 %% Don't add the `all' value for any manual DB snapshots that contain private
-%% information that you don't want available to all AWS accounts.
+%% information that you don't want available to all Amazon Web Services
+%% accounts.
 %%
 %% If the manual DB snapshot is encrypted, it can be shared, but only by
-%% specifying a list of authorized AWS account IDs for the `ValuesToAdd'
-%% parameter. You can't use `all' as a value for that parameter in this case.
+%% specifying a list of authorized Amazon Web Services account IDs for the
+%% `ValuesToAdd' parameter. You can't use `all' as a value for that parameter
+%% in this case.
 %%
-%% To view which AWS accounts have access to copy or restore a manual DB
-%% snapshot, or whether a manual DB snapshot public or private, use the
-%% `DescribeDBSnapshotAttributes' API action. The accounts are returned as
-%% values for the `restore' attribute.
+%% To view which Amazon Web Services accounts have access to copy or restore
+%% a manual DB snapshot, or whether a manual DB snapshot public or private,
+%% use the `DescribeDBSnapshotAttributes' API action. The accounts are
+%% returned as values for the `restore' attribute.
 modify_db_snapshot_attribute(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_snapshot_attribute(Client, Input, []).
@@ -1837,7 +2012,7 @@ modify_db_snapshot_attribute(Client, Input, Options)
 %% @doc Modifies an existing DB subnet group.
 %%
 %% DB subnet groups must contain at least one subnet in at least two AZs in
-%% the AWS Region.
+%% the Amazon Web Services Region.
 modify_db_subnet_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_db_subnet_group(Client, Input, []).
@@ -1896,7 +2071,8 @@ modify_option_group(Client, Input, Options)
 %% backup window so that daily backups do not interfere with read replica
 %% promotion.
 %%
-%% This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.
+%% This command doesn't apply to Aurora MySQL, Aurora PostgreSQL, or RDS
+%% Custom.
 promote_read_replica(Client, Input)
   when is_map(Client), is_map(Input) ->
     promote_read_replica(Client, Input, []).
@@ -1935,6 +2111,8 @@ purchase_reserved_db_instances_offering(Client, Input, Options)
 %%
 %% For more information about rebooting, see Rebooting a DB Instance in the
 %% Amazon RDS User Guide.
+%%
+%% This command doesn't apply to RDS Custom.
 reboot_db_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     reboot_db_instance(Client, Input, []).
@@ -1966,11 +2144,12 @@ remove_from_global_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveFromGlobalCluster">>, Input, Options).
 
-%% @doc Disassociates an AWS Identity and Access Management (IAM) role from
-%% an Amazon Aurora DB cluster.
+%% @doc Disassociates an Amazon Web Services Identity and Access Management
+%% (IAM) role from an Amazon Aurora DB cluster.
 %%
 %% For more information, see Authorizing Amazon Aurora MySQL to Access Other
-%% AWS Services on Your Behalf in the Amazon Aurora User Guide.
+%% Amazon Web Services Services on Your Behalf in the Amazon Aurora User
+%% Guide.
 %%
 %% This action only applies to Aurora DB clusters.
 remove_role_from_db_cluster(Client, Input)
@@ -1980,8 +2159,8 @@ remove_role_from_db_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveRoleFromDBCluster">>, Input, Options).
 
-%% @doc Disassociates an AWS Identity and Access Management (IAM) role from a
-%% DB instance.
+%% @doc Disassociates an Amazon Web Services Identity and Access Management
+%% (IAM) role from a DB instance.
 remove_role_from_db_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     remove_role_from_db_instance(Client, Input, []).
@@ -2168,6 +2347,8 @@ restore_db_instance_from_db_snapshot(Client, Input, Options)
 %% a new Amazon RDS DB instance running MySQL. For more information, see
 %% Importing Data into an Amazon RDS MySQL DB Instance in the Amazon RDS User
 %% Guide.
+%%
+%% This command doesn't apply to RDS Custom.
 restore_db_instance_from_s3(Client, Input)
   when is_map(Client), is_map(Input) ->
     restore_db_instance_from_s3(Client, Input, []).
@@ -2199,7 +2380,7 @@ restore_db_instance_to_point_in_time(Client, Input, Options)
     request(Client, <<"RestoreDBInstanceToPointInTime">>, Input, Options).
 
 %% @doc Revokes ingress from a DBSecurityGroup for previously authorized IP
-%% ranges or EC2 or VPC Security Groups.
+%% ranges or EC2 or VPC security groups.
 %%
 %% Required parameters for this API are one of CIDRIP, EC2SecurityGroupId for
 %% VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or
@@ -2223,8 +2404,9 @@ start_activity_stream(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartActivityStream">>, Input, Options).
 
-%% @doc Starts an Amazon Aurora DB cluster that was stopped using the AWS
-%% console, the stop-db-cluster AWS CLI command, or the StopDBCluster action.
+%% @doc Starts an Amazon Aurora DB cluster that was stopped using the Amazon
+%% Web Services console, the stop-db-cluster CLI command, or the
+%% StopDBCluster action.
 %%
 %% For more information, see Stopping and Starting an Aurora Cluster in the
 %% Amazon Aurora User Guide.
@@ -2237,15 +2419,15 @@ start_db_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartDBCluster">>, Input, Options).
 
-%% @doc Starts an Amazon RDS DB instance that was stopped using the AWS
-%% console, the stop-db-instance AWS CLI command, or the StopDBInstance
-%% action.
+%% @doc Starts an Amazon RDS DB instance that was stopped using the Amazon
+%% Web Services console, the stop-db-instance CLI command, or the
+%% StopDBInstance action.
 %%
 %% For more information, see Starting an Amazon RDS DB instance That Was
 %% Previously Stopped in the Amazon RDS User Guide.
 %%
-%% This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For
-%% Aurora DB clusters, use `StartDBCluster' instead.
+%% This command doesn't apply to RDS Custom, Aurora MySQL, and Aurora
+%% PostgreSQL. For Aurora DB clusters, use `StartDBCluster' instead.
 start_db_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_db_instance(Client, Input, []).
@@ -2253,10 +2435,13 @@ start_db_instance(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartDBInstance">>, Input, Options).
 
-%% @doc Enables replication of automated backups to a different AWS Region.
+%% @doc Enables replication of automated backups to a different Amazon Web
+%% Services Region.
 %%
-%% For more information, see Replicating Automated Backups to Another AWS
-%% Region in the Amazon RDS User Guide.
+%% This command doesn't apply to RDS Custom.
+%%
+%% For more information, see Replicating Automated Backups to Another Amazon
+%% Web Services Region in the Amazon RDS User Guide.
 start_db_instance_automated_backups_replication(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_db_instance_automated_backups_replication(Client, Input, []).
@@ -2267,6 +2452,8 @@ start_db_instance_automated_backups_replication(Client, Input, Options)
 %% @doc Starts an export of a snapshot to Amazon S3.
 %%
 %% The provided IAM role must have access to the S3 bucket.
+%%
+%% This command doesn't apply to RDS Custom.
 start_export_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_export_task(Client, Input, []).
@@ -2274,8 +2461,8 @@ start_export_task(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartExportTask">>, Input, Options).
 
-%% @doc Stops a database activity stream that was started using the AWS
-%% console, the `start-activity-stream' AWS CLI command, or the
+%% @doc Stops a database activity stream that was started using the Amazon
+%% Web Services console, the `start-activity-stream' CLI command, or the
 %% `StartActivityStream' action.
 %%
 %% For more information, see Database Activity Streams in the Amazon Aurora
@@ -2314,8 +2501,8 @@ stop_db_cluster(Client, Input, Options)
 %% For more information, see Stopping an Amazon RDS DB Instance Temporarily
 %% in the Amazon RDS User Guide.
 %%
-%% This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For
-%% Aurora clusters, use `StopDBCluster' instead.
+%% This command doesn't apply to RDS Custom, Aurora MySQL, and Aurora
+%% PostgreSQL. For Aurora clusters, use `StopDBCluster' instead.
 stop_db_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_db_instance(Client, Input, []).
@@ -2325,8 +2512,10 @@ stop_db_instance(Client, Input, Options)
 
 %% @doc Stops automated backup replication for a DB instance.
 %%
-%% For more information, see Replicating Automated Backups to Another AWS
-%% Region in the Amazon RDS User Guide.
+%% This command doesn't apply to RDS Custom.
+%%
+%% For more information, see Replicating Automated Backups to Another Amazon
+%% Web Services Region in the Amazon RDS User Guide.
 stop_db_instance_automated_backups_replication(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_db_instance_automated_backups_replication(Client, Input, []).

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -235,6 +235,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_redshift.erl
+++ b/src/aws_redshift.erl
@@ -33,8 +33,16 @@
 
 -export([accept_reserved_node_exchange/2,
          accept_reserved_node_exchange/3,
+         add_partner/2,
+         add_partner/3,
+         associate_data_share_consumer/2,
+         associate_data_share_consumer/3,
          authorize_cluster_security_group_ingress/2,
          authorize_cluster_security_group_ingress/3,
+         authorize_data_share/2,
+         authorize_data_share/3,
+         authorize_endpoint_access/2,
+         authorize_endpoint_access/3,
          authorize_snapshot_access/2,
          authorize_snapshot_access/3,
          batch_delete_cluster_snapshots/2,
@@ -45,6 +53,8 @@
          cancel_resize/3,
          copy_cluster_snapshot/2,
          copy_cluster_snapshot/3,
+         create_authentication_profile/2,
+         create_authentication_profile/3,
          create_cluster/2,
          create_cluster/3,
          create_cluster_parameter_group/2,
@@ -55,6 +65,8 @@
          create_cluster_snapshot/3,
          create_cluster_subnet_group/2,
          create_cluster_subnet_group/3,
+         create_endpoint_access/2,
+         create_endpoint_access/3,
          create_event_subscription/2,
          create_event_subscription/3,
          create_hsm_client_certificate/2,
@@ -71,6 +83,10 @@
          create_tags/3,
          create_usage_limit/2,
          create_usage_limit/3,
+         deauthorize_data_share/2,
+         deauthorize_data_share/3,
+         delete_authentication_profile/2,
+         delete_authentication_profile/3,
          delete_cluster/2,
          delete_cluster/3,
          delete_cluster_parameter_group/2,
@@ -81,12 +97,16 @@
          delete_cluster_snapshot/3,
          delete_cluster_subnet_group/2,
          delete_cluster_subnet_group/3,
+         delete_endpoint_access/2,
+         delete_endpoint_access/3,
          delete_event_subscription/2,
          delete_event_subscription/3,
          delete_hsm_client_certificate/2,
          delete_hsm_client_certificate/3,
          delete_hsm_configuration/2,
          delete_hsm_configuration/3,
+         delete_partner/2,
+         delete_partner/3,
          delete_scheduled_action/2,
          delete_scheduled_action/3,
          delete_snapshot_copy_grant/2,
@@ -99,6 +119,8 @@
          delete_usage_limit/3,
          describe_account_attributes/2,
          describe_account_attributes/3,
+         describe_authentication_profiles/2,
+         describe_authentication_profiles/3,
          describe_cluster_db_revisions/2,
          describe_cluster_db_revisions/3,
          describe_cluster_parameter_groups/2,
@@ -117,8 +139,18 @@
          describe_cluster_versions/3,
          describe_clusters/2,
          describe_clusters/3,
+         describe_data_shares/2,
+         describe_data_shares/3,
+         describe_data_shares_for_consumer/2,
+         describe_data_shares_for_consumer/3,
+         describe_data_shares_for_producer/2,
+         describe_data_shares_for_producer/3,
          describe_default_cluster_parameters/2,
          describe_default_cluster_parameters/3,
+         describe_endpoint_access/2,
+         describe_endpoint_access/3,
+         describe_endpoint_authorization/2,
+         describe_endpoint_authorization/3,
          describe_event_categories/2,
          describe_event_categories/3,
          describe_event_subscriptions/2,
@@ -135,6 +167,8 @@
          describe_node_configuration_options/3,
          describe_orderable_cluster_options/2,
          describe_orderable_cluster_options/3,
+         describe_partners/2,
+         describe_partners/3,
          describe_reserved_node_offerings/2,
          describe_reserved_node_offerings/3,
          describe_reserved_nodes/2,
@@ -159,6 +193,8 @@
          disable_logging/3,
          disable_snapshot_copy/2,
          disable_snapshot_copy/3,
+         disassociate_data_share_consumer/2,
+         disassociate_data_share_consumer/3,
          enable_logging/2,
          enable_logging/3,
          enable_snapshot_copy/2,
@@ -167,6 +203,10 @@
          get_cluster_credentials/3,
          get_reserved_node_exchange_offerings/2,
          get_reserved_node_exchange_offerings/3,
+         modify_aqua_configuration/2,
+         modify_aqua_configuration/3,
+         modify_authentication_profile/2,
+         modify_authentication_profile/3,
          modify_cluster/2,
          modify_cluster/3,
          modify_cluster_db_revision/2,
@@ -183,6 +223,8 @@
          modify_cluster_snapshot_schedule/3,
          modify_cluster_subnet_group/2,
          modify_cluster_subnet_group/3,
+         modify_endpoint_access/2,
+         modify_endpoint_access/3,
          modify_event_subscription/2,
          modify_event_subscription/3,
          modify_scheduled_action/2,
@@ -199,6 +241,8 @@
          purchase_reserved_node_offering/3,
          reboot_cluster/2,
          reboot_cluster/3,
+         reject_data_share/2,
+         reject_data_share/3,
          reset_cluster_parameter_group/2,
          reset_cluster_parameter_group/3,
          resize_cluster/2,
@@ -211,10 +255,14 @@
          resume_cluster/3,
          revoke_cluster_security_group_ingress/2,
          revoke_cluster_security_group_ingress/3,
+         revoke_endpoint_access/2,
+         revoke_endpoint_access/3,
          revoke_snapshot_access/2,
          revoke_snapshot_access/3,
          rotate_encryption_key/2,
-         rotate_encryption_key/3]).
+         rotate_encryption_key/3,
+         update_partner_status/2,
+         update_partner_status/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -232,6 +280,29 @@ accept_reserved_node_exchange(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AcceptReservedNodeExchange">>, Input, Options).
 
+%% @doc Adds a partner integration to a cluster.
+%%
+%% This operation authorizes a partner to push status updates for the
+%% specified database. To complete the integration, you also set up the
+%% integration on the partner website.
+add_partner(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    add_partner(Client, Input, []).
+add_partner(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AddPartner">>, Input, Options).
+
+%% @doc From a datashare consumer account, associates a datashare with the
+%% account (AssociateEntireAccount) or the specified namespace (ConsumerArn).
+%%
+%% If you make this association, the consumer can consume the datashare.
+associate_data_share_consumer(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    associate_data_share_consumer(Client, Input, []).
+associate_data_share_consumer(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AssociateDataShareConsumer">>, Input, Options).
+
 %% @doc Adds an inbound (ingress) rule to an Amazon Redshift security group.
 %%
 %% Depending on whether the application accessing your cluster is running on
@@ -242,7 +313,8 @@ accept_reserved_node_exchange(Client, Input, Options)
 %%
 %% If you authorize access to an Amazon EC2 security group, specify
 %% EC2SecurityGroupName and EC2SecurityGroupOwnerId. The Amazon EC2 security
-%% group and Amazon Redshift cluster must be in the same AWS Region.
+%% group and Amazon Redshift cluster must be in the same Amazon Web Services
+%% Region.
 %%
 %% If you authorize access to a CIDR/IP address range, specify CIDRIP. For an
 %% overview of CIDR blocks, see the Wikipedia article on Classless
@@ -260,7 +332,27 @@ authorize_cluster_security_group_ingress(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AuthorizeClusterSecurityGroupIngress">>, Input, Options).
 
-%% @doc Authorizes the specified AWS customer account to restore the
+%% @doc From a data producer account, authorizes the sharing of a datashare
+%% with one or more consumer accounts.
+%%
+%% To authorize a datashare for a data consumer, the producer account must
+%% have the correct access privileges.
+authorize_data_share(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    authorize_data_share(Client, Input, []).
+authorize_data_share(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AuthorizeDataShare">>, Input, Options).
+
+%% @doc Grants access to a cluster.
+authorize_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    authorize_endpoint_access(Client, Input, []).
+authorize_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AuthorizeEndpointAccess">>, Input, Options).
+
+%% @doc Authorizes the specified Amazon Web Services account to restore the
 %% specified snapshot.
 %%
 %% For more information about working with snapshots, go to Amazon Redshift
@@ -316,6 +408,14 @@ copy_cluster_snapshot(Client, Input)
 copy_cluster_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CopyClusterSnapshot">>, Input, Options).
+
+%% @doc Creates an authentication profile with the specified parameters.
+create_authentication_profile(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_authentication_profile(Client, Input, []).
+create_authentication_profile(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateAuthenticationProfile">>, Input, Options).
 
 %% @doc Creates a new cluster with the specified parameters.
 %%
@@ -390,6 +490,14 @@ create_cluster_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateClusterSubnetGroup">>, Input, Options).
 
+%% @doc Creates a Redshift-managed VPC endpoint.
+create_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_endpoint_access(Client, Input, []).
+create_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateEndpointAccess">>, Input, Options).
+
 %% @doc Creates an Amazon Redshift event notification subscription.
 %%
 %% This action requires an ARN (Amazon Resource Name) of an Amazon SNS topic
@@ -410,11 +518,11 @@ create_cluster_subnet_group(Client, Input, Options)
 %% cluster and source identifier = my-cluster-1, notifications will be sent
 %% for all the cluster events for my-cluster-1. If you specify a source type
 %% but do not specify a source identifier, you will receive notice of the
-%% events for the objects of that type in your AWS account. If you do not
-%% specify either the SourceType nor the SourceIdentifier, you will be
-%% notified of events generated from all Amazon Redshift sources belonging to
-%% your AWS account. You must specify a source type if you specify a source
-%% ID.
+%% events for the objects of that type in your Amazon Web Services account.
+%% If you do not specify either the SourceType nor the SourceIdentifier, you
+%% will be notified of events generated from all Amazon Redshift sources
+%% belonging to your Amazon Web Services account. You must specify a source
+%% type if you specify a source ID.
 create_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_event_subscription(Client, Input, []).
@@ -469,8 +577,8 @@ create_scheduled_action(Client, Input, Options)
     request(Client, <<"CreateScheduledAction">>, Input, Options).
 
 %% @doc Creates a snapshot copy grant that permits Amazon Redshift to use a
-%% customer master key (CMK) from AWS Key Management Service (AWS KMS) to
-%% encrypt copied snapshots in a destination region.
+%% customer master key (CMK) from Key Management Service (KMS) to encrypt
+%% copied snapshots in a destination region.
 %%
 %% For more information about managing snapshot copy grants, go to Amazon
 %% Redshift Database Encryption in the Amazon Redshift Cluster Management
@@ -515,6 +623,23 @@ create_usage_limit(Client, Input)
 create_usage_limit(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateUsageLimit">>, Input, Options).
+
+%% @doc From the producer account, removes authorization from the specified
+%% datashare.
+deauthorize_data_share(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    deauthorize_data_share(Client, Input, []).
+deauthorize_data_share(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeauthorizeDataShare">>, Input, Options).
+
+%% @doc Deletes an authentication profile.
+delete_authentication_profile(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_authentication_profile(Client, Input, []).
+delete_authentication_profile(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteAuthenticationProfile">>, Input, Options).
 
 %% @doc Deletes a previously provisioned cluster without its final snapshot
 %% being created.
@@ -591,6 +716,14 @@ delete_cluster_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteClusterSubnetGroup">>, Input, Options).
 
+%% @doc Deletes a Redshift-managed VPC endpoint.
+delete_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_endpoint_access(Client, Input, []).
+delete_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteEndpointAccess">>, Input, Options).
+
 %% @doc Deletes an Amazon Redshift event notification subscription.
 delete_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -614,6 +747,17 @@ delete_hsm_configuration(Client, Input)
 delete_hsm_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteHsmConfiguration">>, Input, Options).
+
+%% @doc Deletes a partner integration from a cluster.
+%%
+%% Data can still flow to the cluster until the integration is deleted at the
+%% partner's website.
+delete_partner(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_partner(Client, Input, []).
+delete_partner(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeletePartner">>, Input, Options).
 
 %% @doc Deletes a scheduled action.
 delete_scheduled_action(Client, Input)
@@ -665,6 +809,14 @@ describe_account_attributes(Client, Input)
 describe_account_attributes(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAccountAttributes">>, Input, Options).
+
+%% @doc Describes an authentication profile.
+describe_authentication_profiles(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_authentication_profiles(Client, Input, []).
+describe_authentication_profiles(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeAuthenticationProfiles">>, Input, Options).
 
 %% @doc Returns an array of `ClusterDbRevision' objects.
 describe_cluster_db_revisions(Client, Input)
@@ -749,8 +901,9 @@ describe_cluster_security_groups(Client, Input, Options)
 %% your cluster snapshots.
 %%
 %% By default, this operation returns information about all snapshots of all
-%% clusters that are owned by you AWS customer account. No information is
-%% returned for snapshots owned by inactive AWS customer accounts.
+%% clusters that are owned by your Amazon Web Services account. No
+%% information is returned for snapshots owned by inactive Amazon Web
+%% Services accounts.
 %%
 %% If you specify both tag keys and tag values in the same request, Amazon
 %% Redshift returns all snapshots that match any combination of the specified
@@ -774,7 +927,7 @@ describe_cluster_snapshots(Client, Input, Options)
 %% metadata about your cluster subnet groups.
 %%
 %% By default, this operation returns information about all cluster subnet
-%% groups that are defined in you AWS account.
+%% groups that are defined in your Amazon Web Services account.
 %%
 %% If you specify both tag keys and tag values in the same request, Amazon
 %% Redshift returns all subnet groups that match any combination of the
@@ -838,6 +991,33 @@ describe_clusters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeClusters">>, Input, Options).
 
+%% @doc Shows the status of any inbound or outbound datashares available in
+%% the specified account.
+describe_data_shares(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_data_shares(Client, Input, []).
+describe_data_shares(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataShares">>, Input, Options).
+
+%% @doc Returns a list of datashares where the account identifier being
+%% called is a consumer account identifier.
+describe_data_shares_for_consumer(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_data_shares_for_consumer(Client, Input, []).
+describe_data_shares_for_consumer(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataSharesForConsumer">>, Input, Options).
+
+%% @doc Returns a list of datashares when the account identifier being called
+%% is a producer account identifier.
+describe_data_shares_for_producer(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_data_shares_for_producer(Client, Input, []).
+describe_data_shares_for_producer(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDataSharesForProducer">>, Input, Options).
+
 %% @doc Returns a list of parameter settings for the specified parameter
 %% group family.
 %%
@@ -849,6 +1029,22 @@ describe_default_cluster_parameters(Client, Input)
 describe_default_cluster_parameters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDefaultClusterParameters">>, Input, Options).
+
+%% @doc Describes a Redshift-managed VPC endpoint.
+describe_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_endpoint_access(Client, Input, []).
+describe_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEndpointAccess">>, Input, Options).
+
+%% @doc Describes an endpoint authorization.
+describe_endpoint_authorization(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_endpoint_authorization(Client, Input, []).
+describe_endpoint_authorization(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEndpointAuthorization">>, Input, Options).
 
 %% @doc Displays a list of event categories for all event source types, or
 %% for a specified source type.
@@ -901,7 +1097,7 @@ describe_events(Client, Input, Options)
 %% @doc Returns information about the specified HSM client certificate.
 %%
 %% If no certificate ID is specified, returns information about all the HSM
-%% certificates owned by your AWS customer account.
+%% certificates owned by your Amazon Web Services account.
 %%
 %% If you specify both tag keys and tag values in the same request, Amazon
 %% Redshift returns all HSM client certificates that match any combination of
@@ -924,7 +1120,7 @@ describe_hsm_client_certificates(Client, Input, Options)
 %% configuration.
 %%
 %% If no configuration ID is specified, returns information about all the HSM
-%% configurations owned by your AWS customer account.
+%% configurations owned by your Amazon Web Services account.
 %%
 %% If you specify both tag keys and tag values in the same request, Amazon
 %% Redshift returns all HSM connections that match any combination of the
@@ -964,18 +1160,27 @@ describe_node_configuration_options(Client, Input, Options)
 %%
 %% Before you create a new cluster you can use this operation to find what
 %% options are available, such as the EC2 Availability Zones (AZ) in the
-%% specific AWS Region that you can specify, and the node types you can
-%% request. The node types differ by available storage, memory, CPU and
-%% price. With the cost involved you might want to obtain a list of cluster
-%% options in the specific region and specify values when creating a cluster.
-%% For more information about managing clusters, go to Amazon Redshift
-%% Clusters in the Amazon Redshift Cluster Management Guide.
+%% specific Amazon Web Services Region that you can specify, and the node
+%% types you can request. The node types differ by available storage, memory,
+%% CPU and price. With the cost involved you might want to obtain a list of
+%% cluster options in the specific region and specify values when creating a
+%% cluster. For more information about managing clusters, go to Amazon
+%% Redshift Clusters in the Amazon Redshift Cluster Management Guide.
 describe_orderable_cluster_options(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_orderable_cluster_options(Client, Input, []).
 describe_orderable_cluster_options(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeOrderableClusterOptions">>, Input, Options).
+
+%% @doc Returns information about the partner integrations defined for a
+%% cluster.
+describe_partners(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_partners(Client, Input, []).
+describe_partners(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribePartners">>, Input, Options).
 
 %% @doc Returns a list of the available reserved node offerings by Amazon
 %% Redshift with their descriptions including the node type, the fixed and
@@ -1029,8 +1234,8 @@ describe_scheduled_actions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeScheduledActions">>, Input, Options).
 
-%% @doc Returns a list of snapshot copy grants owned by the AWS account in
-%% the destination region.
+%% @doc Returns a list of snapshot copy grants owned by the Amazon Web
+%% Services account in the destination region.
 %%
 %% For more information about managing snapshot copy grants, go to Amazon
 %% Redshift Database Encryption in the Amazon Redshift Cluster Management
@@ -1146,15 +1351,24 @@ disable_logging(Client, Input, Options)
 %% another region for a specified cluster.
 %%
 %% If your cluster and its snapshots are encrypted using a customer master
-%% key (CMK) from AWS KMS, use `DeleteSnapshotCopyGrant' to delete the grant
-%% that grants Amazon Redshift permission to the CMK in the destination
-%% region.
+%% key (CMK) from Key Management Service, use `DeleteSnapshotCopyGrant' to
+%% delete the grant that grants Amazon Redshift permission to the CMK in the
+%% destination region.
 disable_snapshot_copy(Client, Input)
   when is_map(Client), is_map(Input) ->
     disable_snapshot_copy(Client, Input, []).
 disable_snapshot_copy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableSnapshotCopy">>, Input, Options).
+
+%% @doc From a consumer account, remove association for the specified
+%% datashare.
+disassociate_data_share_consumer(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    disassociate_data_share_consumer(Client, Input, []).
+disassociate_data_share_consumer(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DisassociateDataShareConsumer">>, Input, Options).
 
 %% @doc Starts logging information, such as queries and connection attempts,
 %% for the specified Amazon Redshift cluster.
@@ -1186,7 +1400,7 @@ enable_snapshot_copy(Client, Input, Options)
 %% IAM Authentication to Generate Database User Credentials in the Amazon
 %% Redshift Cluster Management Guide.
 %%
-%% The AWS Identity and Access Management (IAM)user or role that executes
+%% The Identity and Access Management (IAM) user or role that runs
 %% GetClusterCredentials must have an IAM policy attached that allows access
 %% to all necessary actions and resources. For more information about
 %% permissions, see Resource Policies for GetClusterCredentials in the Amazon
@@ -1216,13 +1430,29 @@ get_reserved_node_exchange_offerings(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetReservedNodeExchangeOfferings">>, Input, Options).
 
+%% @doc Modifies whether a cluster can use AQUA (Advanced Query Accelerator).
+modify_aqua_configuration(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_aqua_configuration(Client, Input, []).
+modify_aqua_configuration(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyAquaConfiguration">>, Input, Options).
+
+%% @doc Modifies an authentication profile.
+modify_authentication_profile(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_authentication_profile(Client, Input, []).
+modify_authentication_profile(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyAuthenticationProfile">>, Input, Options).
+
 %% @doc Modifies the settings for a cluster.
 %%
 %% You can also change node type and the number of nodes to scale up or down
 %% the cluster. When resizing a cluster, you must specify both the number of
 %% nodes and the node type even if one of the parameters does not change.
 %%
-%% You can add another security or parameter group, or change the master user
+%% You can add another security or parameter group, or change the admin user
 %% password. Resetting a cluster password or modifying the security groups
 %% associated with a cluster do not need a reboot. However, modifying a
 %% parameter group requires a reboot for parameters to take effect. For more
@@ -1246,8 +1476,8 @@ modify_cluster_db_revision(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyClusterDbRevision">>, Input, Options).
 
-%% @doc Modifies the list of AWS Identity and Access Management (IAM) roles
-%% that can be used by the cluster to access other AWS services.
+%% @doc Modifies the list of Identity and Access Management (IAM) roles that
+%% can be used by the cluster to access other Amazon Web Services services.
 %%
 %% A cluster can have up to 10 IAM roles associated at any time.
 modify_cluster_iam_roles(Client, Input)
@@ -1266,6 +1496,8 @@ modify_cluster_maintenance(Client, Input, Options)
     request(Client, <<"ModifyClusterMaintenance">>, Input, Options).
 
 %% @doc Modifies the parameters of a parameter group.
+%%
+%% For the parameters parameter, it can't contain ASCII characters.
 %%
 %% For more information about parameters and parameter groups, go to Amazon
 %% Redshift Parameter Groups in the Amazon Redshift Cluster Management Guide.
@@ -1307,6 +1539,14 @@ modify_cluster_subnet_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ModifyClusterSubnetGroup">>, Input, Options).
 
+%% @doc Modifies a Redshift-managed VPC endpoint.
+modify_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    modify_endpoint_access(Client, Input, []).
+modify_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ModifyEndpointAccess">>, Input, Options).
+
 %% @doc Modifies an existing Amazon Redshift event notification subscription.
 modify_event_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1324,7 +1564,8 @@ modify_scheduled_action(Client, Input, Options)
     request(Client, <<"ModifyScheduledAction">>, Input, Options).
 
 %% @doc Modifies the number of days to retain snapshots in the destination
-%% AWS Region after they are copied from the source AWS Region.
+%% Amazon Web Services Region after they are copied from the source Amazon
+%% Web Services Region.
 %%
 %% By default, this operation only changes the retention period of copied
 %% automated snapshots. The retention periods for both new and existing
@@ -1398,6 +1639,14 @@ reboot_cluster(Client, Input)
 reboot_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RebootCluster">>, Input, Options).
+
+%% @doc From the consumer account, rejects the specified datashare.
+reject_data_share(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    reject_data_share(Client, Input, []).
+reject_data_share(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RejectDataShare">>, Input, Options).
 
 %% @doc Sets one or more parameters of the specified parameter group to their
 %% default values and sets the source values of the parameters to
@@ -1520,8 +1769,16 @@ revoke_cluster_security_group_ingress(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RevokeClusterSecurityGroupIngress">>, Input, Options).
 
-%% @doc Removes the ability of the specified AWS customer account to restore
-%% the specified snapshot.
+%% @doc Revokes access to a cluster.
+revoke_endpoint_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    revoke_endpoint_access(Client, Input, []).
+revoke_endpoint_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RevokeEndpointAccess">>, Input, Options).
+
+%% @doc Removes the ability of the specified Amazon Web Services account to
+%% restore the specified snapshot.
 %%
 %% If the account is currently restoring the snapshot, the restore will run
 %% to completion.
@@ -1542,6 +1799,14 @@ rotate_encryption_key(Client, Input)
 rotate_encryption_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RotateEncryptionKey">>, Input, Options).
+
+%% @doc Updates the status of a partner integration.
+update_partner_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_partner_status(Client, Input, []).
+update_partner_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdatePartnerStatus">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_redshift_data.erl
+++ b/src/aws_redshift_data.erl
@@ -4,14 +4,15 @@
 %% @doc You can use the Amazon Redshift Data API to run queries on Amazon
 %% Redshift tables.
 %%
-%% You can run individual SQL statements, which are committed if the
-%% statement succeeds.
+%% You can run SQL statements, which are committed if the statement succeeds.
 %%
 %% For more information about the Amazon Redshift Data API, see Using the
 %% Amazon Redshift Data API in the Amazon Redshift Cluster Management Guide.
 -module(aws_redshift_data).
 
--export([cancel_statement/2,
+-export([batch_execute_statement/2,
+         batch_execute_statement/3,
+         cancel_statement/2,
          cancel_statement/3,
          describe_statement/2,
          describe_statement/3,
@@ -35,6 +36,28 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Runs one or more SQL statements, which can be data manipulation
+%% language (DML) or data definition language (DDL).
+%%
+%% Depending on the authorization method, use one of the following
+%% combinations of request parameters:
+%%
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
+%%
+%% </li> <li> Temporary credentials - specify the cluster identifier, the
+%% database name, and the database user name. Permission to call the
+%% `redshift:GetClusterCredentials' operation is required to use this method.
+%%
+%% </li> </ul>
+batch_execute_statement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_execute_statement(Client, Input, []).
+batch_execute_statement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchExecuteStatement">>, Input, Options).
 
 %% @doc Cancels a running query.
 %%
@@ -65,9 +88,9 @@ describe_statement(Client, Input, Options)
 %% the column list. Depending on the authorization method, use one of the
 %% following combinations of request parameters:
 %%
-%% <ul> <li> AWS Secrets Manager - specify the Amazon Resource Name (ARN) of
-%% the secret and the cluster identifier that matches the cluster in the
-%% secret.
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
 %%
 %% </li> <li> Temporary credentials - specify the cluster identifier, the
 %% database name, and the database user name. Permission to call the
@@ -88,9 +111,9 @@ describe_table(Client, Input, Options)
 %% authorization method, use one of the following combinations of request
 %% parameters:
 %%
-%% <ul> <li> AWS Secrets Manager - specify the Amazon Resource Name (ARN) of
-%% the secret and the cluster identifier that matches the cluster in the
-%% secret.
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
 %%
 %% </li> <li> Temporary credentials - specify the cluster identifier, the
 %% database name, and the database user name. Permission to call the
@@ -120,9 +143,9 @@ get_statement_result(Client, Input, Options)
 %% authorization method, use one of the following combinations of request
 %% parameters:
 %%
-%% <ul> <li> AWS Secrets Manager - specify the Amazon Resource Name (ARN) of
-%% the secret and the cluster identifier that matches the cluster in the
-%% secret.
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
 %%
 %% </li> <li> Temporary credentials - specify the cluster identifier, the
 %% database name, and the database user name. Permission to call the
@@ -142,9 +165,9 @@ list_databases(Client, Input, Options)
 %% authorization method, use one of the following combinations of request
 %% parameters:
 %%
-%% <ul> <li> AWS Secrets Manager - specify the Amazon Resource Name (ARN) of
-%% the secret and the cluster identifier that matches the cluster in the
-%% secret.
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
 %%
 %% </li> <li> Temporary credentials - specify the cluster identifier, the
 %% database name, and the database user name. Permission to call the
@@ -176,9 +199,9 @@ list_statements(Client, Input, Options)
 %% the table list. Depending on the authorization method, use one of the
 %% following combinations of request parameters:
 %%
-%% <ul> <li> AWS Secrets Manager - specify the Amazon Resource Name (ARN) of
-%% the secret and the cluster identifier that matches the cluster in the
-%% secret.
+%% <ul> <li> Secrets Manager - specify the Amazon Resource Name (ARN) of the
+%% secret, the database name, and the cluster identifier that matches the
+%% cluster in the secret.
 %%
 %% </li> <li> Temporary credentials - specify the cluster identifier, the
 %% database name, and the database user name. Permission to call the

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -326,6 +326,12 @@ group_resources(Client, Input0, Options0) ->
 %%
 %% <ul> <li> `resource-groups:ListGroupResources'
 %%
+%% </li> <li> `cloudformation:DescribeStacks'
+%%
+%% </li> <li> `cloudformation:ListStackResources'
+%%
+%% </li> <li> `tag:GetResources'
+%%
 %% </li> </ul>
 list_group_resources(Client, Input) ->
     list_group_resources(Client, Input, []).
@@ -427,6 +433,12 @@ put_group_configuration(Client, Input0, Options0) ->
 %% To run this command, you must have the following permissions:
 %%
 %% <ul> <li> `resource-groups:SearchResources'
+%%
+%% </li> <li> `cloudformation:DescribeStacks'
+%%
+%% </li> <li> `cloudformation:ListStackResources'
+%%
+%% </li> <li> `tag:GetResources'
 %%
 %% </li> </ul>
 search_resources(Client, Input) ->
@@ -654,6 +666,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_resource_groups_tagging_api.erl
+++ b/src/aws_resource_groups_tagging_api.erl
@@ -41,7 +41,7 @@ describe_report_creation(Client, Input, Options)
 %% @doc Returns a table that shows counts of resources that are noncompliant
 %% with their tag policies.
 %%
-%% For more information on tag policies, see Tag Policies in the AWS
+%% For more information on tag policies, see Tag Policies in the
 %% Organizations User Guide.
 %%
 %% You can call this operation only from the organization's management
@@ -62,7 +62,7 @@ get_compliance_summary(Client, Input, Options)
     request(Client, <<"GetComplianceSummary">>, Input, Options).
 
 %% @doc Returns all the tagged or previously tagged resources that are
-%% located in the specified Region for the AWS account.
+%% located in the specified Amazon Web Services Region for the account.
 %%
 %% Depending on what information you want returned, you can also specify the
 %% following:
@@ -72,7 +72,7 @@ get_compliance_summary(Client, Input, Options)
 %% requested resources.
 %%
 %% </li> <li> Information about compliance with the account's effective tag
-%% policy. For more information on tag policies, see Tag Policies in the AWS
+%% policy. For more information on tag policies, see Tag Policies in the
 %% Organizations User Guide.
 %%
 %% </li> </ul> This operation supports pagination, where the response can be
@@ -89,8 +89,8 @@ get_resources(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetResources">>, Input, Options).
 
-%% @doc Returns all tag keys currently in use in the specified Region for the
-%% calling AWS account.
+%% @doc Returns all tag keys currently in use in the specified Amazon Web
+%% Services Region for the calling account.
 %%
 %% This operation supports pagination, where the response can be sent in
 %% multiple pages. You should check the `PaginationToken' response parameter
@@ -107,7 +107,7 @@ get_tag_keys(Client, Input, Options)
     request(Client, <<"GetTagKeys">>, Input, Options).
 
 %% @doc Returns all tag values for the specified key that are used in the
-%% specified AWS Region for the calling AWS account.
+%% specified Amazon Web Services Region for the calling account.
 %%
 %% This operation supports pagination, where the response can be sent in
 %% multiple pages. You should check the `PaginationToken' response parameter
@@ -149,13 +149,16 @@ start_report_creation(Client, Input, Options)
 %%
 %% <ul> <li> Not all resources can have tags. For a list of services with
 %% resources that support tagging using this operation, see Services that
-%% support the Resource Groups Tagging API.
+%% support the Resource Groups Tagging API. If the resource doesn't yet
+%% support this operation, the resource's service might support tagging using
+%% its own API operations. For more information, refer to the documentation
+%% for that service.
 %%
 %% </li> <li> Each resource can have up to 50 tags. For other limits, see Tag
-%% Naming and Usage Conventions in the AWS General Reference.
+%% Naming and Usage Conventions in the Amazon Web Services General Reference.
 %%
 %% </li> <li> You can only tag resources that are located in the specified
-%% AWS Region for the AWS account.
+%% Amazon Web Services Region for the Amazon Web Services account.
 %%
 %% </li> <li> To add tags to a resource, you need the necessary permissions
 %% for the service that the resource belongs to as well as permissions for
@@ -165,6 +168,20 @@ start_report_creation(Client, Input, Options)
 %% other confidential or sensitive information in tags. We use tags to
 %% provide you with billing and administration services. Tags are not
 %% intended to be used for private or sensitive data.
+%%
+%% Minimum permissions
+%%
+%% In addition to the `tag:TagResources' permission required by this
+%% operation, you must also have the tagging permission defined by the
+%% service that created the resource. For example, to tag an Amazon EC2
+%% instance using the `TagResources' operation, you must have both of the
+%% following permissions:
+%%
+%% <ul> <li> `tag:TagResource'
+%%
+%% </li> <li> `ec2:CreateTags'
+%%
+%% </li> </ul>
 tag_resources(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resources(Client, Input, []).
@@ -184,7 +201,19 @@ tag_resources(Client, Input, Options)
 %% for the service whose resource you want to untag.
 %%
 %% </li> <li> You can only tag resources that are located in the specified
-%% AWS Region for the calling AWS account.
+%% Amazon Web Services Region for the calling Amazon Web Services account.
+%%
+%% </li> </ul> Minimum permissions
+%%
+%% In addition to the `tag:UntagResources' permission required by this
+%% operation, you must also have the remove tags permission defined by the
+%% service that created the resource. For example, to remove the tags from an
+%% Amazon EC2 instance using the `UntagResources' operation, you must have
+%% both of the following permissions:
+%%
+%% <ul> <li> `tag:UntagResource'
+%%
+%% </li> <li> `ec2:DeleteTags'
 %%
 %% </li> </ul>
 untag_resources(Client, Input)

--- a/src/aws_robomaker.erl
+++ b/src/aws_robomaker.erl
@@ -1521,6 +1521,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -206,9 +206,10 @@ activate_key_signing_key(Client, HostedZoneId, Name, Input0, Options0) ->
 %% already exist. You can't convert a public hosted zone into a private
 %% hosted zone.
 %%
-%% If you want to associate a VPC that was created by using one AWS account
-%% with a private hosted zone that was created by using a different account,
-%% the AWS account that created the private hosted zone must first submit a
+%% If you want to associate a VPC that was created by using one Amazon Web
+%% Services account with a private hosted zone that was created by using a
+%% different account, the Amazon Web Services account that created the
+%% private hosted zone must first submit a
 %% `CreateVPCAssociationAuthorization' request. Then the account that created
 %% the VPC must submit an `AssociateVPCWithHostedZone' request.
 associate_vpc_with_hosted_zone(Client, HostedZoneId, Input) ->
@@ -289,9 +290,9 @@ associate_vpc_with_hosted_zone(Client, HostedZoneId, Input0, Options0) ->
 %% </li> <li> `DELETE': Deletes an existing resource record set that has the
 %% specified values.
 %%
-%% </li> <li> `UPSERT': If a resource record set does not already exist, AWS
-%% creates it. If a resource set does exist, Route 53 updates it with the
-%% values in the request.
+%% </li> <li> `UPSERT': If a resource record set does not already exist,
+%% Amazon Web Services creates it. If a resource set does exist, Route 53
+%% updates it with the values in the request.
 %%
 %% </li> </ul> Syntaxes for Creating, Updating, and Deleting Resource Record
 %% Sets
@@ -345,7 +346,7 @@ change_resource_record_sets(Client, HostedZoneId, Input0, Options0) ->
 %% @doc Adds, edits, or deletes tags for a health check or a hosted zone.
 %%
 %% For information about using tags for cost allocation, see Using Cost
-%% Allocation Tags in the AWS Billing and Cost Management User Guide.
+%% Allocation Tags in the Billing and Cost Management User Guide.
 change_tags_for_resource(Client, ResourceId, ResourceType, Input) ->
     change_tags_for_resource(Client, ResourceId, ResourceType, Input, []).
 change_tags_for_resource(Client, ResourceId, ResourceType, Input0, Options0) ->
@@ -481,6 +482,9 @@ create_health_check(Client, Input0, Options0) ->
 %% means that the NS and SOA records are not yet available on all Route 53
 %% DNS servers. When the NS and SOA records are available, the status of the
 %% zone changes to `INSYNC'.
+%%
+%% The `CreateHostedZone' request requires the caller to have an
+%% `ec2:DescribeVpcs' permission.
 create_hosted_zone(Client, Input) ->
     create_hosted_zone(Client, Input, []).
 create_hosted_zone(Client, Input0, Options0) ->
@@ -588,8 +592,9 @@ create_key_signing_key(Client, Input0, Options0) ->
 %%
 %% <ul> <li> You must create the log group in the us-east-1 region.
 %%
-%% </li> <li> You must use the same AWS account to create the log group and
-%% the hosted zone that you want to configure query logging for.
+%% </li> <li> You must use the same Amazon Web Services account to create the
+%% log group and the hosted zone that you want to configure query logging
+%% for.
 %%
 %% </li> <li> When you create log groups for query logging, we recommend that
 %% you use a consistent prefix, for example:
@@ -597,11 +602,11 @@ create_key_signing_key(Client, Input0, Options0) ->
 %% `/aws/route53/hosted zone name '
 %%
 %% In the next step, you'll create a resource policy, which controls access
-%% to one or more log groups and the associated AWS resources, such as Route
-%% 53 hosted zones. There's a limit on the number of resource policies that
-%% you can create, so we recommend that you use a consistent prefix so you
-%% can use the same resource policy for all the log groups that you create
-%% for query logging.
+%% to one or more log groups and the associated Amazon Web Services
+%% resources, such as Route 53 hosted zones. There's a limit on the number of
+%% resource policies that you can create, so we recommend that you use a
+%% consistent prefix so you can use the same resource policy for all the log
+%% groups that you create for query logging.
 %%
 %% </li> </ul> </li> <li> Create a CloudWatch Logs resource policy, and give
 %% it the permissions that Route 53 needs to create log streams and to send
@@ -614,7 +619,8 @@ create_key_signing_key(Client, Input0, Options0) ->
 %% `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*'
 %%
 %% You can't use the CloudWatch console to create or edit a resource policy.
-%% You must use the CloudWatch API, one of the AWS SDKs, or the AWS CLI.
+%% You must use the CloudWatch API, one of the Amazon Web Services SDKs, or
+%% the CLI.
 %%
 %% </li> </ol> </dd> <dt>Log Streams and Edge Locations</dt> <dd> When Route
 %% 53 finishes creating the configuration for DNS query logging, it does the
@@ -702,7 +708,8 @@ create_query_logging_config(Client, Input0, Options0) ->
     end.
 
 %% @doc Creates a delegation set (a group of four name servers) that can be
-%% reused by multiple hosted zones that were created by the same AWS account.
+%% reused by multiple hosted zones that were created by the same Amazon Web
+%% Services account.
 %%
 %% You can also create a reusable delegation set that uses the four name
 %% servers that are associated with an existing hosted zone. Specify the
@@ -924,9 +931,9 @@ create_traffic_policy_version(Client, Id, Input0, Options0) ->
         Result
     end.
 
-%% @doc Authorizes the AWS account that created a specified VPC to submit an
-%% `AssociateVPCWithHostedZone' request to associate the VPC with a specified
-%% hosted zone that was created by a different account.
+%% @doc Authorizes the Amazon Web Services account that created a specified
+%% VPC to submit an `AssociateVPCWithHostedZone' request to associate the VPC
+%% with a specified hosted zone that was created by a different account.
 %%
 %% To submit a `CreateVPCAssociationAuthorization' request, you must use the
 %% account that created the hosted zone. After you authorize the association,
@@ -994,12 +1001,11 @@ deactivate_key_signing_key(Client, HostedZoneId, Name, Input0, Options0) ->
 %% failover configuration. For more information, see Replacing and Deleting
 %% Health Checks in the Amazon Route 53 Developer Guide.
 %%
-%% If you're using AWS Cloud Map and you configured Cloud Map to create a
-%% Route 53 health check when you register an instance, you can't use the
-%% Route 53 `DeleteHealthCheck' command to delete the health check. The
-%% health check is deleted automatically when you deregister the instance;
-%% there can be a delay of several hours before the health check is deleted
-%% from Route 53.
+%% If you're using Cloud Map and you configured Cloud Map to create a Route
+%% 53 health check when you register an instance, you can't use the Route 53
+%% `DeleteHealthCheck' command to delete the health check. The health check
+%% is deleted automatically when you deregister the instance; there can be a
+%% delay of several hours before the health check is deleted from Route 53.
 delete_health_check(Client, HealthCheckId, Input) ->
     delete_health_check(Client, HealthCheckId, Input, []).
 delete_health_check(Client, HealthCheckId, Input0, Options0) ->
@@ -1024,10 +1030,10 @@ delete_health_check(Client, HealthCheckId, Input0, Options0) ->
 
 %% @doc Deletes a hosted zone.
 %%
-%% If the hosted zone was created by another service, such as AWS Cloud Map,
-%% see Deleting Public Hosted Zones That Were Created by Another Service in
-%% the Amazon Route 53 Developer Guide for information about how to delete
-%% it. (The process is the same for public and private hosted zones that were
+%% If the hosted zone was created by another service, such as Cloud Map, see
+%% Deleting Public Hosted Zones That Were Created by Another Service in the
+%% Amazon Route 53 Developer Guide for information about how to delete it.
+%% (The process is the same for public and private hosted zones that were
 %% created by another service.)
 %%
 %% If you want to keep your domain registration but you want to stop routing
@@ -1067,7 +1073,7 @@ delete_health_check(Client, HealthCheckId, Input0, Options0) ->
 %% hosted zone.
 %%
 %% </li> <li> Use the `ListHostedZones' action to get a list of the hosted
-%% zones associated with the current AWS account.
+%% zones associated with the current Amazon Web Services account.
 %%
 %% </li> </ul>
 delete_hosted_zone(Client, Id, Input) ->
@@ -1095,7 +1101,7 @@ delete_hosted_zone(Client, Id, Input0, Options0) ->
 %% @doc Deletes a key-signing key (KSK).
 %%
 %% Before you can delete a KSK, you must deactivate it. The KSK must be
-%% deactived before you can delete it regardless of whether the hosted zone
+%% deactivated before you can delete it regardless of whether the hosted zone
 %% is enabled for DNSSEC signing.
 delete_key_signing_key(Client, HostedZoneId, Name, Input) ->
     delete_key_signing_key(Client, HostedZoneId, Name, Input, []).
@@ -1250,9 +1256,9 @@ delete_traffic_policy_instance(Client, Id, Input0, Options0) ->
 %% You must use the account that created the hosted zone to submit a
 %% `DeleteVPCAssociationAuthorization' request.
 %%
-%% Sending this request only prevents the AWS account that created the VPC
-%% from associating the VPC with the Amazon Route 53 hosted zone in the
-%% future. If the VPC is already associated with the hosted zone,
+%% Sending this request only prevents the Amazon Web Services account that
+%% created the VPC from associating the VPC with the Amazon Route 53 hosted
+%% zone in the future. If the VPC is already associated with the hosted zone,
 %% `DeleteVPCAssociationAuthorization' won't disassociate the VPC from the
 %% hosted zone. If you want to delete an existing association, use
 %% `DisassociateVPCFromHostedZone'.
@@ -1319,11 +1325,11 @@ disable_hosted_zone_dns_sec(Client, HostedZoneId, Input0, Options0) ->
 %% either the account that created the hosted zone or the account that
 %% created the Amazon VPC.
 %%
-%% </li> <li> Some services, such as AWS Cloud Map and Amazon Elastic File
-%% System (Amazon EFS) automatically create hosted zones and associate VPCs
-%% with the hosted zones. A service can create a hosted zone using your
-%% account or using its own account. You can disassociate a VPC from a hosted
-%% zone only if the service created the hosted zone using your account.
+%% </li> <li> Some services, such as Cloud Map and Amazon Elastic File System
+%% (Amazon EFS) automatically create hosted zones and associate VPCs with the
+%% hosted zones. A service can create a hosted zone using your account or
+%% using its own account. You can disassociate a VPC from a hosted zone only
+%% if the service created the hosted zone using your account.
 %%
 %% When you run DisassociateVPCFromHostedZone, if the hosted zone has a value
 %% for `OwningAccount', you can use `DisassociateVPCFromHostedZone'. If the
@@ -1382,10 +1388,10 @@ enable_hosted_zone_dns_sec(Client, HostedZoneId, Input0, Options0) ->
 %% For the default limit, see Limits in the Amazon Route 53 Developer Guide.
 %% To request a higher limit, open a case.
 %%
-%% You can also view account limits in AWS Trusted Advisor. Sign in to the
-%% AWS Management Console and open the Trusted Advisor console at
-%% https://console.aws.amazon.com/trustedadvisor/. Then choose Service limits
-%% in the navigation pane.
+%% You can also view account limits in Amazon Web Services Trusted Advisor.
+%% Sign in to the Amazon Web Services Management Console and open the Trusted
+%% Advisor console at https://console.aws.amazon.com/trustedadvisor/. Then
+%% choose Service limits in the navigation pane.
 get_account_limit(Client, Type)
   when is_map(Client) ->
     get_account_limit(Client, Type, #{}, #{}).
@@ -1446,9 +1452,9 @@ get_change(Client, Id, QueryMap, HeadersMap, Options0)
 %% retrieves information that is already available to the public.
 %%
 %% `GetCheckerIpRanges' still works, but we recommend that you download
-%% ip-ranges.json, which includes IP address ranges for all AWS services. For
-%% more information, see IP Address Ranges of Amazon Route 53 Servers in the
-%% Amazon Route 53 Developer Guide.
+%% ip-ranges.json, which includes IP address ranges for all Amazon Web
+%% Services services. For more information, see IP Address Ranges of Amazon
+%% Route 53 Servers in the Amazon Route 53 Developer Guide.
 get_checker_ip_ranges(Client)
   when is_map(Client) ->
     get_checker_ip_ranges(Client, #{}, #{}).
@@ -1569,7 +1575,7 @@ get_health_check(Client, HealthCheckId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves the number of health checks that are associated with the
-%% current AWS account.
+%% current Amazon Web Services account.
 get_health_check_count(Client)
   when is_map(Client) ->
     get_health_check_count(Client, #{}, #{}).
@@ -1616,6 +1622,10 @@ get_health_check_last_failure_reason(Client, HealthCheckId, QueryMap, HeadersMap
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets status of a specified health check.
+%%
+%% This API is intended for use during development to diagnose behavior. It
+%% doesn’t support production use-cases with high query rates that require
+%% immediate and actionable responses.
 get_health_check_status(Client, HealthCheckId)
   when is_map(Client) ->
     get_health_check_status(Client, HealthCheckId, #{}, #{}).
@@ -1663,7 +1673,7 @@ get_hosted_zone(Client, Id, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves the number of hosted zones that are associated with the
-%% current AWS account.
+%% current Amazon Web Services account.
 get_hosted_zone_count(Client)
   when is_map(Client) ->
     get_hosted_zone_count(Client, #{}, #{}).
@@ -1850,7 +1860,7 @@ get_traffic_policy_instance(Client, Id, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets the number of traffic policy instances that are associated with
-%% the current AWS account.
+%% the current Amazon Web Services account.
 get_traffic_policy_instance_count(Client)
   when is_map(Client) ->
     get_traffic_policy_instance_count(Client, #{}, #{}).
@@ -1914,7 +1924,7 @@ list_geo_locations(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieve a list of the health checks that are associated with the
-%% current AWS account.
+%% current Amazon Web Services account.
 list_health_checks(Client)
   when is_map(Client) ->
     list_health_checks(Client, #{}, #{}).
@@ -1943,7 +1953,7 @@ list_health_checks(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves a list of the public and private hosted zones that are
-%% associated with the current AWS account.
+%% associated with the current Amazon Web Services account.
 %%
 %% The response includes a `HostedZones' child element for each hosted zone.
 %%
@@ -1981,7 +1991,7 @@ list_hosted_zones(Client, QueryMap, HeadersMap, Options0)
 %% @doc Retrieves a list of your hosted zones in lexicographic order.
 %%
 %% The response includes a `HostedZones' child element for each hosted zone
-%% created by the current AWS account.
+%% created by the current Amazon Web Services account.
 %%
 %% `ListHostedZonesByName' sorts hosted zones by name with the labels
 %% reversed. For example:
@@ -2019,7 +2029,8 @@ list_hosted_zones(Client, QueryMap, HeadersMap, Options0)
 %% produced the current response.
 %%
 %% </li> <li> If the value of `IsTruncated' in the response is true, there
-%% are more hosted zones associated with the current AWS account.
+%% are more hosted zones associated with the current Amazon Web Services
+%% account.
 %%
 %% If `IsTruncated' is false, this response includes the last hosted zone
 %% that is associated with the current account. The `NextDNSName' element and
@@ -2027,10 +2038,11 @@ list_hosted_zones(Client, QueryMap, HeadersMap, Options0)
 %%
 %% </li> <li> The `NextDNSName' and `NextHostedZoneId' elements in the
 %% response contain the domain name and the hosted zone ID of the next hosted
-%% zone that is associated with the current AWS account. If you want to list
-%% more hosted zones, make another call to `ListHostedZonesByName', and
-%% specify the value of `NextDNSName' and `NextHostedZoneId' in the `dnsname'
-%% and `hostedzoneid' parameters, respectively.
+%% zone that is associated with the current Amazon Web Services account. If
+%% you want to list more hosted zones, make another call to
+%% `ListHostedZonesByName', and specify the value of `NextDNSName' and
+%% `NextHostedZoneId' in the `dnsname' and `hostedzoneid' parameters,
+%% respectively.
 %%
 %% </li> </ul>
 list_hosted_zones_by_name(Client)
@@ -2062,20 +2074,21 @@ list_hosted_zones_by_name(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists all the private hosted zones that a specified VPC is associated
-%% with, regardless of which AWS account or AWS service owns the hosted
-%% zones.
+%% with, regardless of which Amazon Web Services account or Amazon Web
+%% Services service owns the hosted zones.
 %%
 %% The `HostedZoneOwner' structure in the response contains one of the
 %% following values:
 %%
 %% <ul> <li> An `OwningAccount' element, which contains the account number of
-%% either the current AWS account or another AWS account. Some services, such
-%% as AWS Cloud Map, create hosted zones using the current account.
+%% either the current Amazon Web Services account or another Amazon Web
+%% Services account. Some services, such as Cloud Map, create hosted zones
+%% using the current account.
 %%
-%% </li> <li> An `OwningService' element, which identifies the AWS service
-%% that created and owns the hosted zone. For example, if a hosted zone was
-%% created by Amazon Elastic File System (Amazon EFS), the value of `Owner'
-%% is `efs.amazonaws.com'.
+%% </li> <li> An `OwningService' element, which identifies the Amazon Web
+%% Services service that created and owns the hosted zone. For example, if a
+%% hosted zone was created by Amazon Elastic File System (Amazon EFS), the
+%% value of `Owner' is `efs.amazonaws.com'.
 %%
 %% </li> </ul>
 list_hosted_zones_by_vpc(Client, VPCId, VPCRegion)
@@ -2108,8 +2121,8 @@ list_hosted_zones_by_vpc(Client, VPCId, VPCRegion, QueryMap, HeadersMap, Options
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the configurations for DNS query logging that are associated
-%% with the current AWS account or the configuration that is associated with
-%% a specified hosted zone.
+%% with the current Amazon Web Services account or the configuration that is
+%% associated with a specified hosted zone.
 %%
 %% For more information about DNS query logs, see CreateQueryLoggingConfig.
 %% Additional information, including the format of DNS query logs, appears in
@@ -2144,7 +2157,7 @@ list_query_logging_configs(Client, QueryMap, HeadersMap, Options0)
 
 %% @doc Lists the resource record sets in a specified hosted zone.
 %%
-%% `ListResourceRecordSets' returns up to 100 resource record sets at a time
+%% `ListResourceRecordSets' returns up to 300 resource record sets at a time
 %% in ASCII order, beginning at a position specified by the `name' and `type'
 %% elements.
 %%
@@ -2234,7 +2247,7 @@ list_resource_record_sets(Client, HostedZoneId, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Retrieves a list of the reusable delegation sets that are associated
-%% with the current AWS account.
+%% with the current Amazon Web Services account.
 list_reusable_delegation_sets(Client)
   when is_map(Client) ->
     list_reusable_delegation_sets(Client, #{}, #{}).
@@ -2265,7 +2278,7 @@ list_reusable_delegation_sets(Client, QueryMap, HeadersMap, Options0)
 %% @doc Lists tags for one health check or hosted zone.
 %%
 %% For information about using tags for cost allocation, see Using Cost
-%% Allocation Tags in the AWS Billing and Cost Management User Guide.
+%% Allocation Tags in the Billing and Cost Management User Guide.
 list_tags_for_resource(Client, ResourceId, ResourceType)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceId, ResourceType, #{}, #{}).
@@ -2291,7 +2304,7 @@ list_tags_for_resource(Client, ResourceId, ResourceType, QueryMap, HeadersMap, O
 %% @doc Lists tags for up to 10 health checks or hosted zones.
 %%
 %% For information about using tags for cost allocation, see Using Cost
-%% Allocation Tags in the AWS Billing and Cost Management User Guide.
+%% Allocation Tags in the Billing and Cost Management User Guide.
 list_tags_for_resources(Client, ResourceType, Input) ->
     list_tags_for_resources(Client, ResourceType, Input, []).
 list_tags_for_resources(Client, ResourceType, Input0, Options0) ->
@@ -2315,7 +2328,7 @@ list_tags_for_resources(Client, ResourceType, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Gets information about the latest version for every traffic policy
-%% that is associated with the current AWS account.
+%% that is associated with the current Amazon Web Services account.
 %%
 %% Policies are listed in the order that they were created in.
 %%
@@ -2349,7 +2362,7 @@ list_traffic_policies(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Gets information about the traffic policy instances that you created
-%% by using the current AWS account.
+%% by using the current Amazon Web Services account.
 %%
 %% After you submit an `UpdateTrafficPolicyInstance' request, there's a brief
 %% delay while Amazon Route 53 creates the resource record sets that are
@@ -2541,6 +2554,8 @@ list_vpc_association_authorizations(Client, HostedZoneId, QueryMap, HeadersMap, 
 %%
 %% You can optionally specify the IP address of a DNS resolver, an EDNS0
 %% client subnet IP address, and a subnet mask.
+%%
+%% This call only supports querying public hosted zones.
 test_dns_answer(Client, HostedZoneId, RecordName, RecordType)
   when is_map(Client) ->
     test_dns_answer(Client, HostedZoneId, RecordName, RecordType, #{}, #{}).
@@ -2725,6 +2740,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_route53_recovery_cluster.erl
+++ b/src/aws_route53_recovery_cluster.erl
@@ -1,0 +1,154 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Welcome to the Amazon Route 53 Application Recovery Controller API
+%% Reference Guide for Recovery Control Data Plane .
+%%
+%% Recovery control in Route 53 Application Recovery Controller includes
+%% extremely reliable routing controls that enable you to recover
+%% applications by rerouting traffic, for example, across Availability Zones
+%% or AWS Regions. Routing controls are simple on/off switches hosted on a
+%% cluster. A cluster is a set of five redundant regional endpoints against
+%% which you can execute API calls to update or get the state of routing
+%% controls. You use routing controls to failover traffic to recover your
+%% application across Availability Zones or Regions.
+%%
+%% This API guide includes information about how to get and update routing
+%% control states in Route 53 Application Recovery Controller.
+%%
+%% For more information about Route 53 Application Recovery Controller, see
+%% the following:
+%%
+%% <ul> <li> You can create clusters, routing controls, and control panels by
+%% using the control plane API for Recovery Control. For more information,
+%% see Amazon Route 53 Application Recovery Controller Recovery Control API
+%% Reference.
+%%
+%% </li> <li> Route 53 Application Recovery Controller also provides
+%% continuous readiness checks to ensure that your applications are scaled to
+%% handle failover traffic. For more information about the related API
+%% actions, see Amazon Route 53 Application Recovery Controller Recovery
+%% Readiness API Reference.
+%%
+%% </li> <li> For more information about creating resilient applications and
+%% preparing for recovery readiness with Route 53 Application Recovery
+%% Controller, see the Amazon Route 53 Application Recovery Controller
+%% Developer Guide.
+%%
+%% </li> </ul>
+-module(aws_route53_recovery_cluster).
+
+-export([get_routing_control_state/2,
+         get_routing_control_state/3,
+         update_routing_control_state/2,
+         update_routing_control_state/3,
+         update_routing_control_states/2,
+         update_routing_control_states/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Get the state for a routing control.
+%%
+%% A routing control is a simple on/off switch that you can use to route
+%% traffic to cells. When the state is On, traffic flows to a cell. When it's
+%% off, traffic does not flow.
+%%
+%% Before you can create a routing control, you first must create a cluster
+%% to host the control. For more information, see CreateCluster. Access one
+%% of the endpoints for the cluster to get or update the routing control
+%% state to redirect traffic.
+%%
+%% For more information about working with routing controls, see Routing
+%% control in the Route 53 Application Recovery Controller Developer Guide.
+get_routing_control_state(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_routing_control_state(Client, Input, []).
+get_routing_control_state(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetRoutingControlState">>, Input, Options).
+
+%% @doc Set the state of the routing control to reroute traffic.
+%%
+%% You can set the value to be On or Off. When the state is On, traffic flows
+%% to a cell. When it's off, traffic does not flow.
+%%
+%% For more information about working with routing controls, see Routing
+%% control in the Route 53 Application Recovery Controller Developer Guide.
+update_routing_control_state(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_routing_control_state(Client, Input, []).
+update_routing_control_state(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateRoutingControlState">>, Input, Options).
+
+%% @doc Set multiple routing control states.
+%%
+%% You can set the value for each state to be On or Off. When the state is
+%% On, traffic flows to a cell. When it's off, traffic does not flow.
+%%
+%% For more information about working with routing controls, see Routing
+%% control in the Route 53 Application Recovery Controller Developer Guide.
+update_routing_control_states(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_routing_control_states(Client, Input, []).
+update_routing_control_states(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateRoutingControlStates">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"route53-recovery-cluster">>},
+    Host = build_host(<<"route53-recovery-cluster">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"ToggleCustomerAPI.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_route53_recovery_control_config.erl
+++ b/src/aws_route53_recovery_control_config.erl
@@ -1,0 +1,699 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Recovery Control Configuration API Reference for Amazon Route 53
+%% Application Recovery Controller
+-module(aws_route53_recovery_control_config).
+
+-export([create_cluster/2,
+         create_cluster/3,
+         create_control_panel/2,
+         create_control_panel/3,
+         create_routing_control/2,
+         create_routing_control/3,
+         create_safety_rule/2,
+         create_safety_rule/3,
+         delete_cluster/3,
+         delete_cluster/4,
+         delete_control_panel/3,
+         delete_control_panel/4,
+         delete_routing_control/3,
+         delete_routing_control/4,
+         delete_safety_rule/3,
+         delete_safety_rule/4,
+         describe_cluster/2,
+         describe_cluster/4,
+         describe_cluster/5,
+         describe_control_panel/2,
+         describe_control_panel/4,
+         describe_control_panel/5,
+         describe_routing_control/2,
+         describe_routing_control/4,
+         describe_routing_control/5,
+         describe_safety_rule/2,
+         describe_safety_rule/4,
+         describe_safety_rule/5,
+         list_associated_route53_health_checks/2,
+         list_associated_route53_health_checks/4,
+         list_associated_route53_health_checks/5,
+         list_clusters/1,
+         list_clusters/3,
+         list_clusters/4,
+         list_control_panels/1,
+         list_control_panels/3,
+         list_control_panels/4,
+         list_routing_controls/2,
+         list_routing_controls/4,
+         list_routing_controls/5,
+         list_safety_rules/2,
+         list_safety_rules/4,
+         list_safety_rules/5,
+         update_control_panel/2,
+         update_control_panel/3,
+         update_routing_control/2,
+         update_routing_control/3,
+         update_safety_rule/2,
+         update_safety_rule/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Create a new cluster.
+%%
+%% A cluster is a set of redundant Regional endpoints against which you can
+%% run API calls to update or get the state of one or more routing controls.
+%% Each cluster has a name, status, Amazon Resource Name (ARN), and an array
+%% of the five cluster endpoints (one for each supported Amazon Web Services
+%% Region) that you can use with API calls to the Amazon Route 53 Application
+%% Recovery Controller cluster data plane.
+create_cluster(Client, Input) ->
+    create_cluster(Client, Input, []).
+create_cluster(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/cluster"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new control panel.
+%%
+%% A control panel represents a group of routing controls that can be changed
+%% together in a single transaction. You can use a control panel to centrally
+%% view the operational status of applications across your organization, and
+%% trigger multi-app failovers in a single transaction, for example, to fail
+%% over an Availability Zone or AWS Region.
+create_control_panel(Client, Input) ->
+    create_control_panel(Client, Input, []).
+create_control_panel(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/controlpanel"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new routing control.
+%%
+%% A routing control has one of two states: ON and OFF. You can map the
+%% routing control state to the state of an Amazon Route 53 health check,
+%% which can be used to control traffic routing.
+%%
+%% To get or update the routing control state, see the Recovery Cluster (data
+%% plane) API actions for Amazon Route 53 Application Recovery Controller.
+create_routing_control(Client, Input) ->
+    create_routing_control(Client, Input, []).
+create_routing_control(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/routingcontrol"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a safety rule in a control panel.
+%%
+%% Safety rules let you add safeguards around enabling and disabling routing
+%% controls, to help prevent unexpected outcomes.
+%%
+%% There are two types of safety rules: assertion rules and gating rules.
+%%
+%% Assertion rule: An assertion rule enforces that, when a routing control
+%% state is changed, the criteria set by the rule configuration is met.
+%% Otherwise, the change to the routing control is not accepted.
+%%
+%% Gating rule: A gating rule verifies that a set of gating controls
+%% evaluates as true, based on a rule configuration that you specify. If the
+%% gating rule evaluates to true, Amazon Route 53 Application Recovery
+%% Controller allows a set of routing control state changes to run and
+%% complete against the set of target controls.
+create_safety_rule(Client, Input) ->
+    create_safety_rule(Client, Input, []).
+create_safety_rule(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/safetyrule"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete a cluster.
+delete_cluster(Client, ClusterArn, Input) ->
+    delete_cluster(Client, ClusterArn, Input, []).
+delete_cluster(Client, ClusterArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/cluster/", aws_util:encode_uri(ClusterArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a control panel.
+delete_control_panel(Client, ControlPanelArn, Input) ->
+    delete_control_panel(Client, ControlPanelArn, Input, []).
+delete_control_panel(Client, ControlPanelArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/controlpanel/", aws_util:encode_uri(ControlPanelArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a routing control.
+delete_routing_control(Client, RoutingControlArn, Input) ->
+    delete_routing_control(Client, RoutingControlArn, Input, []).
+delete_routing_control(Client, RoutingControlArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/routingcontrol/", aws_util:encode_uri(RoutingControlArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a safety rule.
+%%
+%% />
+delete_safety_rule(Client, SafetyRuleArn, Input) ->
+    delete_safety_rule(Client, SafetyRuleArn, Input, []).
+delete_safety_rule(Client, SafetyRuleArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/safetyrule/", aws_util:encode_uri(SafetyRuleArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Display the details about a cluster.
+%%
+%% The response includes the cluster name, endpoints, status, and Amazon
+%% Resource Name (ARN).
+describe_cluster(Client, ClusterArn)
+  when is_map(Client) ->
+    describe_cluster(Client, ClusterArn, #{}, #{}).
+
+describe_cluster(Client, ClusterArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_cluster(Client, ClusterArn, QueryMap, HeadersMap, []).
+
+describe_cluster(Client, ClusterArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/cluster/", aws_util:encode_uri(ClusterArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Displays details about a control panel.
+describe_control_panel(Client, ControlPanelArn)
+  when is_map(Client) ->
+    describe_control_panel(Client, ControlPanelArn, #{}, #{}).
+
+describe_control_panel(Client, ControlPanelArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_control_panel(Client, ControlPanelArn, QueryMap, HeadersMap, []).
+
+describe_control_panel(Client, ControlPanelArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/controlpanel/", aws_util:encode_uri(ControlPanelArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Displays details about a routing control.
+%%
+%% A routing control has one of two states: ON and OFF. You can map the
+%% routing control state to the state of an Amazon Route 53 health check,
+%% which can be used to control routing.
+%%
+%% To get or update the routing control state, see the Recovery Cluster (data
+%% plane) API actions for Amazon Route 53 Application Recovery Controller.
+describe_routing_control(Client, RoutingControlArn)
+  when is_map(Client) ->
+    describe_routing_control(Client, RoutingControlArn, #{}, #{}).
+
+describe_routing_control(Client, RoutingControlArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_routing_control(Client, RoutingControlArn, QueryMap, HeadersMap, []).
+
+describe_routing_control(Client, RoutingControlArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/routingcontrol/", aws_util:encode_uri(RoutingControlArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Describes the safety rules (that is, the assertion rules and gating
+%% rules) for the routing controls in a control panel.
+describe_safety_rule(Client, SafetyRuleArn)
+  when is_map(Client) ->
+    describe_safety_rule(Client, SafetyRuleArn, #{}, #{}).
+
+describe_safety_rule(Client, SafetyRuleArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_safety_rule(Client, SafetyRuleArn, QueryMap, HeadersMap, []).
+
+describe_safety_rule(Client, SafetyRuleArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/safetyrule/", aws_util:encode_uri(SafetyRuleArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns an array of all Amazon Route 53 health checks associated with
+%% a specific routing control.
+list_associated_route53_health_checks(Client, RoutingControlArn)
+  when is_map(Client) ->
+    list_associated_route53_health_checks(Client, RoutingControlArn, #{}, #{}).
+
+list_associated_route53_health_checks(Client, RoutingControlArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_associated_route53_health_checks(Client, RoutingControlArn, QueryMap, HeadersMap, []).
+
+list_associated_route53_health_checks(Client, RoutingControlArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/routingcontrol/", aws_util:encode_uri(RoutingControlArn), "/associatedRoute53HealthChecks"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns an array of all the clusters in an account.
+list_clusters(Client)
+  when is_map(Client) ->
+    list_clusters(Client, #{}, #{}).
+
+list_clusters(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_clusters(Client, QueryMap, HeadersMap, []).
+
+list_clusters(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/cluster"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns an array of control panels for a cluster.
+list_control_panels(Client)
+  when is_map(Client) ->
+    list_control_panels(Client, #{}, #{}).
+
+list_control_panels(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_control_panels(Client, QueryMap, HeadersMap, []).
+
+list_control_panels(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/controlpanels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"ClusterArn">>, maps:get(<<"ClusterArn">>, QueryMap, undefined)},
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns an array of routing controls for a control panel.
+%%
+%% A routing control is an Amazon Route 53 Application Recovery Controller
+%% construct that has one of two states: ON and OFF. You can map the routing
+%% control state to the state of an Amazon Route 53 health check, which can
+%% be used to control routing.
+list_routing_controls(Client, ControlPanelArn)
+  when is_map(Client) ->
+    list_routing_controls(Client, ControlPanelArn, #{}, #{}).
+
+list_routing_controls(Client, ControlPanelArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_routing_controls(Client, ControlPanelArn, QueryMap, HeadersMap, []).
+
+list_routing_controls(Client, ControlPanelArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/controlpanel/", aws_util:encode_uri(ControlPanelArn), "/routingcontrols"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc List the safety rules (the assertion rules and gating rules) that
+%% you've defined for the routing controls in a control panel.
+list_safety_rules(Client, ControlPanelArn)
+  when is_map(Client) ->
+    list_safety_rules(Client, ControlPanelArn, #{}, #{}).
+
+list_safety_rules(Client, ControlPanelArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_safety_rules(Client, ControlPanelArn, QueryMap, HeadersMap, []).
+
+list_safety_rules(Client, ControlPanelArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/controlpanel/", aws_util:encode_uri(ControlPanelArn), "/safetyrules"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Updates a control panel.
+%%
+%% The only update you can make to a control panel is to change the name of
+%% the control panel.
+update_control_panel(Client, Input) ->
+    update_control_panel(Client, Input, []).
+update_control_panel(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/controlpanel"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a routing control.
+%%
+%% You can only update the name of the routing control. To get or update the
+%% routing control state, see the Recovery Cluster (data plane) API actions
+%% for Amazon Route 53 Application Recovery Controller.
+update_routing_control(Client, Input) ->
+    update_routing_control(Client, Input, []).
+update_routing_control(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/routingcontrol"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update a safety rule (an assertion rule or gating rule) for the
+%% routing controls in a control panel.
+%%
+%% You can only update the name and the waiting period for a safety rule. To
+%% make other updates, delete the safety rule and create a new safety rule.
+update_safety_rule(Client, Input) ->
+    update_safety_rule(Client, Input, []).
+update_safety_rule(Client, Input0, Options0) ->
+    Method = put,
+    Path = ["/safetyrule"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"route53-recovery-control-config">>},
+    Host = build_host(<<"route53-recovery-control-config">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_route53_recovery_readiness.erl
+++ b/src/aws_route53_recovery_readiness.erl
@@ -1,0 +1,977 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc AWS Route53 Recovery Readiness
+-module(aws_route53_recovery_readiness).
+
+-export([create_cell/2,
+         create_cell/3,
+         create_cross_account_authorization/2,
+         create_cross_account_authorization/3,
+         create_readiness_check/2,
+         create_readiness_check/3,
+         create_recovery_group/2,
+         create_recovery_group/3,
+         create_resource_set/2,
+         create_resource_set/3,
+         delete_cell/3,
+         delete_cell/4,
+         delete_cross_account_authorization/3,
+         delete_cross_account_authorization/4,
+         delete_readiness_check/3,
+         delete_readiness_check/4,
+         delete_recovery_group/3,
+         delete_recovery_group/4,
+         delete_resource_set/3,
+         delete_resource_set/4,
+         get_architecture_recommendations/2,
+         get_architecture_recommendations/4,
+         get_architecture_recommendations/5,
+         get_cell/2,
+         get_cell/4,
+         get_cell/5,
+         get_cell_readiness_summary/2,
+         get_cell_readiness_summary/4,
+         get_cell_readiness_summary/5,
+         get_readiness_check/2,
+         get_readiness_check/4,
+         get_readiness_check/5,
+         get_readiness_check_resource_status/3,
+         get_readiness_check_resource_status/5,
+         get_readiness_check_resource_status/6,
+         get_readiness_check_status/2,
+         get_readiness_check_status/4,
+         get_readiness_check_status/5,
+         get_recovery_group/2,
+         get_recovery_group/4,
+         get_recovery_group/5,
+         get_recovery_group_readiness_summary/2,
+         get_recovery_group_readiness_summary/4,
+         get_recovery_group_readiness_summary/5,
+         get_resource_set/2,
+         get_resource_set/4,
+         get_resource_set/5,
+         list_cells/1,
+         list_cells/3,
+         list_cells/4,
+         list_cross_account_authorizations/1,
+         list_cross_account_authorizations/3,
+         list_cross_account_authorizations/4,
+         list_readiness_checks/1,
+         list_readiness_checks/3,
+         list_readiness_checks/4,
+         list_recovery_groups/1,
+         list_recovery_groups/3,
+         list_recovery_groups/4,
+         list_resource_sets/1,
+         list_resource_sets/3,
+         list_resource_sets/4,
+         list_rules/1,
+         list_rules/3,
+         list_rules/4,
+         list_tags_for_resources/2,
+         list_tags_for_resources/4,
+         list_tags_for_resources/5,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_cell/3,
+         update_cell/4,
+         update_readiness_check/3,
+         update_readiness_check/4,
+         update_recovery_group/3,
+         update_recovery_group/4,
+         update_resource_set/3,
+         update_resource_set/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a new Cell.
+create_cell(Client, Input) ->
+    create_cell(Client, Input, []).
+create_cell(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/cells"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Create a new cross account readiness authorization.
+create_cross_account_authorization(Client, Input) ->
+    create_cross_account_authorization(Client, Input, []).
+create_cross_account_authorization(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/crossaccountauthorizations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Readiness Check.
+create_readiness_check(Client, Input) ->
+    create_readiness_check(Client, Input, []).
+create_readiness_check(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/readinesschecks"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Recovery Group.
+create_recovery_group(Client, Input) ->
+    create_recovery_group(Client, Input, []).
+create_recovery_group(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/recoverygroups"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new Resource Set.
+create_resource_set(Client, Input) ->
+    create_resource_set(Client, Input, []).
+create_resource_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/resourcesets"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an existing Cell.
+delete_cell(Client, CellName, Input) ->
+    delete_cell(Client, CellName, Input, []).
+delete_cell(Client, CellName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/cells/", aws_util:encode_uri(CellName), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete cross account readiness authorization
+delete_cross_account_authorization(Client, CrossAccountAuthorization, Input) ->
+    delete_cross_account_authorization(Client, CrossAccountAuthorization, Input, []).
+delete_cross_account_authorization(Client, CrossAccountAuthorization, Input0, Options0) ->
+    Method = delete,
+    Path = ["/crossaccountauthorizations/", aws_util:encode_uri(CrossAccountAuthorization), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an existing Readiness Check.
+delete_readiness_check(Client, ReadinessCheckName, Input) ->
+    delete_readiness_check(Client, ReadinessCheckName, Input, []).
+delete_readiness_check(Client, ReadinessCheckName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/readinesschecks/", aws_util:encode_uri(ReadinessCheckName), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an existing Recovery Group.
+delete_recovery_group(Client, RecoveryGroupName, Input) ->
+    delete_recovery_group(Client, RecoveryGroupName, Input, []).
+delete_recovery_group(Client, RecoveryGroupName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/recoverygroups/", aws_util:encode_uri(RecoveryGroupName), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an existing Resource Set.
+delete_resource_set(Client, ResourceSetName, Input) ->
+    delete_resource_set(Client, ResourceSetName, Input, []).
+delete_resource_set(Client, ResourceSetName, Input0, Options0) ->
+    Method = delete,
+    Path = ["/resourcesets/", aws_util:encode_uri(ResourceSetName), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of recommendations to improve resilliance and
+%% readiness check quality for a Recovery Group.
+get_architecture_recommendations(Client, RecoveryGroupName)
+  when is_map(Client) ->
+    get_architecture_recommendations(Client, RecoveryGroupName, #{}, #{}).
+
+get_architecture_recommendations(Client, RecoveryGroupName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_architecture_recommendations(Client, RecoveryGroupName, QueryMap, HeadersMap, []).
+
+get_architecture_recommendations(Client, RecoveryGroupName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/recoverygroups/", aws_util:encode_uri(RecoveryGroupName), "/architectureRecommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a Cell.
+get_cell(Client, CellName)
+  when is_map(Client) ->
+    get_cell(Client, CellName, #{}, #{}).
+
+get_cell(Client, CellName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_cell(Client, CellName, QueryMap, HeadersMap, []).
+
+get_cell(Client, CellName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/cells/", aws_util:encode_uri(CellName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about readiness of a Cell.
+get_cell_readiness_summary(Client, CellName)
+  when is_map(Client) ->
+    get_cell_readiness_summary(Client, CellName, #{}, #{}).
+
+get_cell_readiness_summary(Client, CellName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_cell_readiness_summary(Client, CellName, QueryMap, HeadersMap, []).
+
+get_cell_readiness_summary(Client, CellName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/cellreadiness/", aws_util:encode_uri(CellName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a ReadinessCheck.
+get_readiness_check(Client, ReadinessCheckName)
+  when is_map(Client) ->
+    get_readiness_check(Client, ReadinessCheckName, #{}, #{}).
+
+get_readiness_check(Client, ReadinessCheckName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_readiness_check(Client, ReadinessCheckName, QueryMap, HeadersMap, []).
+
+get_readiness_check(Client, ReadinessCheckName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/readinesschecks/", aws_util:encode_uri(ReadinessCheckName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns detailed information about the status of an individual
+%% resource within a Readiness Check's Resource Set.
+get_readiness_check_resource_status(Client, ReadinessCheckName, ResourceIdentifier)
+  when is_map(Client) ->
+    get_readiness_check_resource_status(Client, ReadinessCheckName, ResourceIdentifier, #{}, #{}).
+
+get_readiness_check_resource_status(Client, ReadinessCheckName, ResourceIdentifier, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_readiness_check_resource_status(Client, ReadinessCheckName, ResourceIdentifier, QueryMap, HeadersMap, []).
+
+get_readiness_check_resource_status(Client, ReadinessCheckName, ResourceIdentifier, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/readinesschecks/", aws_util:encode_uri(ReadinessCheckName), "/resource/", aws_util:encode_uri(ResourceIdentifier), "/status"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about the status of a Readiness Check.
+get_readiness_check_status(Client, ReadinessCheckName)
+  when is_map(Client) ->
+    get_readiness_check_status(Client, ReadinessCheckName, #{}, #{}).
+
+get_readiness_check_status(Client, ReadinessCheckName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_readiness_check_status(Client, ReadinessCheckName, QueryMap, HeadersMap, []).
+
+get_readiness_check_status(Client, ReadinessCheckName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/readinesschecks/", aws_util:encode_uri(ReadinessCheckName), "/status"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a Recovery Group.
+get_recovery_group(Client, RecoveryGroupName)
+  when is_map(Client) ->
+    get_recovery_group(Client, RecoveryGroupName, #{}, #{}).
+
+get_recovery_group(Client, RecoveryGroupName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_recovery_group(Client, RecoveryGroupName, QueryMap, HeadersMap, []).
+
+get_recovery_group(Client, RecoveryGroupName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/recoverygroups/", aws_util:encode_uri(RecoveryGroupName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a Recovery Group.
+get_recovery_group_readiness_summary(Client, RecoveryGroupName)
+  when is_map(Client) ->
+    get_recovery_group_readiness_summary(Client, RecoveryGroupName, #{}, #{}).
+
+get_recovery_group_readiness_summary(Client, RecoveryGroupName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_recovery_group_readiness_summary(Client, RecoveryGroupName, QueryMap, HeadersMap, []).
+
+get_recovery_group_readiness_summary(Client, RecoveryGroupName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/recoverygroupreadiness/", aws_util:encode_uri(RecoveryGroupName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns information about a Resource Set.
+get_resource_set(Client, ResourceSetName)
+  when is_map(Client) ->
+    get_resource_set(Client, ResourceSetName, #{}, #{}).
+
+get_resource_set(Client, ResourceSetName, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_resource_set(Client, ResourceSetName, QueryMap, HeadersMap, []).
+
+get_resource_set(Client, ResourceSetName, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/resourcesets/", aws_util:encode_uri(ResourceSetName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of Cells.
+list_cells(Client)
+  when is_map(Client) ->
+    list_cells(Client, #{}, #{}).
+
+list_cells(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_cells(Client, QueryMap, HeadersMap, []).
+
+list_cells(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/cells"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of cross account readiness authorizations.
+list_cross_account_authorizations(Client)
+  when is_map(Client) ->
+    list_cross_account_authorizations(Client, #{}, #{}).
+
+list_cross_account_authorizations(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_cross_account_authorizations(Client, QueryMap, HeadersMap, []).
+
+list_cross_account_authorizations(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/crossaccountauthorizations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of Readiness Checks.
+list_readiness_checks(Client)
+  when is_map(Client) ->
+    list_readiness_checks(Client, #{}, #{}).
+
+list_readiness_checks(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_readiness_checks(Client, QueryMap, HeadersMap, []).
+
+list_readiness_checks(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/readinesschecks"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of Recovery Groups.
+list_recovery_groups(Client)
+  when is_map(Client) ->
+    list_recovery_groups(Client, #{}, #{}).
+
+list_recovery_groups(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_recovery_groups(Client, QueryMap, HeadersMap, []).
+
+list_recovery_groups(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/recoverygroups"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of Resource Sets.
+list_resource_sets(Client)
+  when is_map(Client) ->
+    list_resource_sets(Client, #{}, #{}).
+
+list_resource_sets(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_resource_sets(Client, QueryMap, HeadersMap, []).
+
+list_resource_sets(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/resourcesets"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a collection of rules that are applied as part of Readiness
+%% Checks.
+list_rules(Client)
+  when is_map(Client) ->
+    list_rules(Client, #{}, #{}).
+
+list_rules(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_rules(Client, QueryMap, HeadersMap, []).
+
+list_rules(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/rules"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"resourceType">>, maps:get(<<"resourceType">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of the tags assigned to the specified resource.
+list_tags_for_resources(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resources(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resources(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resources(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resources(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Adds tags to the specified resource.
+%%
+%% You can specify one or more tags to add.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes tags from the specified resource.
+%%
+%% You can specify one or more tags to remove.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"TagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an existing Cell.
+update_cell(Client, CellName, Input) ->
+    update_cell(Client, CellName, Input, []).
+update_cell(Client, CellName, Input0, Options0) ->
+    Method = put,
+    Path = ["/cells/", aws_util:encode_uri(CellName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an exisiting Readiness Check.
+update_readiness_check(Client, ReadinessCheckName, Input) ->
+    update_readiness_check(Client, ReadinessCheckName, Input, []).
+update_readiness_check(Client, ReadinessCheckName, Input0, Options0) ->
+    Method = put,
+    Path = ["/readinesschecks/", aws_util:encode_uri(ReadinessCheckName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an existing Recovery Group.
+update_recovery_group(Client, RecoveryGroupName, Input) ->
+    update_recovery_group(Client, RecoveryGroupName, Input, []).
+update_recovery_group(Client, RecoveryGroupName, Input0, Options0) ->
+    Method = put,
+    Path = ["/recoverygroups/", aws_util:encode_uri(RecoveryGroupName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an existing Resource Set.
+update_resource_set(Client, ResourceSetName, Input) ->
+    update_resource_set(Client, ResourceSetName, Input, []).
+update_resource_set(Client, ResourceSetName, Input0, Options0) ->
+    Method = put,
+    Path = ["/resourcesets/", aws_util:encode_uri(ResourceSetName), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"route53-recovery-readiness">>},
+    Host = build_host(<<"route53-recovery-readiness">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -233,7 +233,9 @@
          upload_part/4,
          upload_part/5,
          upload_part_copy/4,
-         upload_part_copy/5]).
+         upload_part_copy/5,
+         write_get_object_response/2,
+         write_get_object_response/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -241,7 +243,7 @@
 %% API
 %%====================================================================
 
-%% @doc This operation aborts a multipart upload.
+%% @doc This action aborts a multipart upload.
 %%
 %% After a multipart upload is aborted, no additional parts can be uploaded
 %% using that upload ID. The storage consumed by any previously uploaded
@@ -251,11 +253,11 @@
 %% order to completely free all storage consumed by all parts.
 %%
 %% To verify that all parts have been removed, so you don't get charged for
-%% the part storage, you should call the ListParts operation and ensure that
-%% the parts list is empty.
+%% the part storage, you should call the ListParts action and ensure that the
+%% parts list is empty.
 %%
-%% For information about permissions required to use the multipart upload
-%% API, see Multipart Upload API and Permissions.
+%% For information about permissions required to use the multipart upload,
+%% see Multipart Upload and Permissions.
 %%
 %% The following operations are related to `AbortMultipartUpload':
 %%
@@ -316,13 +318,13 @@ abort_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% You first initiate the multipart upload and then upload all parts using
 %% the UploadPart operation. After successfully uploading all relevant parts
-%% of an upload, you call this operation to complete the upload. Upon
-%% receiving this request, Amazon S3 concatenates all the parts in ascending
-%% order by part number to create a new object. In the Complete Multipart
-%% Upload request, you must provide the parts list. You must ensure that the
-%% parts list is complete. This operation concatenates the parts that you
-%% provide in the list. For each part in the list, you must provide the part
-%% number and the `ETag' value, returned after that part was uploaded.
+%% of an upload, you call this action to complete the upload. Upon receiving
+%% this request, Amazon S3 concatenates all the parts in ascending order by
+%% part number to create a new object. In the Complete Multipart Upload
+%% request, you must provide the parts list. You must ensure that the parts
+%% list is complete. This action concatenates the parts that you provide in
+%% the list. For each part in the list, you must provide the part number and
+%% the `ETag' value, returned after that part was uploaded.
 %%
 %% Processing of a Complete Multipart Upload request could take several
 %% minutes to complete. After Amazon S3 begins processing the request, it
@@ -340,7 +342,7 @@ abort_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %% Multipart Upload.
 %%
 %% For information about permissions required to use the multipart upload
-%% API, see Multipart Upload API and Permissions.
+%% API, see Multipart Upload and Permissions.
 %%
 %% `CompleteMultipartUpload' has the following special errors:
 %%
@@ -439,7 +441,7 @@ complete_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %% @doc Creates a copy of an object that is already stored in Amazon S3.
 %%
 %% You can store individual objects of up to 5 TB in Amazon S3. You create a
-%% copy of your object up to 5 GB in size in a single atomic operation using
+%% copy of your object up to 5 GB in size in a single atomic action using
 %% this API. However, to copy an object greater than 5 GB, you must use the
 %% multipart upload Upload Part - Copy API. For more information, see Copy
 %% Object Using the REST Multipart Upload API.
@@ -452,10 +454,10 @@ complete_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% A copy request might return an error when Amazon S3 receives the copy
 %% request or while Amazon S3 is copying the files. If the error occurs
-%% before the copy operation starts, you receive a standard Amazon S3 error.
-%% If the error occurs during the copy operation, the error response is
-%% embedded in the `200 OK' response. This means that a `200 OK' response can
-%% contain either a success or an error. Design your application to parse the
+%% before the copy action starts, you receive a standard Amazon S3 error. If
+%% the error occurs during the copy operation, the error response is embedded
+%% in the `200 OK' response. This means that a `200 OK' response can contain
+%% either a success or an error. Design your application to parse the
 %% contents of the response and handle it appropriately.
 %%
 %% If the copy is successful, you receive a response with information about
@@ -487,9 +489,9 @@ complete_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %% optionally add the `x-amz-metadata-directive' header. When you grant
 %% permissions, you can use the `s3:x-amz-metadata-directive' condition key
 %% to enforce certain metadata behavior when objects are uploaded. For more
-%% information, see Specifying Conditions in a Policy in the Amazon S3
-%% Developer Guide. For a complete list of Amazon S3-specific condition keys,
-%% see Actions, Resources, and Condition Keys for Amazon S3.
+%% information, see Specifying Conditions in a Policy in the Amazon S3 User
+%% Guide. For a complete list of Amazon S3-specific condition keys, see
+%% Actions, Resources, and Condition Keys for Amazon S3.
 %%
 %% `x-amz-copy-source-if' Headers
 %%
@@ -531,33 +533,33 @@ complete_multipart_upload(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% When you perform a CopyObject operation, you can optionally use the
 %% appropriate encryption-related headers to encrypt the object using
-%% server-side encryption with AWS managed encryption keys (SSE-S3 or
-%% SSE-KMS) or a customer-provided encryption key. With server-side
-%% encryption, Amazon S3 encrypts your data as it writes it to disks in its
-%% data centers and decrypts the data when you access it. For more
-%% information about server-side encryption, see Using Server-Side
+%% server-side encryption with Amazon Web Services managed encryption keys
+%% (SSE-S3 or SSE-KMS) or a customer-provided encryption key. With
+%% server-side encryption, Amazon S3 encrypts your data as it writes it to
+%% disks in its data centers and decrypts the data when you access it. For
+%% more information about server-side encryption, see Using Server-Side
 %% Encryption.
 %%
 %% If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the
-%% object. For more information, see Amazon S3 Bucket Keys in the Amazon
-%% Simple Storage Service Developer Guide.
+%% object. For more information, see Amazon S3 Bucket Keys in the Amazon S3
+%% User Guide.
 %%
 %% Access Control List (ACL)-Specific Request Headers
 %%
 %% When copying an object, you can optionally use headers to grant ACL-based
 %% permissions. By default, all objects are private. Only the owner has full
 %% access control. When adding a new object, you can grant permissions to
-%% individual AWS accounts or to predefined groups defined by Amazon S3.
-%% These permissions are then added to the ACL on the object. For more
-%% information, see Access Control List (ACL) Overview and Managing ACLs
+%% individual Amazon Web Services accounts or to predefined groups defined by
+%% Amazon S3. These permissions are then added to the ACL on the object. For
+%% more information, see Access Control List (ACL) Overview and Managing ACLs
 %% Using the REST API.
 %%
 %% Storage Class Options
 %%
-%% You can use the `CopyObject' operation to change the storage class of an
+%% You can use the `CopyObject' action to change the storage class of an
 %% object that is already stored in Amazon S3 using the `StorageClass'
-%% parameter. For more information, see Storage Classes in the Amazon S3
-%% Service Developer Guide.
+%% parameter. For more information, see Storage Classes in the Amazon S3 User
+%% Guide.
 %%
 %% Versioning
 %%
@@ -675,13 +677,13 @@ copy_object(Client, Bucket, Key, Input0, Options0) ->
 
 %% @doc Creates a new S3 bucket.
 %%
-%% To create a bucket, you must register with Amazon S3 and have a valid AWS
-%% Access Key ID to authenticate requests. Anonymous requests are never
-%% allowed to create buckets. By creating the bucket, you become the bucket
-%% owner.
+%% To create a bucket, you must register with Amazon S3 and have a valid
+%% Amazon Web Services Access Key ID to authenticate requests. Anonymous
+%% requests are never allowed to create buckets. By creating the bucket, you
+%% become the bucket owner.
 %%
 %% Not every string is an acceptable bucket name. For information about
-%% bucket naming restrictions, see Working with Amazon S3 buckets.
+%% bucket naming restrictions, see Bucket naming rules.
 %%
 %% If you want to create an Amazon S3 on Outposts bucket, see Create Bucket.
 %%
@@ -719,16 +721,16 @@ copy_object(Client, Bucket, Key, Input0, Options0) ->
 %% You specify each grantee as a type=value pair, where the type is one of
 %% the following:
 %%
-%% <ul> <li> `id' – if the value specified is the canonical user ID of an AWS
-%% account
+%% <ul> <li> `id' – if the value specified is the canonical user ID of an
+%% Amazon Web Services account
 %%
 %% </li> <li> `uri' – if you are granting permissions to a predefined group
 %%
 %% </li> <li> `emailAddress' – if the value specified is the email address of
-%% an AWS account
+%% an Amazon Web Services account
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -747,16 +749,29 @@ copy_object(Client, Bucket, Key, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> For example, the following `x-amz-grant-read' header grants
-%% the AWS accounts identified by account IDs permissions to read object data
-%% and its metadata:
+%% the Amazon Web Services accounts identified by account IDs permissions to
+%% read object data and its metadata:
 %%
 %% `x-amz-grant-read: id="11112222333", id="444455556666" '
 %%
 %% </li> </ul> You can use either a canned ACL or specify access permissions
 %% explicitly. You cannot do both.
+%%
+%% Permissions
+%%
+%% If your `CreateBucket' request specifies ACL permissions and the ACL is
+%% public-read, public-read-write, authenticated-read, or if you specify
+%% access permissions explicitly through any other ACL, both
+%% `s3:CreateBucket' and `s3:PutBucketAcl' permissions are needed. If the ACL
+%% the `CreateBucket' request is private, only `s3:CreateBucket' permission
+%% is needed.
+%%
+%% If `ObjectLockEnabledForBucket' is set to true in your `CreateBucket'
+%% request, `s3:PutBucketObjectLockConfiguration' and
+%% `s3:PutBucketVersioning' permissions are required.
 %%
 %% The following operations are related to `CreateBucket':
 %%
@@ -811,7 +826,7 @@ create_bucket(Client, Bucket, Input0, Options0) ->
         Result
     end.
 
-%% @doc This operation initiates a multipart upload and returns an upload ID.
+%% @doc This action initiates a multipart upload and returns an upload ID.
 %%
 %% This upload ID is used to associate all of the parts in the specific
 %% multipart upload. You specify this upload ID in each of your subsequent
@@ -825,19 +840,19 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %% If you have configured a lifecycle rule to abort incomplete multipart
 %% uploads, the upload must complete within the number of days specified in
 %% the bucket lifecycle configuration. Otherwise, the incomplete multipart
-%% upload becomes eligible for an abort operation and Amazon S3 aborts the
+%% upload becomes eligible for an abort action and Amazon S3 aborts the
 %% multipart upload. For more information, see Aborting Incomplete Multipart
 %% Uploads Using a Bucket Lifecycle Policy.
 %%
 %% For information about the permissions required to use the multipart upload
-%% API, see Multipart Upload API and Permissions.
+%% API, see Multipart Upload and Permissions.
 %%
 %% For request signing, multipart upload is just a series of regular
 %% requests. You initiate a multipart upload, send one or more requests to
 %% upload parts, and then complete the multipart upload process. You sign
 %% each request individually. There is nothing special about signing
 %% multipart upload requests. For more information about signing, see
-%% Authenticating Requests (AWS Signature Version 4).
+%% Authenticating Requests (Amazon Web Services Signature Version 4).
 %%
 %% After you initiate a multipart upload and upload one or more parts, to
 %% stop being charged for storing the uploaded parts, you must either
@@ -848,24 +863,24 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %% You can optionally request server-side encryption. For server-side
 %% encryption, Amazon S3 encrypts your data as it writes it to disks in its
 %% data centers and decrypts it when you access it. You can provide your own
-%% encryption key, or use AWS Key Management Service (AWS KMS) customer
-%% master keys (CMKs) or Amazon S3-managed encryption keys. If you choose to
-%% provide your own encryption key, the request headers you provide in
-%% UploadPart and UploadPartCopy requests must match the headers you used in
-%% the request to initiate the upload by using `CreateMultipartUpload'.
+%% encryption key, or use Amazon Web Services KMS keys or Amazon S3-managed
+%% encryption keys. If you choose to provide your own encryption key, the
+%% request headers you provide in UploadPart and UploadPartCopy requests must
+%% match the headers you used in the request to initiate the upload by using
+%% `CreateMultipartUpload'.
 %%
-%% To perform a multipart upload with encryption using an AWS KMS CMK, the
-%% requester must have permission to the `kms:Encrypt', `kms:Decrypt',
-%% `kms:ReEncrypt*', `kms:GenerateDataKey*', and `kms:DescribeKey' actions on
-%% the key. These permissions are required because Amazon S3 must decrypt and
-%% read data from the encrypted file parts before it completes the multipart
-%% upload.
+%% To perform a multipart upload with encryption using an Amazon Web Services
+%% KMS key, the requester must have permission to the `kms:Decrypt' and
+%% `kms:GenerateDataKey*' actions on the key. These permissions are required
+%% because Amazon S3 must decrypt and read data from the encrypted file parts
+%% before it completes the multipart upload. For more information, see
+%% Multipart upload API and permissions in the Amazon S3 User Guide.
 %%
-%% If your AWS Identity and Access Management (IAM) user or role is in the
-%% same AWS account as the AWS KMS CMK, then you must have these permissions
-%% on the key policy. If your IAM user or role belongs to a different account
-%% than the key, then you must have the permissions on both the key policy
-%% and your IAM user or role.
+%% If your Identity and Access Management (IAM) user or role is in the same
+%% Amazon Web Services account as the KMS key, then you must have these
+%% permissions on the key policy. If your IAM user or role belongs to a
+%% different account than the key, then you must have the permissions on both
+%% the key policy and your IAM user or role.
 %%
 %% For more information, see Protecting Data Using Server-Side Encryption.
 %%
@@ -891,13 +906,13 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %% encryption. Server-side encryption is for data encryption at rest. Amazon
 %% S3 encrypts your data as it writes it to disks in its data centers and
 %% decrypts it when you access it. The option you use depends on whether you
-%% want to use AWS managed encryption keys or provide your own encryption
-%% key.
+%% want to use Amazon Web Services managed encryption keys or provide your
+%% own encryption key.
 %%
-%% <ul> <li> Use encryption keys managed by Amazon S3 or customer master keys
-%% (CMKs) stored in AWS Key Management Service (AWS KMS) – If you want AWS to
-%% manage the keys used to encrypt data, specify the following headers in the
-%% request.
+%% <ul> <li> Use encryption keys managed by Amazon S3 or customer managed key
+%% stored in Amazon Web Services Key Management Service (Amazon Web Services
+%% KMS) – If you want Amazon Web Services to manage the keys used to encrypt
+%% data, specify the following headers in the request.
 %%
 %% <ul> <li> x-amz-server-side-encryption
 %%
@@ -907,14 +922,14 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> </ul> If you specify `x-amz-server-side-encryption:aws:kms', but
 %% don't provide `x-amz-server-side-encryption-aws-kms-key-id', Amazon S3
-%% uses the AWS managed CMK in AWS KMS to protect the data.
+%% uses the Amazon Web Services managed key in Amazon Web Services KMS to
+%% protect the data.
 %%
-%% All GET and PUT requests for an object protected by AWS KMS fail if you
-%% don't make them with SSL or by using SigV4.
+%% All GET and PUT requests for an object protected by Amazon Web Services
+%% KMS fail if you don't make them with SSL or by using SigV4.
 %%
-%% For more information about server-side encryption with CMKs stored in AWS
-%% KMS (SSE-KMS), see Protecting Data Using Server-Side Encryption with CMKs
-%% stored in AWS KMS.
+%% For more information about server-side encryption with KMS key (SSE-KMS),
+%% see Protecting Data Using Server-Side Encryption with KMS keys.
 %%
 %% </li> <li> Use customer-provided encryption keys – If you want to manage
 %% your own encryption keys, provide all the following headers in the
@@ -926,30 +941,30 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> <li> x-amz-server-side-encryption-customer-key-MD5
 %%
-%% </li> </ul> For more information about server-side encryption with CMKs
-%% stored in AWS KMS (SSE-KMS), see Protecting Data Using Server-Side
-%% Encryption with CMKs stored in AWS KMS.
+%% </li> </ul> For more information about server-side encryption with KMS
+%% keys (SSE-KMS), see Protecting Data Using Server-Side Encryption with KMS
+%% keys.
 %%
 %% </li> </ul> </dd> <dt>Access-Control-List (ACL)-Specific Request
 %% Headers</dt> <dd> You also can use the following access control–related
 %% headers with this operation. By default, all objects are private. Only the
 %% owner has full access control. When adding a new object, you can grant
-%% permissions to individual AWS accounts or to predefined groups defined by
-%% Amazon S3. These permissions are then added to the access control list
-%% (ACL) on the object. For more information, see Using ACLs. With this
-%% operation, you can grant access permissions using one of the following two
-%% methods:
+%% permissions to individual Amazon Web Services accounts or to predefined
+%% groups defined by Amazon S3. These permissions are then added to the
+%% access control list (ACL) on the object. For more information, see Using
+%% ACLs. With this operation, you can grant access permissions using one of
+%% the following two methods:
 %%
 %% <ul> <li> Specify a canned ACL (`x-amz-acl') — Amazon S3 supports a set of
 %% predefined ACLs, known as canned ACLs. Each canned ACL has a predefined
 %% set of grantees and permissions. For more information, see Canned ACL.
 %%
 %% </li> <li> Specify access permissions explicitly — To explicitly grant
-%% access permissions to specific AWS accounts or groups, use the following
-%% headers. Each header maps to specific permissions that Amazon S3 supports
-%% in an ACL. For more information, see Access Control List (ACL) Overview.
-%% In the header, you specify a list of grantees who get the specific
-%% permission. To grant permissions explicitly, use:
+%% access permissions to specific Amazon Web Services accounts or groups, use
+%% the following headers. Each header maps to specific permissions that
+%% Amazon S3 supports in an ACL. For more information, see Access Control
+%% List (ACL) Overview. In the header, you specify a list of grantees who get
+%% the specific permission. To grant permissions explicitly, use:
 %%
 %% <ul> <li> x-amz-grant-read
 %%
@@ -964,16 +979,16 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %% </li> </ul> You specify each grantee as a type=value pair, where the type
 %% is one of the following:
 %%
-%% <ul> <li> `id' – if the value specified is the canonical user ID of an AWS
-%% account
+%% <ul> <li> `id' – if the value specified is the canonical user ID of an
+%% Amazon Web Services account
 %%
 %% </li> <li> `uri' – if you are granting permissions to a predefined group
 %%
 %% </li> <li> `emailAddress' – if the value specified is the email address of
-%% an AWS account
+%% an Amazon Web Services account
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -992,11 +1007,11 @@ create_bucket(Client, Bucket, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> For example, the following `x-amz-grant-read' header grants
-%% the AWS accounts identified by account IDs permissions to read object data
-%% and its metadata:
+%% the Amazon Web Services accounts identified by account IDs permissions to
+%% read object data and its metadata:
 %%
 %% `x-amz-grant-read: id="11112222333", id="444455556666" '
 %%
@@ -1180,7 +1195,7 @@ delete_bucket_analytics_configuration(Client, Bucket, Input0, Options0) ->
 %% and can grant this permission to others.
 %%
 %% For information about `cors', see Enabling Cross-Origin Resource Sharing
-%% in the Amazon Simple Storage Service Developer Guide.
+%% in the Amazon S3 User Guide.
 %%
 %% == Related Resources: ==
 %%
@@ -1213,19 +1228,18 @@ delete_bucket_cors(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This implementation of the DELETE operation removes default
-%% encryption from the bucket.
+%% @doc This implementation of the DELETE action removes default encryption
+%% from the bucket.
 %%
 %% For information about the Amazon S3 default encryption feature, see Amazon
-%% S3 Default Bucket Encryption in the Amazon Simple Storage Service
-%% Developer Guide.
+%% S3 Default Bucket Encryption in the Amazon S3 User Guide.
 %%
 %% To use this operation, you must have permissions to perform the
 %% `s3:PutEncryptionConfiguration' action. The bucket owner has this
 %% permission by default. The bucket owner can grant this permission to
 %% others. For more information about permissions, see Permissions Related to
 %% Bucket Subresource Operations and Managing Access Permissions to your
-%% Amazon S3 Resources in the Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 Resources in the Amazon S3 User Guide.
 %%
 %% == Related Resources ==
 %%
@@ -1263,20 +1277,21 @@ delete_bucket_encryption(Client, Bucket, Input0, Options0) ->
 %%
 %% The S3 Intelligent-Tiering storage class is designed to optimize storage
 %% costs by automatically moving data to the most cost-effective storage
-%% access tier, without additional operational overhead. S3
-%% Intelligent-Tiering delivers automatic cost savings by moving data between
-%% access tiers, when access patterns change.
+%% access tier, without performance impact or operational overhead. S3
+%% Intelligent-Tiering delivers automatic cost savings in two low latency and
+%% high throughput access tiers. For data that can be accessed
+%% asynchronously, you can choose to activate automatic archiving
+%% capabilities within the S3 Intelligent-Tiering storage class.
 %%
-%% The S3 Intelligent-Tiering storage class is suitable for objects larger
-%% than 128 KB that you plan to store for at least 30 days. If the size of an
-%% object is less than 128 KB, it is not eligible for auto-tiering. Smaller
-%% objects can be stored, but they are always charged at the frequent access
-%% tier rates in the S3 Intelligent-Tiering storage class.
+%% The S3 Intelligent-Tiering storage class is the ideal storage class for
+%% data with unknown, changing, or unpredictable access patterns, independent
+%% of object size or retention period. If the size of an object is less than
+%% 128 KB, it is not eligible for auto-tiering. Smaller objects can be
+%% stored, but they are always charged at the Frequent Access tier rates in
+%% the S3 Intelligent-Tiering storage class.
 %%
-%% If you delete an object before the end of the 30-day minimum storage
-%% duration period, you are charged for 30 days. For more information, see
-%% Storage class for automatically optimizing frequently and infrequently
-%% accessed objects.
+%% For more information, see Storage class for automatically optimizing
+%% frequently and infrequently accessed objects.
 %%
 %% Operations related to `DeleteBucketIntelligentTieringConfiguration'
 %% include:
@@ -1498,11 +1513,11 @@ delete_bucket_ownership_controls(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This implementation of the DELETE operation uses the policy
-%% subresource to delete the policy of a specified bucket.
+%% @doc This implementation of the DELETE action uses the policy subresource
+%% to delete the policy of a specified bucket.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the bucket, the calling identity must have the
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the bucket, the calling identity must have the
 %% `DeleteBucketPolicy' permissions on the specified bucket and belong to the
 %% bucket owner's account to use this operation.
 %%
@@ -1511,9 +1526,9 @@ delete_bucket_ownership_controls(Client, Bucket, Input0, Options0) ->
 %% not using an identity that belongs to the bucket owner's account, Amazon
 %% S3 returns a `405 Method Not Allowed' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this operation, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
 %% For more information about bucket policies, see Using Bucket Policies and
 %% UserPolicies.
@@ -1561,7 +1576,7 @@ delete_bucket_policy(Client, Bucket, Input0, Options0) ->
 %% fully propagate.
 %%
 %% For information about replication configuration, see Replication in the
-%% Amazon S3 Developer Guide.
+%% Amazon S3 User Guide.
 %%
 %% The following operations are related to `DeleteBucketReplication':
 %%
@@ -1631,7 +1646,7 @@ delete_bucket_tagging(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This operation removes the website configuration for a bucket.
+%% @doc This action removes the website configuration for a bucket.
 %%
 %% Amazon S3 returns a `200 OK' response upon successfully deleting a website
 %% configuration on the specified bucket. You will get a `200 OK' response if
@@ -1639,7 +1654,7 @@ delete_bucket_tagging(Client, Bucket, Input0, Options0) ->
 %% bucket. Amazon S3 returns a `404' response if the bucket specified in the
 %% request does not exist.
 %%
-%% This DELETE operation requires the `S3:DeleteBucketWebsite' permission. By
+%% This DELETE action requires the `S3:DeleteBucketWebsite' permission. By
 %% default, only the bucket owner can delete the website configuration
 %% attached to a bucket. However, bucket owners can grant other users
 %% permission to delete the website configuration by writing a bucket policy
@@ -1682,7 +1697,8 @@ delete_bucket_website(Client, Bucket, Input0, Options0) ->
 %% @doc Removes the null version (if there is one) of an object and inserts a
 %% delete marker, which becomes the latest version of the object.
 %%
-%% If there isn't a null version, Amazon S3 does not remove any objects.
+%% If there isn't a null version, Amazon S3 does not remove any objects but
+%% will still respond that the command was successful.
 %%
 %% To remove a specific version, you must be the bucket owner and you must
 %% use the version Id subresource. Using this subresource permanently deletes
@@ -1697,14 +1713,13 @@ delete_bucket_website(Client, Bucket, Input0, Options0) ->
 %% For more information about MFA Delete, see Using MFA Delete. To see sample
 %% requests that use versioning, see Sample Request.
 %%
-%% You can delete objects by explicitly calling the DELETE Object API or
-%% configure its lifecycle (PutBucketLifecycle) to enable Amazon S3 to remove
-%% them for you. If you want to block users or accounts from removing or
-%% deleting objects from your bucket, you must deny them the
-%% `s3:DeleteObject', `s3:DeleteObjectVersion', and
-%% `s3:PutLifeCycleConfiguration' actions.
+%% You can delete objects by explicitly calling DELETE Object or configure
+%% its lifecycle (PutBucketLifecycle) to enable Amazon S3 to remove them for
+%% you. If you want to block users or accounts from removing or deleting
+%% objects from your bucket, you must deny them the `s3:DeleteObject',
+%% `s3:DeleteObjectVersion', and `s3:PutLifeCycleConfiguration' actions.
 %%
-%% The following operation is related to `DeleteObject':
+%% The following action is related to `DeleteObject':
 %%
 %% <ul> <li> PutObject
 %%
@@ -1815,10 +1830,10 @@ delete_object_tagging(Client, Bucket, Key, Input0, Options0) ->
         Result
     end.
 
-%% @doc This operation enables you to delete multiple objects from a bucket
+%% @doc This action enables you to delete multiple objects from a bucket
 %% using a single HTTP request.
 %%
-%% If you know the object keys that you want to delete, then this operation
+%% If you know the object keys that you want to delete, then this action
 %% provides a suitable alternative to sending individual delete requests,
 %% reducing per-request overhead.
 %%
@@ -1826,20 +1841,20 @@ delete_object_tagging(Client, Bucket, Key, Input0, Options0) ->
 %% the XML, you provide the object key names, and optionally, version IDs if
 %% you want to delete a specific version of the object from a
 %% versioning-enabled bucket. For each key, Amazon S3 performs a delete
-%% operation and returns the result of that delete, success, or failure, in
-%% the response. Note that if the object specified in the request is not
-%% found, Amazon S3 returns the result as deleted.
+%% action and returns the result of that delete, success, or failure, in the
+%% response. Note that if the object specified in the request is not found,
+%% Amazon S3 returns the result as deleted.
 %%
-%% The operation supports two modes for the response: verbose and quiet. By
-%% default, the operation uses verbose mode in which the response includes
-%% the result of deletion of each key in your request. In quiet mode the
-%% response includes only keys where the delete operation encountered an
-%% error. For a successful deletion, the operation does not return any
-%% information about the delete in the response body.
+%% The action supports two modes for the response: verbose and quiet. By
+%% default, the action uses verbose mode in which the response includes the
+%% result of deletion of each key in your request. In quiet mode the response
+%% includes only keys where the delete action encountered an error. For a
+%% successful deletion, the action does not return any information about the
+%% delete in the response body.
 %%
-%% When performing this operation on an MFA Delete enabled bucket, that
-%% attempts to delete any versioned objects, you must include an MFA token.
-%% If you do not provide one, the entire request will fail, even if there are
+%% When performing this action on an MFA Delete enabled bucket, that attempts
+%% to delete any versioned objects, you must include an MFA token. If you do
+%% not provide one, the entire request will fail, even if there are
 %% non-versioned objects you are trying to delete. If you provide an invalid
 %% token, whether there are versioned keys in the request or not, the entire
 %% Multi-Object Delete request will fail. For information about MFA Delete,
@@ -1948,7 +1963,7 @@ delete_public_access_block(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This implementation of the GET operation uses the `accelerate'
+%% @doc This implementation of the GET action uses the `accelerate'
 %% subresource to return the Transfer Acceleration state of a bucket, which
 %% is either `Enabled' or `Suspended'.
 %%
@@ -1960,7 +1975,7 @@ delete_public_access_block(Client, Bucket, Input0, Options0) ->
 %% permission by default. The bucket owner can grant this permission to
 %% others. For more information about permissions, see Permissions Related to
 %% Bucket Subresource Operations and Managing Access Permissions to your
-%% Amazon S3 Resources in the Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 Resources in the Amazon S3 User Guide.
 %%
 %% You set the Transfer Acceleration state of an existing bucket to `Enabled'
 %% or `Suspended' by using the PutBucketAccelerateConfiguration operation.
@@ -1970,7 +1985,7 @@ delete_public_access_block(Client, Bucket, Input0, Options0) ->
 %% state if a state has never been set on the bucket.
 %%
 %% For more information about transfer acceleration, see Transfer
-%% Acceleration in the Amazon Simple Storage Service Developer Guide.
+%% Acceleration in the Amazon S3 User Guide.
 %%
 %% == Related Resources ==
 %%
@@ -2003,8 +2018,8 @@ get_bucket_accelerate_configuration(Client, Bucket, QueryMap, HeadersMap, Option
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This implementation of the `GET' operation uses the `acl' subresource
-%% to return the access control list (ACL) of a bucket.
+%% @doc This implementation of the `GET' action uses the `acl' subresource to
+%% return the access control list (ACL) of a bucket.
 %%
 %% To use `GET' to return the ACL of the bucket, you must have `READ_ACP'
 %% access to the bucket. If `READ_ACP' permission is granted to the anonymous
@@ -2042,7 +2057,7 @@ get_bucket_acl(Client, Bucket, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This implementation of the GET operation returns an analytics
+%% @doc This implementation of the GET action returns an analytics
 %% configuration (identified by the analytics configuration ID) from the
 %% bucket.
 %%
@@ -2051,11 +2066,10 @@ get_bucket_acl(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% permission by default. The bucket owner can grant this permission to
 %% others. For more information about permissions, see Permissions Related to
 %% Bucket Subresource Operations and Managing Access Permissions to Your
-%% Amazon S3 Resources in the Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 Resources in the Amazon S3 User Guide.
 %%
 %% For information about Amazon S3 analytics feature, see Amazon S3 Analytics
-%% – Storage Class Analysis in the Amazon Simple Storage Service Developer
-%% Guide.
+%% – Storage Class Analysis in the Amazon S3 User Guide.
 %%
 %% == Related Resources ==
 %%
@@ -2192,20 +2206,21 @@ get_bucket_encryption(Client, Bucket, QueryMap, HeadersMap, Options0)
 %%
 %% The S3 Intelligent-Tiering storage class is designed to optimize storage
 %% costs by automatically moving data to the most cost-effective storage
-%% access tier, without additional operational overhead. S3
-%% Intelligent-Tiering delivers automatic cost savings by moving data between
-%% access tiers, when access patterns change.
+%% access tier, without performance impact or operational overhead. S3
+%% Intelligent-Tiering delivers automatic cost savings in two low latency and
+%% high throughput access tiers. For data that can be accessed
+%% asynchronously, you can choose to activate automatic archiving
+%% capabilities within the S3 Intelligent-Tiering storage class.
 %%
-%% The S3 Intelligent-Tiering storage class is suitable for objects larger
-%% than 128 KB that you plan to store for at least 30 days. If the size of an
-%% object is less than 128 KB, it is not eligible for auto-tiering. Smaller
-%% objects can be stored, but they are always charged at the frequent access
-%% tier rates in the S3 Intelligent-Tiering storage class.
+%% The S3 Intelligent-Tiering storage class is the ideal storage class for
+%% data with unknown, changing, or unpredictable access patterns, independent
+%% of object size or retention period. If the size of an object is less than
+%% 128 KB, it is not eligible for auto-tiering. Smaller objects can be
+%% stored, but they are always charged at the Frequent Access tier rates in
+%% the S3 Intelligent-Tiering storage class.
 %%
-%% If you delete an object before the end of the 30-day minimum storage
-%% duration period, you are charged for 30 days. For more information, see
-%% Storage class for automatically optimizing frequently and infrequently
-%% accessed objects.
+%% For more information, see Storage class for automatically optimizing
+%% frequently and infrequently accessed objects.
 %%
 %% Operations related to `GetBucketIntelligentTieringConfiguration' include:
 %%
@@ -2366,7 +2381,7 @@ get_bucket_lifecycle(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% the new filter element that you can use to specify a filter to select a
 %% subset of objects to which the rule applies. If you are using a previous
 %% version of the lifecycle configuration, it still works. For the earlier
-%% API description, see GetBucketLifecycle.
+%% action, see GetBucketLifecycle.
 %%
 %% Returns the lifecycle configuration information set on the bucket. For
 %% information about lifecycle configuration, see Object Lifecycle
@@ -2432,6 +2447,9 @@ get_bucket_lifecycle_configuration(Client, Bucket, QueryMap, HeadersMap, Options
 %% CreateBucket.
 %%
 %% To use this implementation of the operation, you must be the bucket owner.
+%%
+%% To use this API against an access point, provide the alias of the access
+%% point in place of the bucket name.
 %%
 %% The following operations are related to `GetBucketLocation':
 %%
@@ -2589,7 +2607,7 @@ get_bucket_notification(Client, Bucket, QueryMap, HeadersMap, Options0)
 
 %% @doc Returns the notification configuration of a bucket.
 %%
-%% If notifications are not enabled on the bucket, the operation returns an
+%% If notifications are not enabled on the bucket, the action returns an
 %% empty `NotificationConfiguration' element.
 %%
 %% By default, you must be the bucket owner to read the notification
@@ -2601,7 +2619,7 @@ get_bucket_notification(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% configuration on a bucket, see Setting Up Notification of Bucket Events.
 %% For more information about bucket policies, see Using Bucket Policies.
 %%
-%% The following operation is related to `GetBucketNotification':
+%% The following action is related to `GetBucketNotification':
 %%
 %% <ul> <li> PutBucketNotification
 %%
@@ -2676,24 +2694,24 @@ get_bucket_ownership_controls(Client, Bucket, QueryMap, HeadersMap, Options0)
 
 %% @doc Returns the policy of a specified bucket.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the bucket, the calling identity must have the `GetBucketPolicy'
-%% permissions on the specified bucket and belong to the bucket owner's
-%% account in order to use this operation.
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the bucket, the calling identity must have the
+%% `GetBucketPolicy' permissions on the specified bucket and belong to the
+%% bucket owner's account in order to use this operation.
 %%
 %% If you don't have `GetBucketPolicy' permissions, Amazon S3 returns a `403
 %% Access Denied' error. If you have the correct permissions, but you're not
 %% using an identity that belongs to the bucket owner's account, Amazon S3
 %% returns a `405 Method Not Allowed' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this operation, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
 %% For more information about bucket policies, see Using Bucket Policies and
 %% User Policies.
 %%
-%% The following operation is related to `GetBucketPolicy':
+%% The following action is related to `GetBucketPolicy':
 %%
 %% <ul> <li> GetObject
 %%
@@ -2778,11 +2796,11 @@ get_bucket_policy_status(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% after put or delete can return a wrong result.
 %%
 %% For information about replication configuration, see Replication in the
-%% Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 User Guide.
 %%
-%% This operation requires permissions for the
-%% `s3:GetReplicationConfiguration' action. For more information about
-%% permissions, see Using Bucket Policies and User Policies.
+%% This action requires permissions for the `s3:GetReplicationConfiguration'
+%% action. For more information about permissions, see Using Bucket Policies
+%% and User Policies.
 %%
 %% If you include the `Filter' element in a replication configuration, you
 %% must also include the `DeleteMarkerReplication' and `Priority' elements.
@@ -2956,11 +2974,11 @@ get_bucket_versioning(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% adding a website configuration. For more information about hosting
 %% websites, see Hosting Websites on Amazon S3.
 %%
-%% This GET operation requires the `S3:GetBucketWebsite' permission. By
-%% default, only the bucket owner can read the bucket website configuration.
-%% However, bucket owners can allow other users to read the website
-%% configuration by writing a bucket policy granting them the
-%% `S3:GetBucketWebsite' permission.
+%% This GET action requires the `S3:GetBucketWebsite' permission. By default,
+%% only the bucket owner can read the bucket website configuration. However,
+%% bucket owners can allow other users to read the website configuration by
+%% writing a bucket policy granting them the `S3:GetBucketWebsite'
+%% permission.
 %%
 %% The following operations are related to `DeleteBucketWebsite':
 %%
@@ -3023,15 +3041,15 @@ get_bucket_website(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% If the object you are retrieving is stored in the S3 Glacier or S3 Glacier
 %% Deep Archive storage class, or S3 Intelligent-Tiering Archive or S3
 %% Intelligent-Tiering Deep Archive tiers, before you can retrieve the object
-%% you must first restore a copy using RestoreObject. Otherwise, this
-%% operation returns an `InvalidObjectStateError' error. For information
-%% about restoring archived objects, see Restoring Archived Objects.
+%% you must first restore a copy using RestoreObject. Otherwise, this action
+%% returns an `InvalidObjectStateError' error. For information about
+%% restoring archived objects, see Restoring Archived Objects.
 %%
 %% Encryption request headers, like `x-amz-server-side-encryption', should
 %% not be sent for GET requests if your object uses server-side encryption
-%% with CMKs stored in AWS KMS (SSE-KMS) or server-side encryption with
-%% Amazon S3–managed encryption keys (SSE-S3). If your object does use these
-%% types of keys, you’ll get an HTTP 400 BadRequest error.
+%% with KMS keys (SSE-KMS) or server-side encryption with Amazon S3–managed
+%% encryption keys (SSE-S3). If your object does use these types of keys,
+%% you’ll get an HTTP 400 BadRequest error.
 %%
 %% If you encrypt an object by using server-side encryption with
 %% customer-provided encryption keys (SSE-C) when you store the object in
@@ -3047,18 +3065,17 @@ get_bucket_website(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% </li> </ul> For more information about SSE-C, see Server-Side Encryption
 %% (Using Customer-Provided Encryption Keys).
 %%
-%% Assuming you have permission to read object tags (permission for the
-%% `s3:GetObjectVersionTagging' action), the response also returns the
-%% `x-amz-tagging-count' header that provides the count of number of tags
-%% associated with the object. You can use GetObjectTagging to retrieve the
-%% tag set associated with an object.
+%% Assuming you have the relevant permission to read object tags, the
+%% response also returns the `x-amz-tagging-count' header that provides the
+%% count of number of tags associated with the object. You can use
+%% GetObjectTagging to retrieve the tag set associated with an object.
 %%
 %% Permissions
 %%
-%% You need the `s3:GetObject' permission for this operation. For more
-%% information, see Specifying Permissions in a Policy. If the object you
-%% request does not exist, the error Amazon S3 returns depends on whether you
-%% also have the `s3:ListBucket' permission.
+%% You need the relevant read object (or version) permission for this
+%% operation. For more information, see Specifying Permissions in a Policy.
+%% If the object you request does not exist, the error Amazon S3 returns
+%% depends on whether you also have the `s3:ListBucket' permission.
 %%
 %% <ul> <li> If you have the `s3:ListBucket' permission on the bucket, Amazon
 %% S3 will return an HTTP status code 404 ("no such key") error.
@@ -3068,8 +3085,11 @@ get_bucket_website(Client, Bucket, QueryMap, HeadersMap, Options0)
 %%
 %% </li> </ul> Versioning
 %%
-%% By default, the GET operation returns the current version of an object. To
+%% By default, the GET action returns the current version of an object. To
 %% return a different version, use the `versionId' subresource.
+%%
+%% You need the `s3:GetObjectVersion' permission to access a specific version
+%% of an object.
 %%
 %% If the current version of the object is a delete marker, Amazon S3 behaves
 %% as if the object was deleted and includes `x-amz-delete-marker: true' in
@@ -3398,7 +3418,7 @@ get_object_retention(Client, Bucket, Key, QueryMap, HeadersMap, Options0)
 %% the object.
 %%
 %% To use this operation, you must have permission to perform the
-%% `s3:GetObjectTagging' action. By default, the GET operation returns
+%% `s3:GetObjectTagging' action. By default, the GET action returns
 %% information about current version of an object. For a versioned bucket,
 %% you can have multiple versions of an object in your bucket. To retrieve
 %% tags of any other version, use the versionId query parameter. You also
@@ -3410,7 +3430,7 @@ get_object_retention(Client, Bucket, Key, QueryMap, HeadersMap, Options0)
 %% For information about the Amazon S3 object tagging feature, see Object
 %% Tagging.
 %%
-%% The following operation is related to `GetObjectTagging':
+%% The following action is related to `GetObjectTagging':
 %%
 %% <ul> <li> PutObjectTagging
 %%
@@ -3478,7 +3498,7 @@ get_object_tagging(Client, Bucket, Key, QueryMap, HeadersMap, Options0)
 %%
 %% This action is not supported by Amazon S3 on Outposts.
 %%
-%% The following operation is related to `GetObjectTorrent':
+%% The following action is related to `GetObjectTorrent':
 %%
 %% <ul> <li> GetObject
 %%
@@ -3580,11 +3600,11 @@ get_public_access_block(Client, Bucket, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This operation is useful to determine if a bucket exists and you have
+%% @doc This action is useful to determine if a bucket exists and you have
 %% permission to access it.
 %%
-%% The operation returns a `200 OK' if the bucket exists and you have
-%% permission to access it.
+%% The action returns a `200 OK' if the bucket exists and you have permission
+%% to access it.
 %%
 %% If the bucket does not exist or you do not have permission to access it,
 %% the `HEAD' request returns a generic `404 Not Found' or `403 Forbidden'
@@ -3596,6 +3616,14 @@ get_public_access_block(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% and can grant this permission to others. For more information about
 %% permissions, see Permissions Related to Bucket Subresource Operations and
 %% Managing Access Permissions to Your Amazon S3 Resources.
+%%
+%% To use this API against an access point, you must provide the alias of the
+%% access point in place of the bucket name or specify the access point ARN.
+%% When using the access point ARN, you must direct requests to the access
+%% point hostname. The access point hostname takes the form
+%% AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using
+%% the Amazon Web Services SDKs, you provide the ARN in place of the bucket
+%% name. For more information see, Using access points.
 head_bucket(Client, Bucket, Input) ->
     head_bucket(Client, Bucket, Input, []).
 head_bucket(Client, Bucket, Input0, Options0) ->
@@ -3620,14 +3648,14 @@ head_bucket(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc The HEAD operation retrieves metadata from an object without
-%% returning the object itself.
+%% @doc The HEAD action retrieves metadata from an object without returning
+%% the object itself.
 %%
-%% This operation is useful if you're only interested in an object's
-%% metadata. To use HEAD, you must have READ access to the object.
+%% This action is useful if you're only interested in an object's metadata.
+%% To use HEAD, you must have READ access to the object.
 %%
-%% A `HEAD' request has the same options as a `GET' operation on an object.
-%% The response is identical to the `GET' response except that there is no
+%% A `HEAD' request has the same options as a `GET' action on an object. The
+%% response is identical to the `GET' response except that there is no
 %% response body. Because of this, if the `HEAD' request generates an error,
 %% it returns a generic `404 Not Found' or `403 Forbidden' code. It is not
 %% possible to retrieve the exact exception beyond these error codes.
@@ -3648,9 +3676,9 @@ head_bucket(Client, Bucket, Input0, Options0) ->
 %%
 %% Encryption request headers, like `x-amz-server-side-encryption', should
 %% not be sent for GET requests if your object uses server-side encryption
-%% with CMKs stored in AWS KMS (SSE-KMS) or server-side encryption with
-%% Amazon S3–managed encryption keys (SSE-S3). If your object does use these
-%% types of keys, you’ll get an HTTP 400 BadRequest error.
+%% with KMS keys (SSE-KMS) or server-side encryption with Amazon S3–managed
+%% encryption keys (SSE-S3). If your object does use these types of keys,
+%% you’ll get an HTTP 400 BadRequest error.
 %%
 %% The last modified property in this case is the creation date of the
 %% object.
@@ -3682,10 +3710,10 @@ head_bucket(Client, Bucket, Input0, Options0) ->
 %%
 %% Permissions
 %%
-%% You need the `s3:GetObject' permission for this operation. For more
-%% information, see Specifying Permissions in a Policy. If the object you
-%% request does not exist, the error Amazon S3 returns depends on whether you
-%% also have the s3:ListBucket permission.
+%% You need the relevant read object (or version) permission for this
+%% operation. For more information, see Specifying Permissions in a Policy.
+%% If the object you request does not exist, the error Amazon S3 returns
+%% depends on whether you also have the s3:ListBucket permission.
 %%
 %% <ul> <li> If you have the `s3:ListBucket' permission on the bucket, Amazon
 %% S3 returns an HTTP status code 404 ("no such key") error.
@@ -3693,7 +3721,7 @@ head_bucket(Client, Bucket, Input0, Options0) ->
 %% </li> <li> If you don’t have the `s3:ListBucket' permission, Amazon S3
 %% returns an HTTP status code 403 ("access denied") error.
 %%
-%% </li> </ul> The following operation is related to `HeadObject':
+%% </li> </ul> The following action is related to `HeadObject':
 %%
 %% <ul> <li> GetObject
 %%
@@ -3781,7 +3809,7 @@ head_object(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% You can have up to 1,000 analytics configurations per bucket.
 %%
-%% This operation supports list pagination and does not return more than 100
+%% This action supports list pagination and does not return more than 100
 %% configurations at a time. You should always check the `IsTruncated'
 %% element in the response. If there are no more configurations to list,
 %% `IsTruncated' is set to false. If there are more configurations to list,
@@ -3845,20 +3873,21 @@ list_bucket_analytics_configurations(Client, Bucket, QueryMap, HeadersMap, Optio
 %%
 %% The S3 Intelligent-Tiering storage class is designed to optimize storage
 %% costs by automatically moving data to the most cost-effective storage
-%% access tier, without additional operational overhead. S3
-%% Intelligent-Tiering delivers automatic cost savings by moving data between
-%% access tiers, when access patterns change.
+%% access tier, without performance impact or operational overhead. S3
+%% Intelligent-Tiering delivers automatic cost savings in two low latency and
+%% high throughput access tiers. For data that can be accessed
+%% asynchronously, you can choose to activate automatic archiving
+%% capabilities within the S3 Intelligent-Tiering storage class.
 %%
-%% The S3 Intelligent-Tiering storage class is suitable for objects larger
-%% than 128 KB that you plan to store for at least 30 days. If the size of an
-%% object is less than 128 KB, it is not eligible for auto-tiering. Smaller
-%% objects can be stored, but they are always charged at the frequent access
-%% tier rates in the S3 Intelligent-Tiering storage class.
+%% The S3 Intelligent-Tiering storage class is the ideal storage class for
+%% data with unknown, changing, or unpredictable access patterns, independent
+%% of object size or retention period. If the size of an object is less than
+%% 128 KB, it is not eligible for auto-tiering. Smaller objects can be
+%% stored, but they are always charged at the Frequent Access tier rates in
+%% the S3 Intelligent-Tiering storage class.
 %%
-%% If you delete an object before the end of the 30-day minimum storage
-%% duration period, you are charged for 30 days. For more information, see
-%% Storage class for automatically optimizing frequently and infrequently
-%% accessed objects.
+%% For more information, see Storage class for automatically optimizing
+%% frequently and infrequently accessed objects.
 %%
 %% Operations related to `ListBucketIntelligentTieringConfigurations'
 %% include:
@@ -3900,7 +3929,7 @@ list_bucket_intelligent_tiering_configurations(Client, Bucket, QueryMap, Headers
 %%
 %% You can have up to 1,000 analytics configurations per bucket.
 %%
-%% This operation supports list pagination and does not return more than 100
+%% This action supports list pagination and does not return more than 100
 %% configurations at a time. Always check the `IsTruncated' element in the
 %% response. If there are no more configurations to list, `IsTruncated' is
 %% set to false. If there are more configurations to list, `IsTruncated' is
@@ -3965,7 +3994,7 @@ list_bucket_inventory_configurations(Client, Bucket, QueryMap, HeadersMap, Optio
 %% and do not provide information on daily storage metrics. You can have up
 %% to 1,000 configurations per bucket.
 %%
-%% This operation supports list pagination and does not return more than 100
+%% This action supports list pagination and does not return more than 100
 %% configurations at a time. Always check the `IsTruncated' element in the
 %% response. If there are no more configurations to list, `IsTruncated' is
 %% set to false. If there are more configurations to list, `IsTruncated' is
@@ -4047,16 +4076,16 @@ list_buckets(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This operation lists in-progress multipart uploads.
+%% @doc This action lists in-progress multipart uploads.
 %%
 %% An in-progress multipart upload is a multipart upload that has been
 %% initiated using the Initiate Multipart Upload request, but has not yet
 %% been completed or aborted.
 %%
-%% This operation returns at most 1,000 multipart uploads in the response.
-%% 1,000 multipart uploads is the maximum number of uploads a response can
-%% include, which is also the default value. You can further limit the number
-%% of uploads in a response by specifying the `max-uploads' parameter in the
+%% This action returns at most 1,000 multipart uploads in the response. 1,000
+%% multipart uploads is the maximum number of uploads a response can include,
+%% which is also the default value. You can further limit the number of
+%% uploads in a response by specifying the `max-uploads' parameter in the
 %% response. If additional multipart uploads satisfy the list criteria, the
 %% response will contain an `IsTruncated' element with the value true. To
 %% list the additional multipart uploads, use the `key-marker' and
@@ -4071,7 +4100,7 @@ list_buckets(Client, QueryMap, HeadersMap, Options0)
 %% Multipart Upload.
 %%
 %% For information on permissions required to use the multipart upload API,
-%% see Multipart Upload API and Permissions.
+%% see Multipart Upload and Permissions.
 %%
 %% The following operations are related to `ListMultipartUploads':
 %%
@@ -4125,6 +4154,9 @@ list_multipart_uploads(Client, Bucket, QueryMap, HeadersMap, Options0)
 %%
 %% You can also use request parameters as selection criteria to return
 %% metadata about a subset of all the object versions.
+%%
+%% To use this operation, you must have permissions to perform the
+%% `s3:ListBucketVersions' action. Be aware of the name difference.
 %%
 %% A 200 OK response can contain valid or invalid XML. Make sure to design
 %% your application to parse the contents of the response and handle it
@@ -4187,7 +4219,7 @@ list_object_versions(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% invalid XML. Be sure to design your application to parse the contents of
 %% the response and handle it appropriately.
 %%
-%% This API has been revised. We recommend that you use the newer version,
+%% This action has been revised. We recommend that you use the newer version,
 %% ListObjectsV2, when developing applications. For backward compatibility,
 %% Amazon S3 continues to support `ListObjects'.
 %%
@@ -4239,25 +4271,28 @@ list_objects(Client, Bucket, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns some or all (up to 1,000) of the objects in a bucket.
+%% @doc Returns some or all (up to 1,000) of the objects in a bucket with
+%% each request.
 %%
 %% You can use the request parameters as selection criteria to return a
 %% subset of the objects in a bucket. A `200 OK' response can contain valid
 %% or invalid XML. Make sure to design your application to parse the contents
 %% of the response and handle it appropriately. Objects are returned sorted
-%% in an ascending order of the respective key names in the list.
+%% in an ascending order of the respective key names in the list. For more
+%% information about listing objects, see Listing object keys
+%% programmatically
 %%
 %% To use this operation, you must have READ access to the bucket.
 %%
-%% To use this operation in an AWS Identity and Access Management (IAM)
-%% policy, you must have permissions to perform the `s3:ListBucket' action.
-%% The bucket owner has this permission by default and can grant this
-%% permission to others. For more information about permissions, see
-%% Permissions Related to Bucket Subresource Operations and Managing Access
-%% Permissions to Your Amazon S3 Resources.
+%% To use this action in an Identity and Access Management (IAM) policy, you
+%% must have permissions to perform the `s3:ListBucket' action. The bucket
+%% owner has this permission by default and can grant this permission to
+%% others. For more information about permissions, see Permissions Related to
+%% Bucket Subresource Operations and Managing Access Permissions to Your
+%% Amazon S3 Resources.
 %%
-%% This section describes the latest revision of the API. We recommend that
-%% you use this revised API for application development. For backward
+%% This section describes the latest revision of this action. We recommend
+%% that you use this revised API for application development. For backward
 %% compatibility, Amazon S3 continues to support the prior version of this
 %% API, ListObjects.
 %%
@@ -4327,7 +4362,7 @@ list_objects_v2(Client, Bucket, QueryMap, HeadersMap, Options0)
 %% Multipart Upload.
 %%
 %% For information on permissions required to use the multipart upload API,
-%% see Multipart Upload API and Permissions.
+%% see Multipart Upload and Permissions.
 %%
 %% The following operations are related to `ListParts':
 %%
@@ -4412,7 +4447,7 @@ list_parts(Client, Bucket, Key, UploadId, QueryMap, HeadersMap, Options0)
 %%
 %% </li> <li> Suspended – Disables accelerated data transfers to the bucket.
 %%
-%% </li> </ul> The GetBucketAccelerateConfiguration operation returns the
+%% </li> </ul> The GetBucketAccelerateConfiguration action returns the
 %% transfer acceleration state of a bucket.
 %%
 %% After setting the Transfer Acceleration state of a bucket to Enabled, it
@@ -4491,25 +4526,26 @@ put_bucket_accelerate_configuration(Client, Bucket, Input0, Options0) ->
 %% </li> <li> Specify access permissions explicitly with the
 %% `x-amz-grant-read', `x-amz-grant-read-acp', `x-amz-grant-write-acp', and
 %% `x-amz-grant-full-control' headers. When using these headers, you specify
-%% explicit access permissions and grantees (AWS accounts or Amazon S3
-%% groups) who will receive the permission. If you use these ACL-specific
-%% headers, you cannot use the `x-amz-acl' header to set a canned ACL. These
-%% parameters map to the set of permissions that Amazon S3 supports in an
-%% ACL. For more information, see Access Control List (ACL) Overview.
+%% explicit access permissions and grantees (Amazon Web Services accounts or
+%% Amazon S3 groups) who will receive the permission. If you use these
+%% ACL-specific headers, you cannot use the `x-amz-acl' header to set a
+%% canned ACL. These parameters map to the set of permissions that Amazon S3
+%% supports in an ACL. For more information, see Access Control List (ACL)
+%% Overview.
 %%
 %% You specify each grantee as a type=value pair, where the type is one of
 %% the following:
 %%
-%% <ul> <li> `id' – if the value specified is the canonical user ID of an AWS
-%% account
+%% <ul> <li> `id' – if the value specified is the canonical user ID of an
+%% Amazon Web Services account
 %%
 %% </li> <li> `uri' – if you are granting permissions to a predefined group
 %%
 %% </li> <li> `emailAddress' – if the value specified is the email address of
-%% an AWS account
+%% an Amazon Web Services account
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -4528,12 +4564,12 @@ put_bucket_accelerate_configuration(Client, Bucket, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> For example, the following `x-amz-grant-write' header grants
 %% create, overwrite, and delete objects permission to LogDelivery group
-%% predefined by Amazon S3 and two AWS accounts identified by their email
-%% addresses.
+%% predefined by Amazon S3 and two Amazon Web Services accounts identified by
+%% their email addresses.
 %%
 %% `x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
 %% id="111122223333", id="555566667777" '
@@ -4568,7 +4604,7 @@ put_bucket_accelerate_configuration(Client, Bucket, Input0, Options0) ->
 %% Object acl request, appears as the CanonicalUser.
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -4587,7 +4623,7 @@ put_bucket_accelerate_configuration(Client, Bucket, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> == Related Resources ==
 %%
@@ -4751,7 +4787,7 @@ put_bucket_analytics_configuration(Client, Bucket, Input0, Options0) ->
 %% element.
 %%
 %% </li> </ul> For more information about CORS, go to Enabling Cross-Origin
-%% Resource Sharing in the Amazon Simple Storage Service Developer Guide.
+%% Resource Sharing in the Amazon S3 User Guide.
 %%
 %% == Related Resources ==
 %%
@@ -4787,26 +4823,27 @@ put_bucket_cors(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This operation uses the `encryption' subresource to configure default
+%% @doc This action uses the `encryption' subresource to configure default
 %% encryption and Amazon S3 Bucket Key for an existing bucket.
 %%
 %% Default encryption for a bucket can use server-side encryption with Amazon
-%% S3-managed keys (SSE-S3) or AWS KMS customer master keys (SSE-KMS). If you
+%% S3-managed keys (SSE-S3) or customer managed keys (SSE-KMS). If you
 %% specify default encryption using SSE-KMS, you can also configure Amazon S3
 %% Bucket Key. For information about default encryption, see Amazon S3
-%% default bucket encryption in the Amazon Simple Storage Service Developer
-%% Guide. For more information about S3 Bucket Keys, see Amazon S3 Bucket
-%% Keys in the Amazon Simple Storage Service Developer Guide.
+%% default bucket encryption in the Amazon S3 User Guide. For more
+%% information about S3 Bucket Keys, see Amazon S3 Bucket Keys in the Amazon
+%% S3 User Guide.
 %%
-%% This operation requires AWS Signature Version 4. For more information, see
-%% Authenticating Requests (AWS Signature Version 4).
+%% This action requires Amazon Web Services Signature Version 4. For more
+%% information, see Authenticating Requests (Amazon Web Services Signature
+%% Version 4).
 %%
 %% To use this operation, you must have permissions to perform the
 %% `s3:PutEncryptionConfiguration' action. The bucket owner has this
 %% permission by default. The bucket owner can grant this permission to
 %% others. For more information about permissions, see Permissions Related to
 %% Bucket Subresource Operations and Managing Access Permissions to Your
-%% Amazon S3 Resources in the Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 Resources in the Amazon S3 User Guide.
 %%
 %% == Related Resources ==
 %%
@@ -4846,20 +4883,21 @@ put_bucket_encryption(Client, Bucket, Input0, Options0) ->
 %%
 %% The S3 Intelligent-Tiering storage class is designed to optimize storage
 %% costs by automatically moving data to the most cost-effective storage
-%% access tier, without additional operational overhead. S3
-%% Intelligent-Tiering delivers automatic cost savings by moving data between
-%% access tiers, when access patterns change.
+%% access tier, without performance impact or operational overhead. S3
+%% Intelligent-Tiering delivers automatic cost savings in two low latency and
+%% high throughput access tiers. For data that can be accessed
+%% asynchronously, you can choose to activate automatic archiving
+%% capabilities within the S3 Intelligent-Tiering storage class.
 %%
-%% The S3 Intelligent-Tiering storage class is suitable for objects larger
-%% than 128 KB that you plan to store for at least 30 days. If the size of an
-%% object is less than 128 KB, it is not eligible for auto-tiering. Smaller
-%% objects can be stored, but they are always charged at the frequent access
-%% tier rates in the S3 Intelligent-Tiering storage class.
+%% The S3 Intelligent-Tiering storage class is the ideal storage class for
+%% data with unknown, changing, or unpredictable access patterns, independent
+%% of object size or retention period. If the size of an object is less than
+%% 128 KB, it is not eligible for auto-tiering. Smaller objects can be
+%% stored, but they are always charged at the Frequent Access tier rates in
+%% the S3 Intelligent-Tiering storage class.
 %%
-%% If you delete an object before the end of the 30-day minimum storage
-%% duration period, you are charged for 30 days. For more information, see
-%% Storage class for automatically optimizing frequently and infrequently
-%% accessed objects.
+%% For more information, see Storage class for automatically optimizing
+%% frequently and infrequently accessed objects.
 %%
 %% Operations related to `PutBucketIntelligentTieringConfiguration' include:
 %%
@@ -4921,7 +4959,7 @@ put_bucket_intelligent_tiering_configuration(Client, Bucket, Input0, Options0) -
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This implementation of the `PUT' operation adds an inventory
+%% @doc This implementation of the `PUT' action adds an inventory
 %% configuration (identified by the inventory ID) to the bucket.
 %%
 %% You can have up to 1,000 inventory configurations per bucket.
@@ -4930,15 +4968,15 @@ put_bucket_intelligent_tiering_configuration(Client, Bucket, Input0, Options0) -
 %% a daily or weekly basis, and the results are published to a flat file. The
 %% bucket that is inventoried is called the source bucket, and the bucket
 %% where the inventory flat file is stored is called the destination bucket.
-%% The destination bucket must be in the same AWS Region as the source
-%% bucket.
+%% The destination bucket must be in the same Amazon Web Services Region as
+%% the source bucket.
 %%
 %% When you configure an inventory for a source bucket, you specify the
 %% destination bucket where you want the inventory to be stored, and whether
 %% to generate the inventory daily or weekly. You can also configure what
 %% object metadata to include and whether to inventory all object versions or
 %% only current versions. For more information, see Amazon S3 Inventory in
-%% the Amazon Simple Storage Service Developer Guide.
+%% the Amazon S3 User Guide.
 %%
 %% You must create a bucket policy on the destination bucket to grant
 %% permissions to Amazon S3 to write objects to the bucket in the defined
@@ -4950,7 +4988,7 @@ put_bucket_intelligent_tiering_configuration(Client, Bucket, Input0, Options0) -
 %% permission by default and can grant this permission to others. For more
 %% information about permissions, see Permissions Related to Bucket
 %% Subresource Operations and Managing Access Permissions to Your Amazon S3
-%% Resources in the Amazon Simple Storage Service Developer Guide.
+%% Resources in the Amazon S3 User Guide.
 %%
 %% == Special Errors ==
 %%
@@ -5017,15 +5055,16 @@ put_bucket_inventory_configuration(Client, Bucket, Input0, Options0) ->
 %%
 %% Creates a new lifecycle configuration for the bucket or replaces an
 %% existing lifecycle configuration. For information about lifecycle
-%% configuration, see Object Lifecycle Management in the Amazon Simple
-%% Storage Service Developer Guide.
+%% configuration, see Object Lifecycle Management in the Amazon S3 User
+%% Guide.
 %%
 %% By default, all Amazon S3 resources, including buckets, objects, and
 %% related subresources (for example, lifecycle configuration and website
-%% configuration) are private. Only the resource owner, the AWS account that
-%% created the resource, can access it. The resource owner can optionally
-%% grant access permissions to others by writing an access policy. For this
-%% operation, users must get the `s3:PutLifecycleConfiguration' permission.
+%% configuration) are private. Only the resource owner, the Amazon Web
+%% Services account that created the resource, can access it. The resource
+%% owner can optionally grant access permissions to others by writing an
+%% access policy. For this operation, users must get the
+%% `s3:PutLifecycleConfiguration' permission.
 %%
 %% You can also explicitly deny permissions. Explicit denial also supersedes
 %% any other permissions. If you want to prevent users or accounts from
@@ -5039,8 +5078,7 @@ put_bucket_inventory_configuration(Client, Bucket, Input0, Options0) ->
 %% </li> <li> `s3:PutLifecycleConfiguration'
 %%
 %% </li> </ul> For more information about permissions, see Managing Access
-%% Permissions to your Amazon S3 Resources in the Amazon Simple Storage
-%% Service Developer Guide.
+%% Permissions to your Amazon S3 Resources in the Amazon S3 User Guide.
 %%
 %% For more examples of transitioning objects to storage classes such as
 %% STANDARD_IA or ONEZONE_IA, see Examples of Lifecycle Configuration.
@@ -5054,10 +5092,10 @@ put_bucket_inventory_configuration(Client, Bucket, Input0, Options0) ->
 %% </li> <li> RestoreObject
 %%
 %% </li> <li> By default, a resource owner—in this case, a bucket owner,
-%% which is the AWS account that created the bucket—can perform any of the
-%% operations. A resource owner can also grant others permission to perform
-%% the operation. For more information, see the following topics in the
-%% Amazon Simple Storage Service Developer Guide:
+%% which is the Amazon Web Services account that created the bucket—can
+%% perform any of the operations. A resource owner can also grant others
+%% permission to perform the operation. For more information, see the
+%% following topics in the Amazon S3 User Guide:
 %%
 %% <ul> <li> Specifying Permissions in a Policy
 %%
@@ -5092,8 +5130,8 @@ put_bucket_lifecycle(Client, Bucket, Input0, Options0) ->
 %% @doc Creates a new lifecycle configuration for the bucket or replaces an
 %% existing lifecycle configuration.
 %%
-%% For information about lifecycle configuration, see Managing Access
-%% Permissions to Your Amazon S3 Resources.
+%% For information about lifecycle configuration, see Managing your storage
+%% lifecycle.
 %%
 %% Bucket lifecycle configuration now supports specifying a lifecycle rule
 %% using an object key name prefix, one or more object tags, or a combination
@@ -5128,11 +5166,11 @@ put_bucket_lifecycle(Client, Bucket, Input0, Options0) ->
 %%
 %% By default, all Amazon S3 resources are private, including buckets,
 %% objects, and related subresources (for example, lifecycle configuration
-%% and website configuration). Only the resource owner (that is, the AWS
-%% account that created it) can access the resource. The resource owner can
-%% optionally grant access permissions to others by writing an access policy.
-%% For this operation, a user must get the s3:PutLifecycleConfiguration
-%% permission.
+%% and website configuration). Only the resource owner (that is, the Amazon
+%% Web Services account that created it) can access the resource. The
+%% resource owner can optionally grant access permissions to others by
+%% writing an access policy. For this operation, a user must get the
+%% s3:PutLifecycleConfiguration permission.
 %%
 %% You can also explicitly deny permissions. Explicit deny also supersedes
 %% any other permissions. If you want to block users or accounts from
@@ -5184,8 +5222,9 @@ put_bucket_lifecycle_configuration(Client, Bucket, Input0, Options0) ->
 %% @doc Set the logging parameters for a bucket and to specify permissions
 %% for who can view and modify the logging parameters.
 %%
-%% All logs are saved to buckets in the same AWS Region as the source bucket.
-%% To set the logging status of a bucket, you must be the bucket owner.
+%% All logs are saved to buckets in the same Amazon Web Services Region as
+%% the source bucket. To set the logging status of a bucket, you must be the
+%% bucket owner.
 %%
 %% The bucket owner is automatically granted FULL_CONTROL to all logs. You
 %% use the `Grantee' request element to grant access to other people. The
@@ -5289,7 +5328,7 @@ put_bucket_logging(Client, Bucket, Input0, Options0) ->
 %%
 %% <ul> <li> DeleteBucketMetricsConfiguration
 %%
-%% </li> <li> PutBucketMetricsConfiguration
+%% </li> <li> GetBucketMetricsConfiguration
 %%
 %% </li> <li> ListBucketMetricsConfigurations
 %%
@@ -5373,13 +5412,13 @@ put_bucket_notification(Client, Bucket, Input0, Options0) ->
 %%
 %% `</NotificationConfiguration>'
 %%
-%% This operation replaces the existing notification configuration with the
+%% This action replaces the existing notification configuration with the
 %% configuration you include in the request body.
 %%
 %% After Amazon S3 receives this request, it first verifies that any Amazon
 %% Simple Notification Service (Amazon SNS) or Amazon Simple Queue Service
 %% (Amazon SQS) destination exists, and that the bucket owner has permission
-%% to publish to it by sending a test notification. In the case of AWS Lambda
+%% to publish to it by sending a test notification. In the case of Lambda
 %% destinations, Amazon S3 verifies that the Lambda function permissions
 %% grant Amazon S3 permission to invoke the function from the Amazon S3
 %% bucket. For more information, see Configuring Notifications for Amazon S3
@@ -5397,8 +5436,8 @@ put_bucket_notification(Client, Bucket, Input0, Options0) ->
 %% notification configuration includes SNS topic, SQS queue, and Lambda
 %% function configurations. When you send a PUT request with this
 %% configuration, Amazon S3 sends test messages to your SNS topic. If the
-%% message fails, the entire PUT operation will fail, and Amazon S3 will not
-%% add the configuration to your bucket.
+%% message fails, the entire PUT action will fail, and Amazon S3 will not add
+%% the configuration to your bucket.
 %%
 %% Responses
 %%
@@ -5408,8 +5447,7 @@ put_bucket_notification(Client, Bucket, Input0, Options0) ->
 %% header containing the message ID of the test notification sent to the
 %% topic.
 %%
-%% The following operation is related to
-%% `PutBucketNotificationConfiguration':
+%% The following action is related to `PutBucketNotificationConfiguration':
 %%
 %% <ul> <li> GetBucketNotificationConfiguration
 %%
@@ -5481,22 +5519,21 @@ put_bucket_ownership_controls(Client, Bucket, Input0, Options0) ->
 
 %% @doc Applies an Amazon S3 bucket policy to an Amazon S3 bucket.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the bucket, the calling identity must have the `PutBucketPolicy'
-%% permissions on the specified bucket and belong to the bucket owner's
-%% account in order to use this operation.
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the bucket, the calling identity must have the
+%% `PutBucketPolicy' permissions on the specified bucket and belong to the
+%% bucket owner's account in order to use this operation.
 %%
 %% If you don't have `PutBucketPolicy' permissions, Amazon S3 returns a `403
 %% Access Denied' error. If you have the correct permissions, but you're not
 %% using an identity that belongs to the bucket owner's account, Amazon S3
 %% returns a `405 Method Not Allowed' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this operation, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
-%% For more information about bucket policies, see Using Bucket Policies and
-%% User Policies.
+%% For more information, see Bucket policy examples.
 %%
 %% The following operations are related to `PutBucketPolicy':
 %%
@@ -5533,10 +5570,7 @@ put_bucket_policy(Client, Bucket, Input0, Options0) ->
 
 %% @doc Creates a replication configuration or replaces an existing one.
 %%
-%% For more information, see Replication in the Amazon S3 Developer Guide.
-%%
-%% To perform this operation, the user or role performing the operation must
-%% have the iam:PassRole permission.
+%% For more information, see Replication in the Amazon S3 User Guide.
 %%
 %% Specify the replication configuration in the request body. In the
 %% replication configuration, you provide the name of the destination bucket
@@ -5563,23 +5597,32 @@ put_bucket_policy(Client, Bucket, Input0, Options0) ->
 %% For information about enabling versioning on a bucket, see Using
 %% Versioning.
 %%
-%% By default, a resource owner, in this case the AWS account that created
-%% the bucket, can perform this operation. The resource owner can also grant
-%% others permissions to perform the operation. For more information about
-%% permissions, see Specifying Permissions in a Policy and Managing Access
-%% Permissions to Your Amazon S3 Resources.
-%%
 %% Handling Replication of Encrypted Objects
 %%
 %% By default, Amazon S3 doesn't replicate objects that are stored at rest
-%% using server-side encryption with CMKs stored in AWS KMS. To replicate AWS
-%% KMS-encrypted objects, add the following: `SourceSelectionCriteria',
-%% `SseKmsEncryptedObjects', `Status', `EncryptionConfiguration', and
-%% `ReplicaKmsKeyID'. For information about replication configuration, see
-%% Replicating Objects Created with SSE Using CMKs stored in AWS KMS.
+%% using server-side encryption with KMS keys. To replicate Amazon Web
+%% Services KMS-encrypted objects, add the following:
+%% `SourceSelectionCriteria', `SseKmsEncryptedObjects', `Status',
+%% `EncryptionConfiguration', and `ReplicaKmsKeyID'. For information about
+%% replication configuration, see Replicating Objects Created with SSE Using
+%% KMS keys.
 %%
 %% For information on `PutBucketReplication' errors, see List of
 %% replication-related error codes
+%%
+%% Permissions
+%%
+%% To create a `PutBucketReplication' request, you must have
+%% `s3:PutReplicationConfiguration' permissions for the bucket.
+%%
+%% By default, a resource owner, in this case the Amazon Web Services account
+%% that created the bucket, can perform this operation. The resource owner
+%% can also grant others permissions to perform the operation. For more
+%% information about permissions, see Specifying Permissions in a Policy and
+%% Managing Access Permissions to Your Amazon S3 Resources.
+%%
+%% To perform this operation, the user or role performing the action must
+%% have the iam:PassRole permission.
 %%
 %% The following operations are related to `PutBucketReplication':
 %%
@@ -5655,18 +5698,19 @@ put_bucket_request_payment(Client, Bucket, Input0, Options0) ->
 
 %% @doc Sets the tags for a bucket.
 %%
-%% Use tags to organize your AWS bill to reflect your own cost structure. To
-%% do this, sign up to get your AWS account bill with tag key values
-%% included. Then, to see the cost of combined resources, organize your
-%% billing information according to resources with the same tag key values.
-%% For example, you can tag several resources with a specific application
-%% name, and then organize your billing information to see the total cost of
-%% that application across several services. For more information, see Cost
-%% Allocation and Tagging.
+%% Use tags to organize your Amazon Web Services bill to reflect your own
+%% cost structure. To do this, sign up to get your Amazon Web Services
+%% account bill with tag key values included. Then, to see the cost of
+%% combined resources, organize your billing information according to
+%% resources with the same tag key values. For example, you can tag several
+%% resources with a specific application name, and then organize your billing
+%% information to see the total cost of that application across several
+%% services. For more information, see Cost Allocation and Tagging and Using
+%% Cost Allocation in Amazon S3 Bucket Tags.
 %%
-%% Within a bucket, if you add a tag that has the same key as an existing
-%% tag, the new value overwrites the old value. For more information, see
-%% Using Cost Allocation in Amazon S3 Bucket Tags.
+%% When this operation sets the tags for a bucket, it will overwrite any
+%% current tags the bucket already has. You cannot use this operation to add
+%% tags to an existing list of tags.
 %%
 %% To use this operation, you must have permissions to perform the
 %% `s3:PutBucketTagging' action. The bucket owner has this permission by
@@ -5680,8 +5724,8 @@ put_bucket_request_payment(Client, Bucket, Input0, Options0) ->
 %%
 %% <ul> <li> Description: The tag provided was not a valid tag. This error
 %% can occur if the tag did not pass input validation. For information about
-%% tag restrictions, see User-Defined Tag Restrictions and AWS-Generated Cost
-%% Allocation Tag Restrictions.
+%% tag restrictions, see User-Defined Tag Restrictions and Amazon Web
+%% Services-Generated Cost Allocation Tag Restrictions.
 %%
 %% </li> </ul> </li> <li> Error code: `MalformedXMLError'
 %%
@@ -5689,7 +5733,7 @@ put_bucket_request_payment(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> </ul> </li> <li> Error code: `OperationAbortedError '
 %%
-%% <ul> <li> Description: A conflicting conditional operation is currently in
+%% <ul> <li> Description: A conflicting conditional action is currently in
 %% progress against this resource. Please try again.
 %%
 %% </li> </ul> </li> <li> Error code: `InternalError'
@@ -5802,9 +5846,9 @@ put_bucket_versioning(Client, Bucket, Input0, Options0) ->
 %% index document and any redirect rules. For more information, see Hosting
 %% Websites on Amazon S3.
 %%
-%% This PUT operation requires the `S3:PutBucketWebsite' permission. By
-%% default, only the bucket owner can configure the website attached to a
-%% bucket; however, bucket owners can allow other users to set the website
+%% This PUT action requires the `S3:PutBucketWebsite' permission. By default,
+%% only the bucket owner can configure the website attached to a bucket;
+%% however, bucket owners can allow other users to set the website
 %% configuration by writing a bucket policy that grants them the
 %% `S3:PutBucketWebsite' permission.
 %%
@@ -5862,7 +5906,7 @@ put_bucket_versioning(Client, Bucket, Input0, Options0) ->
 %% </li> </ul> Amazon S3 has a limitation of 50 routing rules per website
 %% configuration. If you require more than 50 routing rules, you can use
 %% object redirect. For more information, see Configuring an Object Redirect
-%% in the Amazon Simple Storage Service Developer Guide.
+%% in the Amazon S3 User Guide.
 put_bucket_website(Client, Bucket, Input) ->
     put_bucket_website(Client, Bucket, Input, []).
 put_bucket_website(Client, Bucket, Input0, Options0) ->
@@ -5906,33 +5950,39 @@ put_bucket_website(Client, Bucket, Input0, Options0) ->
 %% an error. Additionally, you can calculate the MD5 while putting an object
 %% to Amazon S3 and compare the returned ETag to the calculated MD5 value.
 %%
+%% To successfully complete the `PutObject' request, you must have the
+%% `s3:PutObject' in your IAM permissions.
+%%
+%% To successfully change the objects acl of your `PutObject' request, you
+%% must have the `s3:PutObjectAcl' in your IAM permissions.
+%%
 %% The `Content-MD5' header is required for any request to upload an object
 %% with a retention period configured using Amazon S3 Object Lock. For more
 %% information about Amazon S3 Object Lock, see Amazon S3 Object Lock
-%% Overview in the Amazon Simple Storage Service Developer Guide.
+%% Overview in the Amazon S3 User Guide.
 %%
 %% Server-side Encryption
 %%
 %% You can optionally request server-side encryption. With server-side
 %% encryption, Amazon S3 encrypts your data as it writes it to disks in its
 %% data centers and decrypts the data when you access it. You have the option
-%% to provide your own encryption key or use AWS managed encryption keys
-%% (SSE-S3 or SSE-KMS). For more information, see Using Server-Side
-%% Encryption.
+%% to provide your own encryption key or use Amazon Web Services managed
+%% encryption keys (SSE-S3 or SSE-KMS). For more information, see Using
+%% Server-Side Encryption.
 %%
-%% If you request server-side encryption using AWS Key Management Service
-%% (SSE-KMS), you can enable an S3 Bucket Key at the object-level. For more
-%% information, see Amazon S3 Bucket Keys in the Amazon Simple Storage
-%% Service Developer Guide.
+%% If you request server-side encryption using Amazon Web Services Key
+%% Management Service (SSE-KMS), you can enable an S3 Bucket Key at the
+%% object-level. For more information, see Amazon S3 Bucket Keys in the
+%% Amazon S3 User Guide.
 %%
 %% Access Control List (ACL)-Specific Request Headers
 %%
 %% You can use headers to grant ACL- based permissions. By default, all
 %% objects are private. Only the owner has full access control. When adding a
-%% new object, you can grant permissions to individual AWS accounts or to
-%% predefined groups defined by Amazon S3. These permissions are then added
-%% to the ACL on the object. For more information, see Access Control List
-%% (ACL) Overview and Managing ACLs Using the REST API.
+%% new object, you can grant permissions to individual Amazon Web Services
+%% accounts or to predefined groups defined by Amazon S3. These permissions
+%% are then added to the ACL on the object. For more information, see Access
+%% Control List (ACL) Overview and Managing ACLs Using the REST API.
 %%
 %% Storage Class Options
 %%
@@ -5941,7 +5991,7 @@ put_bucket_website(Client, Bucket, Input0, Options0) ->
 %% high availability. Depending on performance needs, you can specify a
 %% different Storage Class. Amazon S3 on Outposts only uses the OUTPOSTS
 %% Storage Class. For more information, see Storage Classes in the Amazon S3
-%% Service Developer Guide.
+%% User Guide.
 %%
 %% Versioning
 %%
@@ -6044,8 +6094,8 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% permissions for a new or existing object in an S3 bucket.
 %%
 %% You must have `WRITE_ACP' permission to set the ACL of an object. For more
-%% information, see What permissions can I grant? in the Amazon Simple
-%% Storage Service Developer Guide.
+%% information, see What permissions can I grant? in the Amazon S3 User
+%% Guide.
 %%
 %% This action is not supported by Amazon S3 on Outposts.
 %%
@@ -6053,7 +6103,7 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% object using either the request body or the headers. For example, if you
 %% have an existing application that updates a bucket ACL using the request
 %% body, you can continue to use that approach. For more information, see
-%% Access Control List (ACL) Overview in the Amazon S3 Developer Guide.
+%% Access Control List (ACL) Overview in the Amazon S3 User Guide.
 %%
 %% Access Permissions
 %%
@@ -6069,25 +6119,26 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% </li> <li> Specify access permissions explicitly with the
 %% `x-amz-grant-read', `x-amz-grant-read-acp', `x-amz-grant-write-acp', and
 %% `x-amz-grant-full-control' headers. When using these headers, you specify
-%% explicit access permissions and grantees (AWS accounts or Amazon S3
-%% groups) who will receive the permission. If you use these ACL-specific
-%% headers, you cannot use `x-amz-acl' header to set a canned ACL. These
-%% parameters map to the set of permissions that Amazon S3 supports in an
-%% ACL. For more information, see Access Control List (ACL) Overview.
+%% explicit access permissions and grantees (Amazon Web Services accounts or
+%% Amazon S3 groups) who will receive the permission. If you use these
+%% ACL-specific headers, you cannot use `x-amz-acl' header to set a canned
+%% ACL. These parameters map to the set of permissions that Amazon S3
+%% supports in an ACL. For more information, see Access Control List (ACL)
+%% Overview.
 %%
 %% You specify each grantee as a type=value pair, where the type is one of
 %% the following:
 %%
-%% <ul> <li> `id' – if the value specified is the canonical user ID of an AWS
-%% account
+%% <ul> <li> `id' – if the value specified is the canonical user ID of an
+%% Amazon Web Services account
 %%
 %% </li> <li> `uri' – if you are granting permissions to a predefined group
 %%
 %% </li> <li> `emailAddress' – if the value specified is the email address of
-%% an AWS account
+%% an Amazon Web Services account
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -6106,11 +6157,11 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> For example, the following `x-amz-grant-read' header grants
-%% list objects permission to the two AWS accounts identified by their email
-%% addresses.
+%% list objects permission to the two Amazon Web Services accounts identified
+%% by their email addresses.
 %%
 %% `x-amz-grant-read: emailAddress="xyz@amazon.com",
 %% emailAddress="abc@amazon.com" '
@@ -6145,7 +6196,7 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% Object acl request, appears as the CanonicalUser.
 %%
 %% Using email addresses to specify a grantee is only supported in the
-%% following AWS Regions:
+%% following Amazon Web Services Regions:
 %%
 %% US East (N. Virginia)
 %%
@@ -6164,7 +6215,7 @@ put_object(Client, Bucket, Key, Input0, Options0) ->
 %% South America (São Paulo)
 %%
 %% For a list of all the Amazon S3 supported Regions and endpoints, see
-%% Regions and Endpoints in the AWS General Reference.
+%% Regions and Endpoints in the Amazon Web Services General Reference.
 %%
 %% </li> </ul> Versioning
 %%
@@ -6230,13 +6281,9 @@ put_object_acl(Client, Bucket, Key, Input0, Options0) ->
 
 %% @doc Applies a Legal Hold configuration to the specified object.
 %%
+%% For more information, see Locking Objects.
+%%
 %% This action is not supported by Amazon S3 on Outposts.
-%%
-%% == Related Resources ==
-%%
-%% <ul> <li> Locking Objects
-%%
-%% </li> </ul>
 put_object_legal_hold(Client, Bucket, Key, Input) ->
     put_object_legal_hold(Client, Bucket, Key, Input, []).
 put_object_legal_hold(Client, Bucket, Key, Input0, Options0) ->
@@ -6283,16 +6330,16 @@ put_object_legal_hold(Client, Bucket, Key, Input0, Options0) ->
 %% @doc Places an Object Lock configuration on the specified bucket.
 %%
 %% The rule specified in the Object Lock configuration will be applied by
-%% default to every new object placed in the specified bucket.
+%% default to every new object placed in the specified bucket. For more
+%% information, see Locking Objects.
 %%
-%% `DefaultRetention' requires either Days or Years. You can't specify both
-%% at the same time.
+%% The `DefaultRetention' settings require both a mode and a period.
 %%
-%% == Related Resources ==
+%% The `DefaultRetention' period can be either `Days' or `Years' but you must
+%% select one. You cannot specify `Days' and `Years' at the same time.
 %%
-%% <ul> <li> Locking Objects
-%%
-%% </li> </ul>
+%% You can only enable Object Lock for new buckets. If you want to turn on
+%% Object Lock for an existing bucket, contact Amazon Web Services Support.
 put_object_lock_configuration(Client, Bucket, Input) ->
     put_object_lock_configuration(Client, Bucket, Input, []).
 put_object_lock_configuration(Client, Bucket, Input0, Options0) ->
@@ -6338,13 +6385,19 @@ put_object_lock_configuration(Client, Bucket, Input0, Options0) ->
 
 %% @doc Places an Object Retention configuration on an object.
 %%
+%% For more information, see Locking Objects. Users or accounts require the
+%% `s3:PutObjectRetention' permission in order to place an Object Retention
+%% configuration on objects. Bypassing a Governance Retention configuration
+%% requires the `s3:BypassGovernanceRetention' permission.
+%%
 %% This action is not supported by Amazon S3 on Outposts.
 %%
-%% == Related Resources ==
+%% Permissions
 %%
-%% <ul> <li> Locking Objects
-%%
-%% </li> </ul>
+%% When the Object Lock retention mode is set to compliance, you need
+%% `s3:PutObjectRetention' and `s3:BypassGovernanceRetention' permissions.
+%% For other requests to `PutObjectRetention', only `s3:PutObjectRetention'
+%% permissions are required.
 put_object_retention(Client, Bucket, Key, Input) ->
     put_object_retention(Client, Bucket, Key, Input, []).
 put_object_retention(Client, Bucket, Key, Input0, Options0) ->
@@ -6425,7 +6478,7 @@ put_object_retention(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% </li> </ul> </li> <li> <ul> <li> Code: OperationAbortedError
 %%
-%% </li> <li> Cause: A conflicting conditional operation is currently in
+%% </li> <li> Cause: A conflicting conditional action is currently in
 %% progress against this resource. Please try again.
 %%
 %% </li> </ul> </li> <li> <ul> <li> Code: InternalError
@@ -6551,7 +6604,7 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %% default and can grant this permission to others. For more information
 %% about permissions, see Permissions Related to Bucket Subresource
 %% Operations and Managing Access Permissions to Your Amazon S3 Resources in
-%% the Amazon Simple Storage Service Developer Guide.
+%% the Amazon S3 User Guide.
 %%
 %% Querying Archives with Select Requests
 %%
@@ -6560,29 +6613,28 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %% must be formatted as uncompressed comma-separated values (CSV) files. You
 %% can run queries and custom analytics on your archived data without having
 %% to restore your data to a hotter Amazon S3 tier. For an overview about
-%% select requests, see Querying Archived Objects in the Amazon Simple
-%% Storage Service Developer Guide.
+%% select requests, see Querying Archived Objects in the Amazon S3 User
+%% Guide.
 %%
 %% When making a select request, do the following:
 %%
 %% <ul> <li> Define an output location for the select query's output. This
-%% must be an Amazon S3 bucket in the same AWS Region as the bucket that
-%% contains the archive object that is being queried. The AWS account that
-%% initiates the job must have permissions to write to the S3 bucket. You can
-%% specify the storage class and encryption for the output objects stored in
-%% the bucket. For more information about output, see Querying Archived
-%% Objects in the Amazon Simple Storage Service Developer Guide.
+%% must be an Amazon S3 bucket in the same Amazon Web Services Region as the
+%% bucket that contains the archive object that is being queried. The Amazon
+%% Web Services account that initiates the job must have permissions to write
+%% to the S3 bucket. You can specify the storage class and encryption for the
+%% output objects stored in the bucket. For more information about output,
+%% see Querying Archived Objects in the Amazon S3 User Guide.
 %%
 %% For more information about the `S3' structure in the request body, see the
 %% following:
 %%
 %% <ul> <li> PutObject
 %%
-%% </li> <li> Managing Access with ACLs in the Amazon Simple Storage Service
-%% Developer Guide
+%% </li> <li> Managing Access with ACLs in the Amazon S3 User Guide
 %%
-%% </li> <li> Protecting Data Using Server-Side Encryption in the Amazon
-%% Simple Storage Service Developer Guide
+%% </li> <li> Protecting Data Using Server-Side Encryption in the Amazon S3
+%% User Guide
 %%
 %% </li> </ul> </li> <li> Define the SQL expression for the `SELECT' type of
 %% restoration for your query in the request body's `SelectParameters'
@@ -6608,7 +6660,7 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> </ul> </li> </ul> For more information about using SQL with S3
 %% Glacier Select restore, see SQL Reference for Amazon S3 Select and S3
-%% Glacier Select in the Amazon Simple Storage Service Developer Guide.
+%% Glacier Select in the Amazon S3 User Guide.
 %%
 %% When making a select request, you can also do the following:
 %%
@@ -6685,19 +6737,18 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> </ul> For more information about archive retrieval options and
 %% provisioned capacity for `Expedited' data access, see Restoring Archived
-%% Objects in the Amazon Simple Storage Service Developer Guide.
+%% Objects in the Amazon S3 User Guide.
 %%
 %% You can use Amazon S3 restore speed upgrade to change the restore speed to
 %% a faster speed while it is in progress. For more information, see
-%% Upgrading the speed of an in-progress restore in the Amazon Simple Storage
-%% Service Developer Guide.
+%% Upgrading the speed of an in-progress restore in the Amazon S3 User Guide.
 %%
 %% To get the status of object restoration, you can send a `HEAD' request.
 %% Operations return the `x-amz-restore' header, which provides information
 %% about the restoration status, in the response. You can use Amazon S3 event
 %% notifications to notify you when a restore is initiated or completed. For
 %% more information, see Configuring Amazon S3 Event Notifications in the
-%% Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 User Guide.
 %%
 %% After restoring an archived object, you can update the restoration period
 %% by reissuing the request with a new period. Amazon S3 updates the
@@ -6712,12 +6763,12 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %% for 10 days, but the object is scheduled to expire in 3 days, Amazon S3
 %% deletes the object in 3 days. For more information about lifecycle
 %% configuration, see PutBucketLifecycleConfiguration and Object Lifecycle
-%% Management in Amazon Simple Storage Service Developer Guide.
+%% Management in Amazon S3 User Guide.
 %%
 %% Responses
 %%
-%% A successful operation returns either the `200 OK' or `202 Accepted'
-%% status code.
+%% A successful action returns either the `200 OK' or `202 Accepted' status
+%% code.
 %%
 %% <ul> <li> If the object is not previously restored, then Amazon S3 returns
 %% `202 Accepted' in the response.
@@ -6755,7 +6806,7 @@ put_public_access_block(Client, Bucket, Input0, Options0) ->
 %% </li> <li> GetBucketNotificationConfiguration
 %%
 %% </li> <li> SQL Reference for Amazon S3 Select and S3 Glacier Select in the
-%% Amazon Simple Storage Service Developer Guide
+%% Amazon S3 User Guide
 %%
 %% </li> </ul>
 restore_object(Client, Bucket, Key, Input) ->
@@ -6801,7 +6852,7 @@ restore_object(Client, Bucket, Key, Input0, Options0) ->
         Result
     end.
 
-%% @doc This operation filters the contents of an Amazon S3 object based on a
+%% @doc This action filters the contents of an Amazon S3 object based on a
 %% simple structured query language (SQL) statement.
 %%
 %% In the request, along with the SQL expression, you must also specify a
@@ -6813,18 +6864,18 @@ restore_object(Client, Bucket, Key, Input0, Options0) ->
 %% This action is not supported by Amazon S3 on Outposts.
 %%
 %% For more information about Amazon S3 Select, see Selecting Content from
-%% Objects in the Amazon Simple Storage Service Developer Guide.
+%% Objects in the Amazon S3 User Guide.
 %%
 %% For more information about using SQL with Amazon S3 Select, see SQL
-%% Reference for Amazon S3 Select and S3 Glacier Select in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Reference for Amazon S3 Select and S3 Glacier Select in the Amazon S3 User
+%% Guide.
 %%
 %% Permissions
 %%
 %% You must have `s3:GetObject' permission for this operation. Amazon S3
 %% Select does not support anonymous access. For more information about
-%% permissions, see Specifying Permissions in a Policy in the Amazon Simple
-%% Storage Service Developer Guide.
+%% permissions, see Specifying Permissions in a Policy in the Amazon S3 User
+%% Guide.
 %%
 %% Object Data Formats
 %%
@@ -6850,26 +6901,25 @@ restore_object(Client, Bucket, Key, Input0, Options0) ->
 %% (SSE-C), you must use HTTPS, and you must use the headers that are
 %% documented in the GetObject. For more information about SSE-C, see
 %% Server-Side Encryption (Using Customer-Provided Encryption Keys) in the
-%% Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 User Guide.
 %%
 %% For objects that are encrypted with Amazon S3 managed encryption keys
-%% (SSE-S3) and customer master keys (CMKs) stored in AWS Key Management
-%% Service (SSE-KMS), server-side encryption is handled transparently, so you
-%% don't need to specify anything. For more information about server-side
-%% encryption, including SSE-S3 and SSE-KMS, see Protecting Data Using
-%% Server-Side Encryption in the Amazon Simple Storage Service Developer
-%% Guide.
+%% (SSE-S3) and Amazon Web Services KMS keys (SSE-KMS), server-side
+%% encryption is handled transparently, so you don't need to specify
+%% anything. For more information about server-side encryption, including
+%% SSE-S3 and SSE-KMS, see Protecting Data Using Server-Side Encryption in
+%% the Amazon S3 User Guide.
 %%
 %% </li> </ul> Working with the Response Body
 %%
 %% Given the response size is unknown, Amazon S3 Select streams the response
 %% as a series of messages and includes a `Transfer-Encoding' header with
 %% `chunked' as its value in the response. For more information, see
-%% Appendix: SelectObjectContent Response .
+%% Appendix: SelectObjectContent Response.
 %%
 %% GetObject Support
 %%
-%% The `SelectObjectContent' operation does not support the following
+%% The `SelectObjectContent' action does not support the following
 %% `GetObject' functionality. For more information, see GetObject.
 %%
 %% <ul> <li> `Range': Although you can specify a scan range for an Amazon S3
@@ -6879,7 +6929,7 @@ restore_object(Client, Bucket, Key, Input0, Options0) ->
 %% </li> <li> GLACIER, DEEP_ARCHIVE and REDUCED_REDUNDANCY storage classes:
 %% You cannot specify the GLACIER, DEEP_ARCHIVE, or `REDUCED_REDUNDANCY'
 %% storage classes. For more information, about storage classes see Storage
-%% Classes in the Amazon Simple Storage Service Developer Guide.
+%% Classes in the Amazon S3 User Guide.
 %%
 %% </li> </ul>
 %%
@@ -6948,10 +6998,10 @@ select_object_content(Client, Bucket, Key, Input0, Options0) ->
 %% part data against the provided MD5 value. If they do not match, Amazon S3
 %% returns an error.
 %%
-%% If the upload request is signed with Signature Version 4, then AWS S3 uses
-%% the `x-amz-content-sha256' header as a checksum instead of `Content-MD5'.
-%% For more information see Authenticating Requests: Using the Authorization
-%% Header (AWS Signature Version 4).
+%% If the upload request is signed with Signature Version 4, then Amazon Web
+%% Services S3 uses the `x-amz-content-sha256' header as a checksum instead
+%% of `Content-MD5'. For more information see Authenticating Requests: Using
+%% the Authorization Header (Amazon Web Services Signature Version 4).
 %%
 %% Note: After you initiate multipart upload and upload one or more parts,
 %% you must either complete or abort multipart upload in order to stop
@@ -6960,21 +7010,20 @@ select_object_content(Client, Bucket, Key, Input0, Options0) ->
 %% and stops charging you for the parts storage.
 %%
 %% For more information on multipart uploads, go to Multipart Upload Overview
-%% in the Amazon Simple Storage Service Developer Guide .
+%% in the Amazon S3 User Guide .
 %%
 %% For information on the permissions required to use the multipart upload
-%% API, go to Multipart Upload API and Permissions in the Amazon Simple
-%% Storage Service Developer Guide.
+%% API, go to Multipart Upload and Permissions in the Amazon S3 User Guide.
 %%
 %% You can optionally request server-side encryption where Amazon S3 encrypts
 %% your data as it writes it to disks in its data centers and decrypts it for
 %% you when you access it. You have the option of providing your own
-%% encryption key, or you can use the AWS managed encryption keys. If you
-%% choose to provide your own encryption key, the request headers you provide
-%% in the request must match the headers you used in the request to initiate
-%% the upload by using CreateMultipartUpload. For more information, go to
-%% Using Server-Side Encryption in the Amazon Simple Storage Service
-%% Developer Guide.
+%% encryption key, or you can use the Amazon Web Services managed encryption
+%% keys. If you choose to provide your own encryption key, the request
+%% headers you provide in the request must match the headers you used in the
+%% request to initiate the upload by using CreateMultipartUpload. For more
+%% information, go to Using Server-Side Encryption in the Amazon S3 User
+%% Guide.
 %%
 %% Server-side encryption is supported by the S3 Multipart Upload actions.
 %% Unless you are using a customer-provided encryption key, you don't need to
@@ -7082,10 +7131,10 @@ upload_part(Client, Bucket, Key, Input0, Options0) ->
 %%
 %% The minimum allowable part size for a multipart upload is 5 MB. For more
 %% information about multipart upload limits, go to Quick Facts in the Amazon
-%% Simple Storage Service Developer Guide.
+%% S3 User Guide.
 %%
 %% Instead of using an existing object as part data, you might use the
-%% UploadPart operation and provide data in your request.
+%% UploadPart action and provide data in your request.
 %%
 %% You must initiate a multipart upload before you can upload any part. In
 %% response to your initiate request. Amazon S3 returns a unique identifier,
@@ -7095,16 +7144,15 @@ upload_part(Client, Bucket, Key, Input0, Options0) ->
 %% following:
 %%
 %% <ul> <li> For conceptual information about multipart uploads, see
-%% Uploading Objects Using Multipart Upload in the Amazon Simple Storage
-%% Service Developer Guide.
+%% Uploading Objects Using Multipart Upload in the Amazon S3 User Guide.
 %%
 %% </li> <li> For information about permissions required to use the multipart
-%% upload API, see Multipart Upload API and Permissions in the Amazon Simple
-%% Storage Service Developer Guide.
+%% upload API, see Multipart Upload and Permissions in the Amazon S3 User
+%% Guide.
 %%
 %% </li> <li> For information about copying objects using a single atomic
-%% operation vs. the multipart upload, see Operations on Objects in the
-%% Amazon Simple Storage Service Developer Guide.
+%% action vs. the multipart upload, see Operations on Objects in the Amazon
+%% S3 User Guide.
 %%
 %% </li> <li> For information about using server-side encryption with
 %% customer-provided encryption keys with the UploadPartCopy operation, see
@@ -7246,6 +7294,113 @@ upload_part_copy(Client, Bucket, Key, Input0, Options0) ->
         Result
     end.
 
+%% @doc Passes transformed objects to a `GetObject' operation when using
+%% Object Lambda access points.
+%%
+%% For information about Object Lambda access points, see Transforming
+%% objects with Object Lambda access points in the Amazon S3 User Guide.
+%%
+%% This operation supports metadata that can be returned by GetObject, in
+%% addition to `RequestRoute', `RequestToken', `StatusCode', `ErrorCode', and
+%% `ErrorMessage'. The `GetObject' response metadata is supported so that the
+%% `WriteGetObjectResponse' caller, typically an Lambda function, can provide
+%% the same metadata when it internally invokes `GetObject'. When
+%% `WriteGetObjectResponse' is called by a customer-owned Lambda function,
+%% the metadata returned to the end user `GetObject' call might differ from
+%% what Amazon S3 would normally return.
+%%
+%% You can include any number of metadata headers. When including a metadata
+%% header, it should be prefaced with `x-amz-meta'. For example,
+%% `x-amz-meta-my-custom-header: MyCustomValue'. The primary use case for
+%% this is to forward `GetObject' metadata.
+%%
+%% Amazon Web Services provides some prebuilt Lambda functions that you can
+%% use with S3 Object Lambda to detect and redact personally identifiable
+%% information (PII) and decompress S3 objects. These Lambda functions are
+%% available in the Amazon Web Services Serverless Application Repository,
+%% and can be selected through the Amazon Web Services Management Console
+%% when you create your Object Lambda access point.
+%%
+%% Example 1: PII Access Control - This Lambda function uses Amazon
+%% Comprehend, a natural language processing (NLP) service using machine
+%% learning to find insights and relationships in text. It automatically
+%% detects personally identifiable information (PII) such as names,
+%% addresses, dates, credit card numbers, and social security numbers from
+%% documents in your Amazon S3 bucket.
+%%
+%% Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a
+%% natural language processing (NLP) service using machine learning to find
+%% insights and relationships in text. It automatically redacts personally
+%% identifiable information (PII) such as names, addresses, dates, credit
+%% card numbers, and social security numbers from documents in your Amazon S3
+%% bucket.
+%%
+%% Example 3: Decompression - The Lambda function
+%% S3ObjectLambdaDecompression, is equipped to decompress objects stored in
+%% S3 in one of six compressed file formats including bzip2, gzip, snappy,
+%% zlib, zstandard and ZIP.
+%%
+%% For information on how to view and use these functions, see Using Amazon
+%% Web Services built Lambda functions in the Amazon S3 User Guide.
+write_get_object_response(Client, Input) ->
+    write_get_object_response(Client, Input, []).
+write_get_object_response(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/WriteGetObjectResponse"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, true},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-fwd-header-ETag">>, <<"ETag">>},
+                       {<<"x-amz-fwd-header-Content-Language">>, <<"ContentLanguage">>},
+                       {<<"x-amz-fwd-header-Expires">>, <<"Expires">>},
+                       {<<"x-amz-fwd-header-x-amz-object-lock-legal-hold">>, <<"ObjectLockLegalHoldStatus">>},
+                       {<<"x-amz-request-route">>, <<"RequestRoute">>},
+                       {<<"x-amz-fwd-header-x-amz-expiration">>, <<"Expiration">>},
+                       {<<"x-amz-fwd-header-x-amz-server-side-encryption-bucket-key-enabled">>, <<"BucketKeyEnabled">>},
+                       {<<"x-amz-fwd-header-x-amz-restore">>, <<"Restore">>},
+                       {<<"x-amz-fwd-header-x-amz-server-side-encryption-customer-key-MD5">>, <<"SSECustomerKeyMD5">>},
+                       {<<"x-amz-fwd-header-x-amz-object-lock-retain-until-date">>, <<"ObjectLockRetainUntilDate">>},
+                       {<<"Content-Length">>, <<"ContentLength">>},
+                       {<<"x-amz-fwd-header-Content-Disposition">>, <<"ContentDisposition">>},
+                       {<<"x-amz-fwd-header-Content-Encoding">>, <<"ContentEncoding">>},
+                       {<<"x-amz-fwd-header-x-amz-server-side-encryption">>, <<"ServerSideEncryption">>},
+                       {<<"x-amz-fwd-header-accept-ranges">>, <<"AcceptRanges">>},
+                       {<<"x-amz-fwd-header-x-amz-storage-class">>, <<"StorageClass">>},
+                       {<<"x-amz-fwd-header-x-amz-version-id">>, <<"VersionId">>},
+                       {<<"x-amz-fwd-header-Content-Type">>, <<"ContentType">>},
+                       {<<"x-amz-fwd-header-x-amz-object-lock-mode">>, <<"ObjectLockMode">>},
+                       {<<"x-amz-fwd-header-x-amz-server-side-encryption-customer-algorithm">>, <<"SSECustomerAlgorithm">>},
+                       {<<"x-amz-fwd-status">>, <<"StatusCode">>},
+                       {<<"x-amz-fwd-header-x-amz-delete-marker">>, <<"DeleteMarker">>},
+                       {<<"x-amz-fwd-error-code">>, <<"ErrorCode">>},
+                       {<<"x-amz-fwd-header-x-amz-server-side-encryption-aws-kms-key-id">>, <<"SSEKMSKeyId">>},
+                       {<<"x-amz-fwd-header-Cache-Control">>, <<"CacheControl">>},
+                       {<<"x-amz-fwd-header-x-amz-mp-parts-count">>, <<"PartsCount">>},
+                       {<<"x-amz-fwd-header-x-amz-request-charged">>, <<"RequestCharged">>},
+                       {<<"x-amz-fwd-header-Last-Modified">>, <<"LastModified">>},
+                       {<<"x-amz-fwd-header-x-amz-missing-meta">>, <<"MissingMeta">>},
+                       {<<"x-amz-fwd-error-message">>, <<"ErrorMessage">>},
+                       {<<"x-amz-fwd-header-x-amz-replication-status">>, <<"ReplicationStatus">>},
+                       {<<"x-amz-request-token">>, <<"RequestToken">>},
+                       {<<"x-amz-fwd-header-x-amz-tagging-count">>, <<"TagCount">>},
+                       {<<"x-amz-fwd-header-Content-Range">>, <<"ContentRange">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeadersMapping = [
+                             {<<"x-amz-meta-">>, <<"Metadata">>}
+                          ],
+    {CustomHeaders, Input2} = aws_request:build_custom_headers(CustomHeadersMapping, Input1),
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -7281,6 +7436,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -1,19 +1,28 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS S3 Control provides access to Amazon S3 control plane operations.
+%% @doc Amazon Web Services S3 Control provides access to Amazon S3 control
+%% plane actions.
 -module(aws_s3_control).
 
 -export([create_access_point/3,
          create_access_point/4,
+         create_access_point_for_object_lambda/3,
+         create_access_point_for_object_lambda/4,
          create_bucket/3,
          create_bucket/4,
          create_job/2,
          create_job/3,
+         create_multi_region_access_point/2,
+         create_multi_region_access_point/3,
          delete_access_point/3,
          delete_access_point/4,
+         delete_access_point_for_object_lambda/3,
+         delete_access_point_for_object_lambda/4,
          delete_access_point_policy/3,
          delete_access_point_policy/4,
+         delete_access_point_policy_for_object_lambda/3,
+         delete_access_point_policy_for_object_lambda/4,
          delete_bucket/3,
          delete_bucket/4,
          delete_bucket_lifecycle_configuration/3,
@@ -24,6 +33,8 @@
          delete_bucket_tagging/4,
          delete_job_tagging/3,
          delete_job_tagging/4,
+         delete_multi_region_access_point/2,
+         delete_multi_region_access_point/3,
          delete_public_access_block/2,
          delete_public_access_block/3,
          delete_storage_lens_configuration/3,
@@ -33,15 +44,30 @@
          describe_job/3,
          describe_job/5,
          describe_job/6,
+         describe_multi_region_access_point_operation/3,
+         describe_multi_region_access_point_operation/5,
+         describe_multi_region_access_point_operation/6,
          get_access_point/3,
          get_access_point/5,
          get_access_point/6,
+         get_access_point_configuration_for_object_lambda/3,
+         get_access_point_configuration_for_object_lambda/5,
+         get_access_point_configuration_for_object_lambda/6,
+         get_access_point_for_object_lambda/3,
+         get_access_point_for_object_lambda/5,
+         get_access_point_for_object_lambda/6,
          get_access_point_policy/3,
          get_access_point_policy/5,
          get_access_point_policy/6,
+         get_access_point_policy_for_object_lambda/3,
+         get_access_point_policy_for_object_lambda/5,
+         get_access_point_policy_for_object_lambda/6,
          get_access_point_policy_status/3,
          get_access_point_policy_status/5,
          get_access_point_policy_status/6,
+         get_access_point_policy_status_for_object_lambda/3,
+         get_access_point_policy_status_for_object_lambda/5,
+         get_access_point_policy_status_for_object_lambda/6,
          get_bucket/3,
          get_bucket/5,
          get_bucket/6,
@@ -57,6 +83,15 @@
          get_job_tagging/3,
          get_job_tagging/5,
          get_job_tagging/6,
+         get_multi_region_access_point/3,
+         get_multi_region_access_point/5,
+         get_multi_region_access_point/6,
+         get_multi_region_access_point_policy/3,
+         get_multi_region_access_point_policy/5,
+         get_multi_region_access_point_policy/6,
+         get_multi_region_access_point_policy_status/3,
+         get_multi_region_access_point_policy_status/5,
+         get_multi_region_access_point_policy_status/6,
          get_public_access_block/2,
          get_public_access_block/4,
          get_public_access_block/5,
@@ -69,17 +104,27 @@
          list_access_points/2,
          list_access_points/4,
          list_access_points/5,
+         list_access_points_for_object_lambda/2,
+         list_access_points_for_object_lambda/4,
+         list_access_points_for_object_lambda/5,
          list_jobs/2,
          list_jobs/4,
          list_jobs/5,
+         list_multi_region_access_points/2,
+         list_multi_region_access_points/4,
+         list_multi_region_access_points/5,
          list_regional_buckets/2,
          list_regional_buckets/4,
          list_regional_buckets/5,
          list_storage_lens_configurations/2,
          list_storage_lens_configurations/4,
          list_storage_lens_configurations/5,
+         put_access_point_configuration_for_object_lambda/3,
+         put_access_point_configuration_for_object_lambda/4,
          put_access_point_policy/3,
          put_access_point_policy/4,
+         put_access_point_policy_for_object_lambda/3,
+         put_access_point_policy_for_object_lambda/4,
          put_bucket_lifecycle_configuration/3,
          put_bucket_lifecycle_configuration/4,
          put_bucket_policy/3,
@@ -88,6 +133,8 @@
          put_bucket_tagging/4,
          put_job_tagging/3,
          put_job_tagging/4,
+         put_multi_region_access_point_policy/2,
+         put_multi_region_access_point_policy/3,
          put_public_access_block/2,
          put_public_access_block/3,
          put_storage_lens_configuration/3,
@@ -108,23 +155,12 @@
 %% @doc Creates an access point and associates it with the specified bucket.
 %%
 %% For more information, see Managing Data Access with Amazon S3 Access
-%% Points in the Amazon Simple Storage Service Developer Guide.
+%% Points in the Amazon S3 User Guide.
 %%
-%% Using this action with Amazon S3 on Outposts
+%% S3 on Outposts only supports VPC-style access points.
 %%
-%% This action:
-%%
-%% <ul> <li> Requires a virtual private cloud (VPC) configuration as S3 on
-%% Outposts only supports VPC style access points.
-%%
-%% </li> <li> Does not support ACL on S3 on Outposts buckets.
-%%
-%% </li> <li> Does not support Public Access on S3 on Outposts buckets.
-%%
-%% </li> <li> Does not support object lock for S3 on Outposts buckets.
-%%
-%% </li> </ul> For more information, see Using Amazon S3 on Outposts in the
-%% Amazon Simple Storage Service Developer Guide .
+%% For more information, see Accessing Amazon S3 on Outposts using virtual
+%% private cloud (VPC) only access points in the Amazon S3 User Guide.
 %%
 %% All Amazon S3 on Outposts REST API requests for this action require an
 %% additional parameter of `x-amz-outpost-id' to be passed with the request
@@ -166,33 +202,69 @@ create_access_point(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API operation creates an Amazon S3 on Outposts bucket.
+%% @doc Creates an Object Lambda Access Point.
 %%
-%% To create an S3 bucket, see Create Bucket in the Amazon Simple Storage
-%% Service API.
+%% For more information, see Transforming objects with Object Lambda Access
+%% Points in the Amazon S3 User Guide.
+%%
+%% The following actions are related to `CreateAccessPointForObjectLambda':
+%%
+%% <ul> <li> DeleteAccessPointForObjectLambda
+%%
+%% </li> <li> GetAccessPointForObjectLambda
+%%
+%% </li> <li> ListAccessPointsForObjectLambda
+%%
+%% </li> </ul>
+create_access_point_for_object_lambda(Client, Name, Input) ->
+    create_access_point_for_object_lambda(Client, Name, Input, []).
+create_access_point_for_object_lambda(Client, Name, Input0, Options0) ->
+    Method = put,
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This action creates an Amazon S3 on Outposts bucket.
+%%
+%% To create an S3 bucket, see Create Bucket in the Amazon S3 API Reference.
 %%
 %% Creates a new Outposts bucket. By creating the bucket, you become the
 %% bucket owner. To create an Outposts bucket, you must have S3 on Outposts.
-%% For more information, see Using Amazon S3 on Outposts in Amazon Simple
-%% Storage Service Developer Guide.
+%% For more information, see Using Amazon S3 on Outposts in Amazon S3 User
+%% Guide.
 %%
 %% Not every string is an acceptable bucket name. For information on bucket
 %% naming restrictions, see Working with Amazon S3 Buckets.
 %%
-%% S3 on Outposts buckets do not support
+%% S3 on Outposts buckets support:
 %%
-%% <ul> <li> ACLs. Instead, configure access point policies to manage access
-%% to buckets.
+%% <ul> <li> Tags
 %%
-%% </li> <li> Public access.
+%% </li> <li> LifecycleConfigurations for deleting expired objects
 %%
-%% </li> <li> Object Lock
+%% </li> </ul> For a complete list of restrictions and Amazon S3 feature
+%% limitations on S3 on Outposts, see Amazon S3 on Outposts Restrictions and
+%% Limitations.
 %%
-%% </li> <li> Bucket Location constraint
-%%
-%% </li> </ul> For an example of the request syntax for Amazon S3 on Outposts
-%% that uses the S3 on Outposts endpoint hostname prefix and
-%% `x-amz-outpost-id' in your API request, see the Examples section.
+%% For an example of the request syntax for Amazon S3 on Outposts that uses
+%% the S3 on Outposts endpoint hostname prefix and `x-amz-outpost-id' in your
+%% API request, see the Examples section.
 %%
 %% The following actions are related to `CreateBucket' for Amazon S3 on
 %% Outposts:
@@ -255,14 +327,14 @@ create_bucket(Client, Bucket, Input0, Options0) ->
         Result
     end.
 
-%% @doc You can use S3 Batch Operations to perform large-scale batch
-%% operations on Amazon S3 objects.
+%% @doc You can use S3 Batch Operations to perform large-scale batch actions
+%% on Amazon S3 objects.
 %%
-%% Batch Operations can run a single operation on lists of Amazon S3 objects
+%% Batch Operations can run a single action on lists of Amazon S3 objects
 %% that you specify. For more information, see S3 Batch Operations in the
-%% Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 User Guide.
 %%
-%% This operation creates a S3 Batch Operations job.
+%% This action creates a S3 Batch Operations job.
 %%
 %% Related actions include:
 %%
@@ -282,6 +354,57 @@ create_job(Client, Input) ->
 create_job(Client, Input0, Options0) ->
     Method = post,
     Path = ["/v20180820/jobs"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a Multi-Region Access Point and associates it with the
+%% specified buckets.
+%%
+%% For more information about creating Multi-Region Access Points, see
+%% Creating Multi-Region Access Points in the Amazon S3 User Guide.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% This request is asynchronous, meaning that you might receive a response
+%% before the command has completed. When this request provides a response,
+%% it provides a token that you can use to monitor the status of the request
+%% with `DescribeMultiRegionAccessPointOperation'.
+%%
+%% The following actions are related to `CreateMultiRegionAccessPoint':
+%%
+%% <ul> <li> DeleteMultiRegionAccessPoint
+%%
+%% </li> <li> DescribeMultiRegionAccessPointOperation
+%%
+%% </li> <li> GetMultiRegionAccessPoint
+%%
+%% </li> <li> ListMultiRegionAccessPoints
+%%
+%% </li> </ul>
+create_multi_region_access_point(Client, Input) ->
+    create_multi_region_access_point(Client, Input, []).
+create_multi_region_access_point(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v20180820/async-requests/mrap/create"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -343,6 +466,41 @@ delete_access_point(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes the specified Object Lambda Access Point.
+%%
+%% The following actions are related to `DeleteAccessPointForObjectLambda':
+%%
+%% <ul> <li> CreateAccessPointForObjectLambda
+%%
+%% </li> <li> GetAccessPointForObjectLambda
+%%
+%% </li> <li> ListAccessPointsForObjectLambda
+%%
+%% </li> </ul>
+delete_access_point_for_object_lambda(Client, Name, Input) ->
+    delete_access_point_for_object_lambda(Client, Name, Input, []).
+delete_access_point_for_object_lambda(Client, Name, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes the access point policy for the specified access point.
 %%
 %% All Amazon S3 on Outposts REST API requests for this action require an
@@ -383,15 +541,48 @@ delete_access_point_policy(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API operation deletes an Amazon S3 on Outposts bucket.
+%% @doc Removes the resource policy for an Object Lambda Access Point.
 %%
-%% To delete an S3 bucket, see DeleteBucket in the Amazon Simple Storage
-%% Service API.
+%% The following actions are related to
+%% `DeleteAccessPointPolicyForObjectLambda':
+%%
+%% <ul> <li> GetAccessPointPolicyForObjectLambda
+%%
+%% </li> <li> PutAccessPointPolicyForObjectLambda
+%%
+%% </li> </ul>
+delete_access_point_policy_for_object_lambda(Client, Name, Input) ->
+    delete_access_point_policy_for_object_lambda(Client, Name, Input, []).
+delete_access_point_policy_for_object_lambda(Client, Name, Input0, Options0) ->
+    Method = delete,
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This action deletes an Amazon S3 on Outposts bucket.
+%%
+%% To delete an S3 bucket, see DeleteBucket in the Amazon S3 API Reference.
 %%
 %% Deletes the Amazon S3 on Outposts bucket. All objects (including all
 %% object versions and delete markers) in the bucket must be deleted before
 %% the bucket itself can be deleted. For more information, see Using Amazon
-%% S3 on Outposts in Amazon Simple Storage Service Developer Guide.
+%% S3 on Outposts in Amazon S3 User Guide.
 %%
 %% All Amazon S3 on Outposts REST API requests for this action require an
 %% additional parameter of `x-amz-outpost-id' to be passed with the request
@@ -433,11 +624,11 @@ delete_bucket(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API action deletes an Amazon S3 on Outposts bucket's lifecycle
+%% @doc This action deletes an Amazon S3 on Outposts bucket's lifecycle
 %% configuration.
 %%
 %% To delete an S3 bucket's lifecycle configuration, see
-%% DeleteBucketLifecycle in the Amazon Simple Storage Service API.
+%% DeleteBucketLifecycle in the Amazon S3 API Reference.
 %%
 %% Deletes the lifecycle configuration from the specified Outposts bucket.
 %% Amazon S3 on Outposts removes all the lifecycle configuration rules in the
@@ -445,9 +636,9 @@ delete_bucket(Client, Bucket, Input0, Options0) ->
 %% expire, and Amazon S3 on Outposts no longer automatically deletes any
 %% objects on the basis of rules contained in the deleted lifecycle
 %% configuration. For more information, see Using Amazon S3 on Outposts in
-%% Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 User Guide.
 %%
-%% To use this operation, you must have permission to perform the
+%% To use this action, you must have permission to perform the
 %% `s3-outposts:DeleteLifecycleConfiguration' action. By default, the bucket
 %% owner has this permission and the Outposts bucket owner can grant this
 %% permission to others.
@@ -493,28 +684,27 @@ delete_bucket_lifecycle_configuration(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This API operation deletes an Amazon S3 on Outposts bucket policy.
+%% @doc This action deletes an Amazon S3 on Outposts bucket policy.
 %%
-%% To delete an S3 bucket policy, see DeleteBucketPolicy in the Amazon Simple
-%% Storage Service API.
+%% To delete an S3 bucket policy, see DeleteBucketPolicy in the Amazon S3 API
+%% Reference.
 %%
-%% This implementation of the DELETE operation uses the policy subresource to
+%% This implementation of the DELETE action uses the policy subresource to
 %% delete the policy of a specified Amazon S3 on Outposts bucket. If you are
-%% using an identity other than the root user of the AWS account that owns
-%% the bucket, the calling identity must have the
+%% using an identity other than the root user of the Amazon Web Services
+%% account that owns the bucket, the calling identity must have the
 %% `s3-outposts:DeleteBucketPolicy' permissions on the specified Outposts
-%% bucket and belong to the bucket owner's account to use this operation. For
-%% more information, see Using Amazon S3 on Outposts in Amazon Simple Storage
-%% Service Developer Guide.
+%% bucket and belong to the bucket owner's account to use this action. For
+%% more information, see Using Amazon S3 on Outposts in Amazon S3 User Guide.
 %%
 %% If you don't have `DeleteBucketPolicy' permissions, Amazon S3 returns a
 %% `403 Access Denied' error. If you have the correct permissions, but you're
 %% not using an identity that belongs to the bucket owner's account, Amazon
 %% S3 returns a `405 Method Not Allowed' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this action, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
 %% For more information about bucket policies, see Using Bucket Policies and
 %% User Policies.
@@ -557,15 +747,15 @@ delete_bucket_policy(Client, Bucket, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc This operation deletes an Amazon S3 on Outposts bucket's tags.
+%% @doc This action deletes an Amazon S3 on Outposts bucket's tags.
 %%
-%% To delete an S3 bucket tags, see DeleteBucketTagging in the Amazon Simple
-%% Storage Service API.
+%% To delete an S3 bucket tags, see DeleteBucketTagging in the Amazon S3 API
+%% Reference.
 %%
 %% Deletes the tags from the Outposts bucket. For more information, see Using
-%% Amazon S3 on Outposts in Amazon Simple Storage Service Developer Guide.
+%% Amazon S3 on Outposts in Amazon S3 User Guide.
 %%
-%% To use this operation, you must have permission to perform the
+%% To use this action, you must have permission to perform the
 %% `PutBucketTagging' action. By default, the bucket owner has this
 %% permission and can grant this permission to others.
 %%
@@ -612,8 +802,7 @@ delete_bucket_tagging(Client, Bucket, Input0, Options0) ->
 %%
 %% To use this operation, you must have permission to perform the
 %% `s3:DeleteJobTagging' action. For more information, see Controlling access
-%% and labeling jobs using tags in the Amazon Simple Storage Service
-%% Developer Guide.
+%% and labeling jobs using tags in the Amazon S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -648,7 +837,58 @@ delete_job_tagging(Client, JobId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes the `PublicAccessBlock' configuration for an AWS account.
+%% @doc Deletes a Multi-Region Access Point.
+%%
+%% This action does not delete the buckets associated with the Multi-Region
+%% Access Point, only the Multi-Region Access Point itself.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% This request is asynchronous, meaning that you might receive a response
+%% before the command has completed. When this request provides a response,
+%% it provides a token that you can use to monitor the status of the request
+%% with `DescribeMultiRegionAccessPointOperation'.
+%%
+%% The following actions are related to `DeleteMultiRegionAccessPoint':
+%%
+%% <ul> <li> CreateMultiRegionAccessPoint
+%%
+%% </li> <li> DescribeMultiRegionAccessPointOperation
+%%
+%% </li> <li> GetMultiRegionAccessPoint
+%%
+%% </li> <li> ListMultiRegionAccessPoints
+%%
+%% </li> </ul>
+delete_multi_region_access_point(Client, Input) ->
+    delete_multi_region_access_point(Client, Input, []).
+delete_multi_region_access_point(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v20180820/async-requests/mrap/delete"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the `PublicAccessBlock' configuration for an Amazon Web
+%% Services account.
 %%
 %% For more information, see Using Amazon S3 block public access.
 %%
@@ -686,13 +926,13 @@ delete_public_access_block(Client, Input0, Options0) ->
 %% @doc Deletes the Amazon S3 Storage Lens configuration.
 %%
 %% For more information about S3 Storage Lens, see Assessing your storage
-%% activity and usage with Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% activity and usage with Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:DeleteStorageLensConfiguration' action. For more information, see
-%% Setting permissions to use Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Setting permissions to use Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 delete_storage_lens_configuration(Client, ConfigId, Input) ->
     delete_storage_lens_configuration(Client, ConfigId, Input, []).
 delete_storage_lens_configuration(Client, ConfigId, Input0, Options0) ->
@@ -720,13 +960,13 @@ delete_storage_lens_configuration(Client, ConfigId, Input0, Options0) ->
 %% @doc Deletes the Amazon S3 Storage Lens configuration tags.
 %%
 %% For more information about S3 Storage Lens, see Assessing your storage
-%% activity and usage with Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% activity and usage with Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:DeleteStorageLensConfigurationTagging' action. For more information,
-%% see Setting permissions to use Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% see Setting permissions to use Amazon S3 Storage Lens in the Amazon S3
+%% User Guide.
 delete_storage_lens_configuration_tagging(Client, ConfigId, Input) ->
     delete_storage_lens_configuration_tagging(Client, ConfigId, Input, []).
 delete_storage_lens_configuration_tagging(Client, ConfigId, Input0, Options0) ->
@@ -754,8 +994,7 @@ delete_storage_lens_configuration_tagging(Client, ConfigId, Input0, Options0) ->
 %% @doc Retrieves the configuration parameters and status for a Batch
 %% Operations job.
 %%
-%% For more information, see S3 Batch Operations in the Amazon Simple Storage
-%% Service Developer Guide.
+%% For more information, see S3 Batch Operations in the Amazon S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -779,6 +1018,50 @@ describe_job(Client, JobId, AccountId, QueryMap, HeadersMap)
 describe_job(Client, JobId, AccountId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/v20180820/jobs/", aws_util:encode_uri(JobId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the status of an asynchronous request to manage a
+%% Multi-Region Access Point.
+%%
+%% For more information about managing Multi-Region Access Points and how
+%% asynchronous requests work, see Managing Multi-Region Access Points in the
+%% Amazon S3 User Guide.
+%%
+%% The following actions are related to `GetMultiRegionAccessPoint':
+%%
+%% <ul> <li> CreateMultiRegionAccessPoint
+%%
+%% </li> <li> DeleteMultiRegionAccessPoint
+%%
+%% </li> <li> GetMultiRegionAccessPoint
+%%
+%% </li> <li> ListMultiRegionAccessPoints
+%%
+%% </li> </ul>
+describe_multi_region_access_point_operation(Client, RequestTokenARN, AccountId)
+  when is_map(Client) ->
+    describe_multi_region_access_point_operation(Client, RequestTokenARN, AccountId, #{}, #{}).
+
+describe_multi_region_access_point_operation(Client, RequestTokenARN, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_multi_region_access_point_operation(Client, RequestTokenARN, AccountId, QueryMap, HeadersMap, []).
+
+describe_multi_region_access_point_operation(Client, RequestTokenARN, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/async-requests/mrap/", aws_util:encode_multi_segment_uri(RequestTokenARN), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -838,6 +1121,78 @@ get_access_point(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns configuration for an Object Lambda Access Point.
+%%
+%% The following actions are related to
+%% `GetAccessPointConfigurationForObjectLambda':
+%%
+%% <ul> <li> PutAccessPointConfigurationForObjectLambda
+%%
+%% </li> </ul>
+get_access_point_configuration_for_object_lambda(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_access_point_configuration_for_object_lambda(Client, Name, AccountId, #{}, #{}).
+
+get_access_point_configuration_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_access_point_configuration_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_access_point_configuration_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/configuration"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns configuration information about the specified Object Lambda
+%% Access Point
+%%
+%% The following actions are related to `GetAccessPointForObjectLambda':
+%%
+%% <ul> <li> CreateAccessPointForObjectLambda
+%%
+%% </li> <li> DeleteAccessPointForObjectLambda
+%%
+%% </li> <li> ListAccessPointsForObjectLambda
+%%
+%% </li> </ul>
+get_access_point_for_object_lambda(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_access_point_for_object_lambda(Client, Name, AccountId, #{}, #{}).
+
+get_access_point_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_access_point_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_access_point_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns the access point policy associated with the specified access
 %% point.
 %%
@@ -874,12 +1229,48 @@ get_access_point_policy(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns the resource policy for an Object Lambda Access Point.
+%%
+%% The following actions are related to
+%% `GetAccessPointPolicyForObjectLambda':
+%%
+%% <ul> <li> DeleteAccessPointPolicyForObjectLambda
+%%
+%% </li> <li> PutAccessPointPolicyForObjectLambda
+%%
+%% </li> </ul>
+get_access_point_policy_for_object_lambda(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_access_point_policy_for_object_lambda(Client, Name, AccountId, #{}, #{}).
+
+get_access_point_policy_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_access_point_policy_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_access_point_policy_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Indicates whether the specified access point currently has a policy
 %% that allows public access.
 %%
 %% For more information about public access through access points, see
-%% Managing Data Access with Amazon S3 Access Points in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Managing Data Access with Amazon S3 access points in the Amazon S3 User
+%% Guide.
 get_access_point_policy_status(Client, Name, AccountId)
   when is_map(Client) ->
     get_access_point_policy_status(Client, Name, AccountId, #{}, #{}).
@@ -906,17 +1297,45 @@ get_access_point_policy_status(Client, Name, AccountId, QueryMap, HeadersMap, Op
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns the status of the resource policy associated with an Object
+%% Lambda Access Point.
+get_access_point_policy_status_for_object_lambda(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_access_point_policy_status_for_object_lambda(Client, Name, AccountId, #{}, #{}).
+
+get_access_point_policy_status_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_access_point_policy_status_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_access_point_policy_status_for_object_lambda(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/policyStatus"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Gets an Amazon S3 on Outposts bucket.
 %%
-%% For more information, see Using Amazon S3 on Outposts in the Amazon Simple
-%% Storage Service Developer Guide.
+%% For more information, see Using Amazon S3 on Outposts in the Amazon S3
+%% User Guide.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the bucket, the calling identity must have the
-%% `s3-outposts:GetBucket' permissions on the specified bucket and belong to
-%% the bucket owner's account in order to use this operation. Only users from
-%% Outposts bucket owner account with the right permissions can perform
-%% actions on an Outposts bucket.
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the Outposts bucket, the calling identity must
+%% have the `s3-outposts:GetBucket' permissions on the specified Outposts
+%% bucket and belong to the Outposts bucket owner's account in order to use
+%% this action. Only users from Outposts bucket owner account with the right
+%% permissions can perform actions on an Outposts bucket.
 %%
 %% If you don't have `s3-outposts:GetBucket' permissions or you're not using
 %% an identity that belongs to the bucket owner's account, Amazon S3 returns
@@ -965,18 +1384,18 @@ get_bucket(Client, Bucket, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This operation gets an Amazon S3 on Outposts bucket's lifecycle
+%% @doc This action gets an Amazon S3 on Outposts bucket's lifecycle
 %% configuration.
 %%
 %% To get an S3 bucket's lifecycle configuration, see
-%% GetBucketLifecycleConfiguration in the Amazon Simple Storage Service API.
+%% GetBucketLifecycleConfiguration in the Amazon S3 API Reference.
 %%
 %% Returns the lifecycle configuration information set on the Outposts
 %% bucket. For more information, see Using Amazon S3 on Outposts and for
 %% information about lifecycle configuration, see Object Lifecycle Management
-%% in Amazon Simple Storage Service Developer Guide.
+%% in Amazon S3 User Guide.
 %%
-%% To use this operation, you must have permission to perform the
+%% To use this action, you must have permission to perform the
 %% `s3-outposts:GetLifecycleConfiguration' action. The Outposts bucket owner
 %% has this permission, by default. The bucket owner can grant this
 %% permission to others. For more information about permissions, see
@@ -1036,17 +1455,16 @@ get_bucket_lifecycle_configuration(Client, Bucket, AccountId, QueryMap, HeadersM
 
 %% @doc This action gets a bucket policy for an Amazon S3 on Outposts bucket.
 %%
-%% To get a policy for an S3 bucket, see GetBucketPolicy in the Amazon Simple
-%% Storage Service API.
+%% To get a policy for an S3 bucket, see GetBucketPolicy in the Amazon S3 API
+%% Reference.
 %%
 %% Returns the policy of a specified Outposts bucket. For more information,
-%% see Using Amazon S3 on Outposts in the Amazon Simple Storage Service
-%% Developer Guide.
+%% see Using Amazon S3 on Outposts in the Amazon S3 User Guide.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the bucket, the calling identity must have the `GetBucketPolicy'
-%% permissions on the specified bucket and belong to the bucket owner's
-%% account in order to use this operation.
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the bucket, the calling identity must have the
+%% `GetBucketPolicy' permissions on the specified bucket and belong to the
+%% bucket owner's account in order to use this action.
 %%
 %% Only users from Outposts bucket owner account with the right permissions
 %% can perform actions on an Outposts bucket. If you don't have
@@ -1054,9 +1472,9 @@ get_bucket_lifecycle_configuration(Client, Bucket, AccountId, QueryMap, HeadersM
 %% that belongs to the bucket owner's account, Amazon S3 returns a `403
 %% Access Denied' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this action, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
 %% For more information about bucket policies, see Using Bucket Policies and
 %% User Policies.
@@ -1103,16 +1521,15 @@ get_bucket_policy(Client, Bucket, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This operation gets an Amazon S3 on Outposts bucket's tags.
+%% @doc This action gets an Amazon S3 on Outposts bucket's tags.
 %%
-%% To get an S3 bucket tags, see GetBucketTagging in the Amazon Simple
-%% Storage Service API.
+%% To get an S3 bucket tags, see GetBucketTagging in the Amazon S3 API
+%% Reference.
 %%
 %% Returns the tag set associated with the Outposts bucket. For more
-%% information, see Using Amazon S3 on Outposts in the Amazon Simple Storage
-%% Service Developer Guide.
+%% information, see Using Amazon S3 on Outposts in the Amazon S3 User Guide.
 %%
-%% To use this operation, you must have permission to perform the
+%% To use this action, you must have permission to perform the
 %% `GetBucketTagging' action. By default, the bucket owner has this
 %% permission and can grant this permission to others.
 %%
@@ -1167,8 +1584,7 @@ get_bucket_tagging(Client, Bucket, AccountId, QueryMap, HeadersMap, Options0)
 %%
 %% To use this operation, you must have permission to perform the
 %% `s3:GetJobTagging' action. For more information, see Controlling access
-%% and labeling jobs using tags in the Amazon Simple Storage Service
-%% Developer Guide.
+%% and labeling jobs using tags in the Amazon S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -1205,7 +1621,136 @@ get_job_tagging(Client, JobId, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Retrieves the `PublicAccessBlock' configuration for an AWS account.
+%% @doc Returns configuration information about the specified Multi-Region
+%% Access Point.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% The following actions are related to `GetMultiRegionAccessPoint':
+%%
+%% <ul> <li> CreateMultiRegionAccessPoint
+%%
+%% </li> <li> DeleteMultiRegionAccessPoint
+%%
+%% </li> <li> DescribeMultiRegionAccessPointOperation
+%%
+%% </li> <li> ListMultiRegionAccessPoints
+%%
+%% </li> </ul>
+get_multi_region_access_point(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_multi_region_access_point(Client, Name, AccountId, #{}, #{}).
+
+get_multi_region_access_point(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_multi_region_access_point(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_multi_region_access_point(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/mrap/instances/", aws_util:encode_uri(Name), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the access control policy of the specified Multi-Region
+%% Access Point.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% The following actions are related to `GetMultiRegionAccessPointPolicy':
+%%
+%% <ul> <li> GetMultiRegionAccessPointPolicyStatus
+%%
+%% </li> <li> PutMultiRegionAccessPointPolicy
+%%
+%% </li> </ul>
+get_multi_region_access_point_policy(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_multi_region_access_point_policy(Client, Name, AccountId, #{}, #{}).
+
+get_multi_region_access_point_policy(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_multi_region_access_point_policy(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_multi_region_access_point_policy(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/mrap/instances/", aws_util:encode_uri(Name), "/policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Indicates whether the specified Multi-Region Access Point has an
+%% access control policy that allows public access.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% The following actions are related to
+%% `GetMultiRegionAccessPointPolicyStatus':
+%%
+%% <ul> <li> GetMultiRegionAccessPointPolicy
+%%
+%% </li> <li> PutMultiRegionAccessPointPolicy
+%%
+%% </li> </ul>
+get_multi_region_access_point_policy_status(Client, Name, AccountId)
+  when is_map(Client) ->
+    get_multi_region_access_point_policy_status(Client, Name, AccountId, #{}, #{}).
+
+get_multi_region_access_point_policy_status(Client, Name, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_multi_region_access_point_policy_status(Client, Name, AccountId, QueryMap, HeadersMap, []).
+
+get_multi_region_access_point_policy_status(Client, Name, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/mrap/instances/", aws_util:encode_uri(Name), "/policystatus"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the `PublicAccessBlock' configuration for an Amazon Web
+%% Services account.
 %%
 %% For more information, see Using Amazon S3 block public access.
 %%
@@ -1245,13 +1790,11 @@ get_public_access_block(Client, AccountId, QueryMap, HeadersMap, Options0)
 %% @doc Gets the Amazon S3 Storage Lens configuration.
 %%
 %% For more information, see Assessing your storage activity and usage with
-%% Amazon S3 Storage Lens in the Amazon Simple Storage Service Developer
-%% Guide.
+%% Amazon S3 Storage Lens in the Amazon S3 User Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:GetStorageLensConfiguration' action. For more information, see Setting
-%% permissions to use Amazon S3 Storage Lens in the Amazon Simple Storage
-%% Service Developer Guide.
+%% permissions to use Amazon S3 Storage Lens in the Amazon S3 User Guide.
 get_storage_lens_configuration(Client, ConfigId, AccountId)
   when is_map(Client) ->
     get_storage_lens_configuration(Client, ConfigId, AccountId, #{}, #{}).
@@ -1281,13 +1824,13 @@ get_storage_lens_configuration(Client, ConfigId, AccountId, QueryMap, HeadersMap
 %% @doc Gets the tags of Amazon S3 Storage Lens configuration.
 %%
 %% For more information about S3 Storage Lens, see Assessing your storage
-%% activity and usage with Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% activity and usage with Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:GetStorageLensConfigurationTagging' action. For more information, see
-%% Setting permissions to use Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Setting permissions to use Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 get_storage_lens_configuration_tagging(Client, ConfigId, AccountId)
   when is_map(Client) ->
     get_storage_lens_configuration_tagging(Client, ConfigId, AccountId, #{}, #{}).
@@ -1370,11 +1913,59 @@ list_access_points(Client, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists current S3 Batch Operations jobs and jobs that have ended
-%% within the last 30 days for the AWS account making the request.
+%% @doc Returns a list of the access points associated with the Object Lambda
+%% Access Point.
 %%
-%% For more information, see S3 Batch Operations in the Amazon Simple Storage
-%% Service Developer Guide.
+%% You can retrieve up to 1000 access points per call. If there are more than
+%% 1,000 access points (or the number specified in `maxResults', whichever is
+%% less), the response will include a continuation token that you can use to
+%% list the additional access points.
+%%
+%% The following actions are related to `ListAccessPointsForObjectLambda':
+%%
+%% <ul> <li> CreateAccessPointForObjectLambda
+%%
+%% </li> <li> DeleteAccessPointForObjectLambda
+%%
+%% </li> <li> GetAccessPointForObjectLambda
+%%
+%% </li> </ul>
+list_access_points_for_object_lambda(Client, AccountId)
+  when is_map(Client) ->
+    list_access_points_for_object_lambda(Client, AccountId, #{}, #{}).
+
+list_access_points_for_object_lambda(Client, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_access_points_for_object_lambda(Client, AccountId, QueryMap, HeadersMap, []).
+
+list_access_points_for_object_lambda(Client, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/accesspointforobjectlambda"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists current S3 Batch Operations jobs and jobs that have ended
+%% within the last 30 days for the Amazon Web Services account making the
+%% request.
+%%
+%% For more information, see S3 Batch Operations in the Amazon S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -1419,11 +2010,65 @@ list_jobs(Client, AccountId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Returns a list of the Multi-Region Access Points currently associated
+%% with the specified Amazon Web Services account.
+%%
+%% Each call can return up to 100 Multi-Region Access Points, the maximum
+%% number of Multi-Region Access Points that can be associated with a single
+%% account.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% The following actions are related to `ListMultiRegionAccessPoint':
+%%
+%% <ul> <li> CreateMultiRegionAccessPoint
+%%
+%% </li> <li> DeleteMultiRegionAccessPoint
+%%
+%% </li> <li> DescribeMultiRegionAccessPointOperation
+%%
+%% </li> <li> GetMultiRegionAccessPoint
+%%
+%% </li> </ul>
+list_multi_region_access_points(Client, AccountId)
+  when is_map(Client) ->
+    list_multi_region_access_points(Client, AccountId, #{}, #{}).
+
+list_multi_region_access_points(Client, AccountId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_multi_region_access_points(Client, AccountId, QueryMap, HeadersMap, []).
+
+list_multi_region_access_points(Client, AccountId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/v20180820/mrap/instances"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers0 =
+      [
+        {<<"x-amz-account-id">>, AccountId}
+      ],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns a list of all Outposts buckets in an Outpost that are owned
 %% by the authenticated sender of the request.
 %%
-%% For more information, see Using Amazon S3 on Outposts in the Amazon Simple
-%% Storage Service Developer Guide.
+%% For more information, see Using Amazon S3 on Outposts in the Amazon S3
+%% User Guide.
 %%
 %% For an example of the request syntax for Amazon S3 on Outposts that uses
 %% the S3 on Outposts endpoint hostname prefix and `x-amz-outpost-id' in your
@@ -1463,13 +2108,13 @@ list_regional_buckets(Client, AccountId, QueryMap, HeadersMap, Options0)
 %% @doc Gets a list of Amazon S3 Storage Lens configurations.
 %%
 %% For more information about S3 Storage Lens, see Assessing your storage
-%% activity and usage with Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% activity and usage with Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:ListStorageLensConfigurations' action. For more information, see
-%% Setting permissions to use Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Setting permissions to use Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 list_storage_lens_configurations(Client, AccountId)
   when is_map(Client) ->
     list_storage_lens_configurations(Client, AccountId, #{}, #{}).
@@ -1499,6 +2144,38 @@ list_storage_lens_configurations(Client, AccountId, QueryMap, HeadersMap, Option
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Replaces configuration for an Object Lambda Access Point.
+%%
+%% The following actions are related to
+%% `PutAccessPointConfigurationForObjectLambda':
+%%
+%% <ul> <li> GetAccessPointConfigurationForObjectLambda
+%%
+%% </li> </ul>
+put_access_point_configuration_for_object_lambda(Client, Name, Input) ->
+    put_access_point_configuration_for_object_lambda(Client, Name, Input, []).
+put_access_point_configuration_for_object_lambda(Client, Name, Input0, Options0) ->
+    Method = put,
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/configuration"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Associates an access policy with the specified access point.
 %%
@@ -1543,17 +2220,54 @@ put_access_point_policy(Client, Name, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates or replaces resource policy for an Object Lambda Access
+%% Point.
+%%
+%% For an example policy, see Creating Object Lambda Access Points in the
+%% Amazon S3 User Guide.
+%%
+%% The following actions are related to
+%% `PutAccessPointPolicyForObjectLambda':
+%%
+%% <ul> <li> DeleteAccessPointPolicyForObjectLambda
+%%
+%% </li> <li> GetAccessPointPolicyForObjectLambda
+%%
+%% </li> </ul>
+put_access_point_policy_for_object_lambda(Client, Name, Input) ->
+    put_access_point_policy_for_object_lambda(Client, Name, Input, []).
+put_access_point_policy_for_object_lambda(Client, Name, Input0, Options0) ->
+    Method = put,
+    Path = ["/v20180820/accesspointforobjectlambda/", aws_util:encode_uri(Name), "/policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc This action puts a lifecycle configuration to an Amazon S3 on
 %% Outposts bucket.
 %%
 %% To put a lifecycle configuration to an S3 bucket, see
-%% PutBucketLifecycleConfiguration in the Amazon Simple Storage Service API.
+%% PutBucketLifecycleConfiguration in the Amazon S3 API Reference.
 %%
-%% Creates a new lifecycle configuration for the Outposts bucket or replaces
-%% an existing lifecycle configuration. Outposts buckets only support
-%% lifecycle configurations that delete/expire objects after a certain period
-%% of time and abort incomplete multipart uploads. For more information, see
-%% Managing Lifecycle Permissions for Amazon S3 on Outposts.
+%% Creates a new lifecycle configuration for the S3 on Outposts bucket or
+%% replaces an existing lifecycle configuration. Outposts buckets only
+%% support lifecycle configurations that delete/expire objects after a
+%% certain period of time and abort incomplete multipart uploads.
 %%
 %% All Amazon S3 on Outposts REST API requests for this action require an
 %% additional parameter of `x-amz-outpost-id' to be passed with the request
@@ -1595,26 +2309,25 @@ put_bucket_lifecycle_configuration(Client, Bucket, Input0, Options0) ->
 
 %% @doc This action puts a bucket policy to an Amazon S3 on Outposts bucket.
 %%
-%% To put a policy on an S3 bucket, see PutBucketPolicy in the Amazon Simple
-%% Storage Service API.
+%% To put a policy on an S3 bucket, see PutBucketPolicy in the Amazon S3 API
+%% Reference.
 %%
 %% Applies an Amazon S3 bucket policy to an Outposts bucket. For more
-%% information, see Using Amazon S3 on Outposts in the Amazon Simple Storage
-%% Service Developer Guide.
+%% information, see Using Amazon S3 on Outposts in the Amazon S3 User Guide.
 %%
-%% If you are using an identity other than the root user of the AWS account
-%% that owns the Outposts bucket, the calling identity must have the
-%% `PutBucketPolicy' permissions on the specified Outposts bucket and belong
-%% to the bucket owner's account in order to use this operation.
+%% If you are using an identity other than the root user of the Amazon Web
+%% Services account that owns the Outposts bucket, the calling identity must
+%% have the `PutBucketPolicy' permissions on the specified Outposts bucket
+%% and belong to the bucket owner's account in order to use this action.
 %%
 %% If you don't have `PutBucketPolicy' permissions, Amazon S3 returns a `403
 %% Access Denied' error. If you have the correct permissions, but you're not
 %% using an identity that belongs to the bucket owner's account, Amazon S3
 %% returns a `405 Method Not Allowed' error.
 %%
-%% As a security precaution, the root user of the AWS account that owns a
-%% bucket can always use this operation, even if the policy explicitly denies
-%% the root user the ability to perform this action.
+%% As a security precaution, the root user of the Amazon Web Services account
+%% that owns a bucket can always use this action, even if the policy
+%% explicitly denies the root user the ability to perform this action.
 %%
 %% For more information about bucket policies, see Using Bucket Policies and
 %% User Policies.
@@ -1660,32 +2373,31 @@ put_bucket_policy(Client, Bucket, Input0, Options0) ->
 
 %% @doc This action puts tags on an Amazon S3 on Outposts bucket.
 %%
-%% To put tags on an S3 bucket, see PutBucketTagging in the Amazon Simple
-%% Storage Service API.
+%% To put tags on an S3 bucket, see PutBucketTagging in the Amazon S3 API
+%% Reference.
 %%
-%% Sets the tags for an Outposts bucket. For more information, see Using
-%% Amazon S3 on Outposts in the Amazon Simple Storage Service Developer
-%% Guide.
+%% Sets the tags for an S3 on Outposts bucket. For more information, see
+%% Using Amazon S3 on Outposts in the Amazon S3 User Guide.
 %%
-%% Use tags to organize your AWS bill to reflect your own cost structure. To
-%% do this, sign up to get your AWS account bill with tag key values
-%% included. Then, to see the cost of combined resources, organize your
-%% billing information according to resources with the same tag key values.
-%% For example, you can tag several resources with a specific application
-%% name, and then organize your billing information to see the total cost of
-%% that application across several services. For more information, see Cost
-%% Allocation and Tagging.
+%% Use tags to organize your Amazon Web Services bill to reflect your own
+%% cost structure. To do this, sign up to get your Amazon Web Services
+%% account bill with tag key values included. Then, to see the cost of
+%% combined resources, organize your billing information according to
+%% resources with the same tag key values. For example, you can tag several
+%% resources with a specific application name, and then organize your billing
+%% information to see the total cost of that application across several
+%% services. For more information, see Cost allocation and tagging.
 %%
 %% Within a bucket, if you add a tag that has the same key as an existing
 %% tag, the new value overwrites the old value. For more information, see
-%% Using Cost Allocation in Amazon S3 Bucket Tags.
+%% Using cost allocation in Amazon S3 bucket tags.
 %%
-%% To use this operation, you must have permissions to perform the
+%% To use this action, you must have permissions to perform the
 %% `s3-outposts:PutBucketTagging' action. The Outposts bucket owner has this
 %% permission by default and can grant this permission to others. For more
 %% information about permissions, see Permissions Related to Bucket
-%% Subresource Operations and Managing Access Permissions to Your Amazon S3
-%% Resources.
+%% Subresource Operations and Managing access permissions to your Amazon S3
+%% resources.
 %%
 %% `PutBucketTagging' has the following special errors:
 %%
@@ -1693,8 +2405,8 @@ put_bucket_policy(Client, Bucket, Input0, Options0) ->
 %%
 %% <ul> <li> Description: The tag provided was not a valid tag. This error
 %% can occur if the tag did not pass input validation. For information about
-%% tag restrictions, see User-Defined Tag Restrictions and AWS-Generated Cost
-%% Allocation Tag Restrictions.
+%% tag restrictions, see User-Defined Tag Restrictions and Amazon Web
+%% Services-Generated Cost Allocation Tag Restrictions.
 %%
 %% </li> </ul> </li> <li> Error code: `MalformedXMLError'
 %%
@@ -1702,7 +2414,7 @@ put_bucket_policy(Client, Bucket, Input0, Options0) ->
 %%
 %% </li> </ul> </li> <li> Error code: `OperationAbortedError '
 %%
-%% <ul> <li> Description: A conflicting conditional operation is currently in
+%% <ul> <li> Description: A conflicting conditional action is currently in
 %% progress against this resource. Try again.
 %%
 %% </li> </ul> </li> <li> Error code: `InternalError'
@@ -1758,7 +2470,7 @@ put_bucket_tagging(Client, Bucket, Input0, Options0) ->
 %% tag set by retrieving the existing tag set using GetJobTagging, modify
 %% that tag set, and use this action to replace the tag set with the one you
 %% modified. For more information, see Controlling access and labeling jobs
-%% using tags in the Amazon Simple Storage Service Developer Guide.
+%% using tags in the Amazon S3 User Guide.
 %%
 %% <ul> <li> If you send this request with an empty tag set, Amazon S3
 %% deletes the existing tag set on the Batch Operations job. If you use this
@@ -1782,12 +2494,12 @@ put_bucket_tagging(Client, Bucket, Input0, Options0) ->
 %% </li> <li> The key and values are case sensitive.
 %%
 %% </li> <li> For tagging-related restrictions related to characters and
-%% encodings, see User-Defined Tag Restrictions in the AWS Billing and Cost
+%% encodings, see User-Defined Tag Restrictions in the Billing and Cost
 %% Management User Guide.
 %%
 %% </li> </ul> </li> </ul>
 %%
-%% To use this operation, you must have permission to perform the
+%% To use this action, you must have permission to perform the
 %% `s3:PutJobTagging' action.
 %%
 %% Related actions include:
@@ -1823,8 +2535,51 @@ put_job_tagging(Client, JobId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates or modifies the `PublicAccessBlock' configuration for an AWS
-%% account.
+%% @doc Associates an access control policy with the specified Multi-Region
+%% Access Point.
+%%
+%% Each Multi-Region Access Point can have only one policy, so a request made
+%% to this action replaces any existing policy that is associated with the
+%% specified Multi-Region Access Point.
+%%
+%% This action will always be routed to the US West (Oregon) Region. For more
+%% information about the restrictions around managing Multi-Region Access
+%% Points, see Managing Multi-Region Access Points in the Amazon S3 User
+%% Guide.
+%%
+%% The following actions are related to `PutMultiRegionAccessPointPolicy':
+%%
+%% <ul> <li> GetMultiRegionAccessPointPolicy
+%%
+%% </li> <li> GetMultiRegionAccessPointPolicyStatus
+%%
+%% </li> </ul>
+put_multi_region_access_point_policy(Client, Input) ->
+    put_multi_region_access_point_policy(Client, Input, []).
+put_multi_region_access_point_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v20180820/async-requests/mrap/put-policy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    HeadersMapping = [
+                       {<<"x-amz-account-id">>, <<"AccountId">>}
+                     ],
+    {Headers, Input1} = aws_request:build_headers(HeadersMapping, Input0),
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates or modifies the `PublicAccessBlock' configuration for an
+%% Amazon Web Services account.
 %%
 %% For more information, see Using Amazon S3 block public access.
 %%
@@ -1862,12 +2617,11 @@ put_public_access_block(Client, Input0, Options0) ->
 %% @doc Puts an Amazon S3 Storage Lens configuration.
 %%
 %% For more information about S3 Storage Lens, see Working with Amazon S3
-%% Storage Lens in the Amazon Simple Storage Service Developer Guide.
+%% Storage Lens in the Amazon S3 User Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:PutStorageLensConfiguration' action. For more information, see Setting
-%% permissions to use Amazon S3 Storage Lens in the Amazon Simple Storage
-%% Service Developer Guide.
+%% permissions to use Amazon S3 Storage Lens in the Amazon S3 User Guide.
 put_storage_lens_configuration(Client, ConfigId, Input) ->
     put_storage_lens_configuration(Client, ConfigId, Input, []).
 put_storage_lens_configuration(Client, ConfigId, Input0, Options0) ->
@@ -1896,13 +2650,13 @@ put_storage_lens_configuration(Client, ConfigId, Input0, Options0) ->
 %% configuration.
 %%
 %% For more information about S3 Storage Lens, see Assessing your storage
-%% activity and usage with Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% activity and usage with Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 %%
 %% To use this action, you must have permission to perform the
 %% `s3:PutStorageLensConfigurationTagging' action. For more information, see
-%% Setting permissions to use Amazon S3 Storage Lens in the Amazon Simple
-%% Storage Service Developer Guide.
+%% Setting permissions to use Amazon S3 Storage Lens in the Amazon S3 User
+%% Guide.
 put_storage_lens_configuration_tagging(Client, ConfigId, Input) ->
     put_storage_lens_configuration_tagging(Client, ConfigId, Input, []).
 put_storage_lens_configuration_tagging(Client, ConfigId, Input0, Options0) ->
@@ -1929,8 +2683,7 @@ put_storage_lens_configuration_tagging(Client, ConfigId, Input0, Options0) ->
 
 %% @doc Updates an existing S3 Batch Operations job's priority.
 %%
-%% For more information, see S3 Batch Operations in the Amazon Simple Storage
-%% Service Developer Guide.
+%% For more information, see S3 Batch Operations in the Amazon S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -1970,9 +2723,9 @@ update_job_priority(Client, JobId, Input0, Options0) ->
 
 %% @doc Updates the status for the specified job.
 %%
-%% Use this operation to confirm that you want to run a job or to cancel an
+%% Use this action to confirm that you want to run a job or to cancel an
 %% existing job. For more information, see S3 Batch Operations in the Amazon
-%% Simple Storage Service Developer Guide.
+%% S3 User Guide.
 %%
 %% Related actions include:
 %%
@@ -2047,6 +2800,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -18,14 +18,17 @@
 %% API
 %%====================================================================
 
-%% @doc S3 on Outposts access points simplify managing data access at scale
-%% for shared datasets in Amazon S3 on Outposts.
+%% @doc Amazon S3 on Outposts Access Points simplify managing data access at
+%% scale for shared datasets in S3 on Outposts.
 %%
 %% S3 on Outposts uses endpoints to connect to Outposts buckets so that you
-%% can perform actions within your virtual private cloud (VPC).
+%% can perform actions within your virtual private cloud (VPC). For more
+%% information, see Accessing S3 on Outposts using VPC only access points.
 %%
 %% This action creates an endpoint and associates it with the specified
-%% Outpost.
+%% Outposts.
+%%
+%% It can take up to 5 minutes for this action to complete.
 %%
 %% Related actions include:
 %%
@@ -56,13 +59,16 @@ create_endpoint(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc S3 on Outposts access points simplify managing data access at scale
-%% for shared datasets in Amazon S3 on Outposts.
+%% @doc Amazon S3 on Outposts Access Points simplify managing data access at
+%% scale for shared datasets in S3 on Outposts.
 %%
 %% S3 on Outposts uses endpoints to connect to Outposts buckets so that you
-%% can perform actions within your virtual private cloud (VPC).
+%% can perform actions within your virtual private cloud (VPC). For more
+%% information, see Accessing S3 on Outposts using VPC only access points.
 %%
 %% This action deletes an endpoint.
+%%
+%% It can take up to 5 minutes for this action to complete.
 %%
 %% Related actions include:
 %%
@@ -95,13 +101,14 @@ delete_endpoint(Client, Input0, Options0) ->
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc S3 on Outposts access points simplify managing data access at scale
-%% for shared datasets in Amazon S3 on Outposts.
+%% @doc Amazon S3 on Outposts Access Points simplify managing data access at
+%% scale for shared datasets in S3 on Outposts.
 %%
 %% S3 on Outposts uses endpoints to connect to Outposts buckets so that you
-%% can perform actions within your virtual private cloud (VPC).
+%% can perform actions within your virtual private cloud (VPC). For more
+%% information, see Accessing S3 on Outposts using VPC only access points.
 %%
-%% This action lists endpoints associated with the Outpost.
+%% This action lists endpoints associated with the Outposts.
 %%
 %% Related actions include:
 %%
@@ -172,6 +179,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_sagemaker.erl
+++ b/src/aws_sagemaker.erl
@@ -18,6 +18,8 @@
          add_tags/3,
          associate_trial_component/2,
          associate_trial_component/3,
+         batch_describe_model_package/2,
+         batch_describe_model_package/3,
          create_action/2,
          create_action/3,
          create_algorithm/2,
@@ -92,6 +94,8 @@
          create_processing_job/3,
          create_project/2,
          create_project/3,
+         create_studio_lifecycle_config/2,
+         create_studio_lifecycle_config/3,
          create_training_job/2,
          create_training_job/3,
          create_transform_job/2,
@@ -168,6 +172,8 @@
          delete_pipeline/3,
          delete_project/2,
          delete_project/3,
+         delete_studio_lifecycle_config/2,
+         delete_studio_lifecycle_config/3,
          delete_tags/2,
          delete_tags/3,
          delete_trial/2,
@@ -258,6 +264,8 @@
          describe_processing_job/3,
          describe_project/2,
          describe_project/3,
+         describe_studio_lifecycle_config/2,
+         describe_studio_lifecycle_config/3,
          describe_subscribed_workteam/2,
          describe_subscribed_workteam/3,
          describe_training_job/2,
@@ -374,6 +382,8 @@
          list_processing_jobs/3,
          list_projects/2,
          list_projects/3,
+         list_studio_lifecycle_configs/2,
+         list_studio_lifecycle_configs/3,
          list_subscribed_workteams/2,
          list_subscribed_workteams/3,
          list_tags/2,
@@ -400,8 +410,14 @@
          register_devices/3,
          render_ui_template/2,
          render_ui_template/3,
+         retry_pipeline_execution/2,
+         retry_pipeline_execution/3,
          search/2,
          search/3,
+         send_pipeline_execution_step_failure/2,
+         send_pipeline_execution_step_failure/3,
+         send_pipeline_execution_step_success/2,
+         send_pipeline_execution_step_success/3,
          start_monitoring_schedule/2,
          start_monitoring_schedule/3,
          start_notebook_instance/2,
@@ -466,6 +482,8 @@
          update_pipeline/3,
          update_pipeline_execution/2,
          update_pipeline_execution/3,
+         update_project/2,
+         update_project/3,
          update_training_job/2,
          update_training_job/3,
          update_trial/2,
@@ -507,7 +525,7 @@ add_association(Client, Input, Options)
 %%
 %% Each tag consists of a key and an optional value. Tag keys must be unique
 %% per resource. For more information about tags, see For more information,
-%% see AWS Tagging Strategies.
+%% see Amazon Web Services Tagging Strategies.
 %%
 %% Tags that you add to a hyperparameter tuning job by calling this API are
 %% also added to any training jobs that the hyperparameter tuning job
@@ -517,6 +535,15 @@ add_association(Client, Input, Options)
 %% added to all training jobs that the hyperparameter tuning job launches,
 %% add the tags when you first create the tuning job by specifying them in
 %% the `Tags' parameter of `CreateHyperParameterTuningJob'
+%%
+%% Tags that you add to a SageMaker Studio Domain or User Profile by calling
+%% this API are also added to any Apps that the Domain or User Profile
+%% launches after you call this API, but not to Apps that the Domain or User
+%% Profile launched before you called this API. To make sure that the tags
+%% associated with a Domain or User Profile are also added to all Apps that
+%% the Domain or User Profile launches, add the tags when you first create
+%% the Domain or User Profile by specifying them in the `Tags' parameter of
+%% `CreateDomain' or `CreateUserProfile'.
 add_tags(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_tags(Client, Input, []).
@@ -535,6 +562,14 @@ associate_trial_component(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssociateTrialComponent">>, Input, Options).
 
+%% @doc This action batch describes a list of versioned model packages
+batch_describe_model_package(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    batch_describe_model_package(Client, Input, []).
+batch_describe_model_package(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"BatchDescribeModelPackage">>, Input, Options).
+
 %% @doc Creates an action.
 %%
 %% An action is a lineage tracking entity that represents an action or
@@ -549,7 +584,7 @@ create_action(Client, Input, Options)
     request(Client, <<"CreateAction">>, Input, Options).
 
 %% @doc Create a machine learning algorithm that you can use in Amazon
-%% SageMaker and list in the AWS Marketplace.
+%% SageMaker and list in the Amazon Web Services Marketplace.
 create_algorithm(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_algorithm(Client, Input, []).
@@ -557,9 +592,9 @@ create_algorithm(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateAlgorithm">>, Input, Options).
 
-%% @doc Creates a running App for the specified UserProfile.
+%% @doc Creates a running app for the specified UserProfile.
 %%
-%% Supported Apps are JupyterServer and KernelGateway. This operation is
+%% Supported apps are `JupyterServer' and `KernelGateway'. This operation is
 %% automatically invoked by Amazon SageMaker Studio upon access to the
 %% associated Domain, and when new kernel configurations are selected by the
 %% user. A user may have multiple Apps active simultaneously.
@@ -597,9 +632,7 @@ create_artifact(Client, Input, Options)
 
 %% @doc Creates an Autopilot job.
 %%
-%% Find the best performing model after you run an Autopilot job by calling .
-%% Deploy that model by following the steps described in Step 6.1: Deploy the
-%% Model to Amazon SageMaker Hosting Services.
+%% Find the best-performing model after you run an Autopilot job by calling .
 %%
 %% For information about how to use Autopilot, see Automate Model Development
 %% with Amazon SageMaker Autopilot.
@@ -619,8 +652,8 @@ create_auto_ml_job(Client, Input, Options)
 %% more than one notebook instance, and it persists independently from the
 %% lifecycle of any notebook instances it is associated with.
 %%
-%% The repository can be hosted either in AWS CodeCommit or in any other Git
-%% repository.
+%% The repository can be hosted either in Amazon Web Services CodeCommit or
+%% in any other Git repository.
 create_code_repository(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_code_repository(Client, Input, []).
@@ -636,8 +669,8 @@ create_code_repository(Client, Input, Options)
 %%
 %% If you choose to host your model using Amazon SageMaker hosting services,
 %% you can use the resulting model artifacts as part of the model. You can
-%% also use the artifacts with AWS IoT Greengrass. In that case, deploy them
-%% as an ML resource.
+%% also use the artifacts with Amazon Web Services IoT Greengrass. In that
+%% case, deploy them as an ML resource.
 %%
 %% In the request body, you provide the following:
 %%
@@ -702,9 +735,9 @@ create_device_fleet(Client, Input, Options)
 %% A domain consists of an associated Amazon Elastic File System (EFS)
 %% volume, a list of authorized users, and a variety of security,
 %% application, policy, and Amazon Virtual Private Cloud (VPC)
-%% configurations. An AWS account is limited to one domain per region. Users
-%% within a domain can share notebook files and other artifacts with each
-%% other.
+%% configurations. An Amazon Web Services account is limited to one domain
+%% per region. Users within a domain can share notebook files and other
+%% artifacts with each other.
 %%
 %% EFS storage
 %%
@@ -712,10 +745,11 @@ create_device_fleet(Client, Input, Options)
 %% users within the domain. Each user receives a private home directory
 %% within the EFS volume for notebooks, Git repositories, and data files.
 %%
-%% SageMaker uses the AWS Key Management Service (AWS KMS) to encrypt the EFS
-%% volume attached to the domain with an AWS managed customer master key
-%% (CMK) by default. For more control, you can specify a customer managed
-%% CMK. For more information, see Protect Data at Rest Using Encryption.
+%% SageMaker uses the Amazon Web Services Key Management Service (Amazon Web
+%% Services KMS) to encrypt the EFS volume attached to the domain with an
+%% Amazon Web Services managed key by default. For more control, you can
+%% specify a customer managed key. For more information, see Protect Data at
+%% Rest Using Encryption.
 %%
 %% VPC configuration
 %%
@@ -738,8 +772,12 @@ create_device_fleet(Client, Input, Options)
 %% endpoint to the SageMaker API and runtime or a NAT gateway and your
 %% security groups allow outbound connections.
 %%
-%% </li> </ul> For more information, see Connect SageMaker Studio Notebooks
-%% to Resources in a VPC.
+%% </li> </ul> NFS traffic over TCP on port 2049 needs to be allowed in both
+%% inbound and outbound rules in order to launch a SageMaker Studio app
+%% successfully.
+%%
+%% For more information, see Connect SageMaker Studio Notebooks to Resources
+%% in a VPC.
 create_domain(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_domain(Client, Input, []).
@@ -769,15 +807,15 @@ create_edge_packaging_job(Client, Input, Options)
 %% Use this API to deploy models using Amazon SageMaker hosting services.
 %%
 %% For an example that calls this method when deploying a model to Amazon
-%% SageMaker hosting services, see Deploy the Model to Amazon SageMaker
-%% Hosting Services (AWS SDK for Python (Boto 3)).
+%% SageMaker hosting services, see the Create Endpoint example notebook.
 %%
 %% You must not delete an `EndpointConfig' that is in use by an endpoint that
 %% is live or while the `UpdateEndpoint' or `CreateEndpoint' operations are
 %% being performed on the endpoint. To update an endpoint, you must create a
 %% new `EndpointConfig'.
 %%
-%% The endpoint name must be unique within an AWS Region in your AWS account.
+%% The endpoint name must be unique within an Amazon Web Services Region in
+%% your Amazon Web Services account.
 %%
 %% When it receives the request, Amazon SageMaker creates the endpoint,
 %% launches the resources (ML compute instances), and deploys the model(s) on
@@ -802,12 +840,14 @@ create_edge_packaging_job(Client, Input, Options)
 %% API.
 %%
 %% If any of the models hosted at this endpoint get model data from an Amazon
-%% S3 location, Amazon SageMaker uses AWS Security Token Service to download
-%% model artifacts from the S3 path you provided. AWS STS is activated in
-%% your IAM user account by default. If you previously deactivated AWS STS
-%% for a region, you need to reactivate AWS STS for that region. For more
-%% information, see Activating and Deactivating AWS STS in an AWS Region in
-%% the AWS Identity and Access Management User Guide.
+%% S3 location, Amazon SageMaker uses Amazon Web Services Security Token
+%% Service to download model artifacts from the S3 path you provided. Amazon
+%% Web Services STS is activated in your IAM user account by default. If you
+%% previously deactivated Amazon Web Services STS for a region, you need to
+%% reactivate Amazon Web Services STS for that region. For more information,
+%% see Activating and Deactivating Amazon Web Services STS in an Amazon Web
+%% Services Region in the Amazon Web Services Identity and Access Management
+%% User Guide.
 %%
 %% To add the IAM role policies for using this API operation, go to the IAM
 %% console, and choose Roles in the left navigation pane. Search the IAM role
@@ -815,7 +855,7 @@ create_edge_packaging_job(Client, Input, Options)
 %% `CreateEndpointConfig' API operations, add the following policies to the
 %% role.
 %%
-%% Option 1: For a full Amazon SageMaker access, search and attach the
+%% Option 1: For a full SageMaker access, search and attach the
 %% `AmazonSageMakerFullAccess' policy.
 %%
 %% Option 2: For granting a limited access to an IAM role, paste the
@@ -831,8 +871,8 @@ create_edge_packaging_job(Client, Input, Options)
 %%
 %% `]'
 %%
-%% For more information, see Amazon SageMaker API Permissions: Actions,
-%% Permissions, and Resources Reference.
+%% For more information, see SageMaker API Permissions: Actions, Permissions,
+%% and Resources Reference.
 create_endpoint(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_endpoint(Client, Input, []).
@@ -860,10 +900,6 @@ create_endpoint(Client, Input, Options)
 %% suppose that you want to host two models, A and B, and you assign traffic
 %% weight 2 for model A and 1 for model B. Amazon SageMaker distributes
 %% two-thirds of the traffic to Model A, and one-third to model B.
-%%
-%% For an example that calls this method when deploying a model to Amazon
-%% SageMaker hosting services, see Deploy the Model to Amazon SageMaker
-%% Hosting Services (AWS SDK for Python (Boto 3)).
 %%
 %% When you call `CreateEndpoint', a load call is made to DynamoDB to verify
 %% that your endpoint configuration exists. When you read data from a
@@ -894,10 +930,10 @@ create_endpoint_config(Client, Input, Options)
 %% measuring the impact of a change to one or more inputs, while keeping the
 %% remaining inputs constant.
 %%
-%% When you use Amazon SageMaker Studio or the Amazon SageMaker Python SDK,
-%% all experiments, trials, and trial components are automatically tracked,
-%% logged, and indexed. When you use the AWS SDK for Python (Boto), you must
-%% use the logging APIs provided by the SDK.
+%% When you use SageMaker Studio or the SageMaker Python SDK, all
+%% experiments, trials, and trial components are automatically tracked,
+%% logged, and indexed. When you use the Amazon Web Services SDK for Python
+%% (Boto), you must use the logging APIs provided by the SDK.
 %%
 %% You can add tags to experiments, trials, trial components and then use the
 %% `Search' API to search for the tags.
@@ -925,8 +961,9 @@ create_experiment(Client, Input, Options)
 %% The `FeatureGroup' defines the schema and features contained in the
 %% FeatureGroup. A `FeatureGroup' definition is composed of a list of
 %% `Features', a `RecordIdentifierFeatureName', an `EventTimeFeatureName' and
-%% configurations for its `OnlineStore' and `OfflineStore'. Check AWS service
-%% quotas to see the `FeatureGroup's quota for your AWS account.
+%% configurations for its `OnlineStore' and `OfflineStore'. Check Amazon Web
+%% Services service quotas to see the `FeatureGroup's quota for your Amazon
+%% Web Services account.
 %%
 %% You must include at least one of `OnlineStoreConfig' and
 %% `OfflineStoreConfig' to create a `FeatureGroup'.
@@ -1006,8 +1043,8 @@ create_image_version(Client, Input, Options)
 %% data to stay within your organization or when a specific set of skills is
 %% required.
 %%
-%% </li> <li> One or more vendors that you select from the AWS Marketplace.
-%% Vendors provide expertise in specific areas.
+%% </li> <li> One or more vendors that you select from the Amazon Web
+%% Services Marketplace. Vendors provide expertise in specific areas.
 %%
 %% </li> <li> The Amazon Mechanical Turk workforce. This is the largest
 %% workforce, but it should only be used for public data or data that has
@@ -1060,7 +1097,7 @@ create_labeling_job(Client, Input, Options)
 %%
 %% For an example that calls this method when deploying a model to Amazon
 %% SageMaker hosting services, see Deploy the Model to Amazon SageMaker
-%% Hosting Services (AWS SDK for Python (Boto 3)).
+%% Hosting Services (Amazon Web Services SDK for Python (Boto 3)).
 %%
 %% To run a batch transform using your model, you start a job with the
 %% `CreateTransformJob' API. Amazon SageMaker uses your model and your
@@ -1073,8 +1110,8 @@ create_labeling_job(Client, Input, Options)
 %% assume to access model artifacts and docker image for deployment on ML
 %% compute hosting instances or for batch transform jobs. In addition, you
 %% also use the IAM role to manage permissions the inference code needs. For
-%% example, if the inference code access any other AWS resources, you grant
-%% necessary permissions via this role.
+%% example, if the inference code access any other Amazon Web Services
+%% resources, you grant necessary permissions via this role.
 create_model(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_model(Client, Input, []).
@@ -1099,17 +1136,17 @@ create_model_explainability_job_definition(Client, Input, Options)
     request(Client, <<"CreateModelExplainabilityJobDefinition">>, Input, Options).
 
 %% @doc Creates a model package that you can use to create Amazon SageMaker
-%% models or list on AWS Marketplace, or a versioned model that is part of a
-%% model group.
+%% models or list on Amazon Web Services Marketplace, or a versioned model
+%% that is part of a model group.
 %%
-%% Buyers can subscribe to model packages listed on AWS Marketplace to create
-%% models in Amazon SageMaker.
+%% Buyers can subscribe to model packages listed on Amazon Web Services
+%% Marketplace to create models in Amazon SageMaker.
 %%
 %% To create a model package by specifying a Docker container that contains
 %% your inference code and the Amazon S3 location of your model artifacts,
 %% provide values for `InferenceSpecification'. To create a model from an
-%% algorithm resource that you created or subscribed to in AWS Marketplace,
-%% provide a value for `SourceAlgorithmSpecification'.
+%% algorithm resource that you created or subscribed to in Amazon Web
+%% Services Marketplace, provide a value for `SourceAlgorithmSpecification'.
 %%
 %% There are two types of model packages:
 %%
@@ -1244,10 +1281,21 @@ create_pipeline(Client, Input, Options)
 %% volume. This operation can only be called when the authentication mode
 %% equals IAM.
 %%
+%% The IAM role or user used to call this API defines the permissions to
+%% access the app. Once the presigned URL is created, no additional
+%% permission is required to access this URL. IAM authorization policies for
+%% this API are also enforced for every HTTP request and WebSocket frame that
+%% attempts to connect to the app.
+%%
+%% You can restrict access to this API and to the URL that it returns to a
+%% list of IP addresses, Amazon VPCs or Amazon VPC Endpoints that you
+%% specify. For more information, see Connect to SageMaker Studio Through an
+%% Interface VPC Endpoint .
+%%
 %% The URL that you get from a call to `CreatePresignedDomainUrl' has a
 %% default timeout of 5 minutes. You can configure this value using
 %% `ExpiresInSeconds'. If you try to use the URL after the timeout limit
-%% expires, you are directed to the AWS console sign-in page.
+%% expires, you are directed to the Amazon Web Services console sign-in page.
 create_presigned_domain_url(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_presigned_domain_url(Client, Input, []).
@@ -1277,7 +1325,8 @@ create_presigned_domain_url(Client, Input, Options)
 %%
 %% The URL that you get from a call to `CreatePresignedNotebookInstanceUrl'
 %% is valid only for 5 minutes. If you try to use the URL after the 5-minute
-%% limit expires, you are directed to the AWS console sign-in page.
+%% limit expires, you are directed to the Amazon Web Services console sign-in
+%% page.
 create_presigned_notebook_instance_url(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_presigned_notebook_instance_url(Client, Input, []).
@@ -1302,6 +1351,14 @@ create_project(Client, Input)
 create_project(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateProject">>, Input, Options).
+
+%% @doc Creates a new Studio Lifecycle Configuration.
+create_studio_lifecycle_config(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_studio_lifecycle_config(Client, Input, []).
+create_studio_lifecycle_config(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateStudioLifecycleConfig">>, Input, Options).
 
 %% @doc Starts a model training job.
 %%
@@ -1345,8 +1402,14 @@ create_project(Client, Input, Options)
 %%
 %% </li> <li> `StoppingCondition' - To help cap training costs, use
 %% `MaxRuntimeInSeconds' to set a time limit for training. Use
-%% `MaxWaitTimeInSeconds' to specify how long you are willing to wait for a
-%% managed spot training job to complete.
+%% `MaxWaitTimeInSeconds' to specify how long a managed spot training job has
+%% to complete.
+%%
+%% </li> <li> `Environment' - The environment variables to set in the Docker
+%% container.
+%%
+%% </li> <li> `RetryStrategy' - The number of times to retry the job when the
+%% job fails due to an `InternalServerError'.
 %%
 %% </li> </ul> For more information about Amazon SageMaker, see How It Works.
 create_training_job(Client, Input)
@@ -1367,11 +1430,13 @@ create_training_job(Client, Input, Options)
 %% In the request body, you provide the following:
 %%
 %% <ul> <li> `TransformJobName' - Identifies the transform job. The name must
-%% be unique within an AWS Region in an AWS account.
+%% be unique within an Amazon Web Services Region in an Amazon Web Services
+%% account.
 %%
 %% </li> <li> `ModelName' - Identifies the model to use. `ModelName' must be
-%% the name of an existing Amazon SageMaker model in the same AWS Region and
-%% AWS account. For information on creating a model, see `CreateModel'.
+%% the name of an existing Amazon SageMaker model in the same Amazon Web
+%% Services Region and Amazon Web Services account. For information on
+%% creating a model, see `CreateModel'.
 %%
 %% </li> <li> `TransformInput' - Describes the dataset to be transformed and
 %% the Amazon S3 location where it is stored.
@@ -1391,15 +1456,15 @@ create_transform_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateTransformJob">>, Input, Options).
 
-%% @doc Creates an Amazon SageMaker trial.
+%% @doc Creates an SageMaker trial.
 %%
 %% A trial is a set of steps called trial components that produce a machine
-%% learning model. A trial is part of a single Amazon SageMaker experiment.
+%% learning model. A trial is part of a single SageMaker experiment.
 %%
-%% When you use Amazon SageMaker Studio or the Amazon SageMaker Python SDK,
-%% all experiments, trials, and trial components are automatically tracked,
-%% logged, and indexed. When you use the AWS SDK for Python (Boto), you must
-%% use the logging APIs provided by the SDK.
+%% When you use SageMaker Studio or the SageMaker Python SDK, all
+%% experiments, trials, and trial components are automatically tracked,
+%% logged, and indexed. When you use the Amazon Web Services SDK for Python
+%% (Boto), you must use the logging APIs provided by the SDK.
 %%
 %% You can add tags to a trial and then use the `Search' API to search for
 %% the tags.
@@ -1423,19 +1488,13 @@ create_trial(Client, Input, Options)
 %% Trial components include pre-processing jobs, training jobs, and batch
 %% transform jobs.
 %%
-%% When you use Amazon SageMaker Studio or the Amazon SageMaker Python SDK,
-%% all experiments, trials, and trial components are automatically tracked,
-%% logged, and indexed. When you use the AWS SDK for Python (Boto), you must
-%% use the logging APIs provided by the SDK.
+%% When you use SageMaker Studio or the SageMaker Python SDK, all
+%% experiments, trials, and trial components are automatically tracked,
+%% logged, and indexed. When you use the Amazon Web Services SDK for Python
+%% (Boto), you must use the logging APIs provided by the SDK.
 %%
 %% You can add tags to a trial component and then use the `Search' API to
 %% search for the tags.
-%%
-%% `CreateTrialComponent' can only be invoked from within an Amazon SageMaker
-%% managed environment. This includes Amazon SageMaker training jobs,
-%% processing jobs, transform jobs, and Amazon SageMaker notebooks. A call to
-%% `CreateTrialComponent' from outside one of these environments results in
-%% an error.
 create_trial_component(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_trial_component(Client, Input, []).
@@ -1463,12 +1522,14 @@ create_user_profile(Client, Input, Options)
 %% @doc Use this operation to create a workforce.
 %%
 %% This operation will return an error if a workforce already exists in the
-%% AWS Region that you specify. You can only create one workforce in each AWS
-%% Region per AWS account.
+%% Amazon Web Services Region that you specify. You can only create one
+%% workforce in each Amazon Web Services Region per Amazon Web Services
+%% account.
 %%
-%% If you want to create a new workforce in an AWS Region where a workforce
-%% already exists, use the API operation to delete the existing workforce and
-%% then use `CreateWorkforce' to create a new workforce.
+%% If you want to create a new workforce in an Amazon Web Services Region
+%% where a workforce already exists, use the API operation to delete the
+%% existing workforce and then use `CreateWorkforce' to create a new
+%% workforce.
 %%
 %% To create a private workforce using Amazon Cognito, you must specify a
 %% Cognito user pool in `CognitoConfig'. You can also create an Amazon
@@ -1627,7 +1688,7 @@ delete_endpoint_config(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteEndpointConfig">>, Input, Options).
 
-%% @doc Deletes an Amazon SageMaker experiment.
+%% @doc Deletes an SageMaker experiment.
 %%
 %% All trials associated with the experiment must be deleted first. Use the
 %% `ListTrials' API to get a list of the trials associated with the
@@ -1645,9 +1706,9 @@ delete_experiment(Client, Input, Options)
 %% Data cannot be accessed from the `OnlineStore' immediately after
 %% `DeleteFeatureGroup' is called.
 %%
-%% Data written into the `OfflineStore' will not be deleted. The AWS Glue
-%% database and tables that are automatically created for your `OfflineStore'
-%% are not deleted.
+%% Data written into the `OfflineStore' will not be deleted. The Amazon Web
+%% Services Glue database and tables that are automatically created for your
+%% `OfflineStore' are not deleted.
 delete_feature_group(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_feature_group(Client, Input, []).
@@ -1727,9 +1788,10 @@ delete_model_explainability_job_definition(Client, Input, Options)
 
 %% @doc Deletes a model package.
 %%
-%% A model package is used to create Amazon SageMaker models or list on AWS
-%% Marketplace. Buyers can subscribe to model packages listed on AWS
-%% Marketplace to create models in Amazon SageMaker.
+%% A model package is used to create Amazon SageMaker models or list on
+%% Amazon Web Services Marketplace. Buyers can subscribe to model packages
+%% listed on Amazon Web Services Marketplace to create models in Amazon
+%% SageMaker.
 delete_model_package(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_model_package(Client, Input, []).
@@ -1795,7 +1857,11 @@ delete_notebook_instance_lifecycle_config(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteNotebookInstanceLifecycleConfig">>, Input, Options).
 
-%% @doc Deletes a pipeline if there are no in-progress executions.
+%% @doc Deletes a pipeline if there are no running instances of the pipeline.
+%%
+%% To delete a pipeline, you must stop all running instances of the pipeline
+%% using the `StopPipelineExecution' API. When you delete a pipeline, all
+%% instances of the pipeline are deleted.
 delete_pipeline(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_pipeline(Client, Input, []).
@@ -1811,6 +1877,18 @@ delete_project(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteProject">>, Input, Options).
 
+%% @doc Deletes the Studio Lifecycle Configuration.
+%%
+%% In order to delete the Lifecycle Configuration, there must be no running
+%% apps using the Lifecycle Configuration. You must also remove the Lifecycle
+%% Configuration from UserSettings in all Domains and UserProfiles.
+delete_studio_lifecycle_config(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_studio_lifecycle_config(Client, Input, []).
+delete_studio_lifecycle_config(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteStudioLifecycleConfig">>, Input, Options).
+
 %% @doc Deletes the specified tags from an Amazon SageMaker resource.
 %%
 %% To list a resource's tags, use the `ListTags' API.
@@ -1818,6 +1896,11 @@ delete_project(Client, Input, Options)
 %% When you call this API to delete tags from a hyperparameter tuning job,
 %% the deleted tags are not removed from training jobs that the
 %% hyperparameter tuning job launched before you called this API.
+%%
+%% When you call this API to delete tags from a SageMaker Studio Domain or
+%% User Profile, the deleted tags are not removed from Apps that the
+%% SageMaker Studio Domain or User Profile launched before you called this
+%% API.
 delete_tags(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_tags(Client, Input, []).
@@ -1861,9 +1944,9 @@ delete_user_profile(Client, Input, Options)
 
 %% @doc Use this operation to delete a workforce.
 %%
-%% If you want to create a new workforce in an AWS Region where a workforce
-%% already exists, use this operation to delete the existing workforce and
-%% then use to create a new workforce.
+%% If you want to create a new workforce in an Amazon Web Services Region
+%% where a workforce already exists, use this operation to delete the
+%% existing workforce and then use to create a new workforce.
 %%
 %% If a private workforce contains one or more work teams, you must use the
 %% operation to delete all work teams before you delete the workforce. If you
@@ -1937,7 +2020,7 @@ describe_artifact(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeArtifact">>, Input, Options).
 
-%% @doc Returns information about an Amazon SageMaker job.
+%% @doc Returns information about an Amazon SageMaker AutoML job.
 describe_auto_ml_job(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_auto_ml_job(Client, Input, []).
@@ -2123,10 +2206,11 @@ describe_model_explainability_job_definition(Client, Input, Options)
     request(Client, <<"DescribeModelExplainabilityJobDefinition">>, Input, Options).
 
 %% @doc Returns a description of the specified model package, which is used
-%% to create Amazon SageMaker models or list them on AWS Marketplace.
+%% to create SageMaker models or list them on Amazon Web Services
+%% Marketplace.
 %%
-%% To create models in Amazon SageMaker, buyers can subscribe to model
-%% packages listed on AWS Marketplace.
+%% To create models in SageMaker, buyers can subscribe to model packages
+%% listed on Amazon Web Services Marketplace.
 describe_model_package(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_model_package(Client, Input, []).
@@ -2217,10 +2301,18 @@ describe_project(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeProject">>, Input, Options).
 
+%% @doc Describes the Studio Lifecycle Configuration.
+describe_studio_lifecycle_config(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_studio_lifecycle_config(Client, Input, []).
+describe_studio_lifecycle_config(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeStudioLifecycleConfig">>, Input, Options).
+
 %% @doc Gets information about a work team provided by a vendor.
 %%
-%% It returns details about the subscription with a vendor in the AWS
-%% Marketplace.
+%% It returns details about the subscription with a vendor in the Amazon Web
+%% Services Marketplace.
 describe_subscribed_workteam(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_subscribed_workteam(Client, Input, []).
@@ -2351,8 +2443,8 @@ get_device_fleet_report(Client, Input, Options)
 %% @doc Gets a resource policy that manages access for a model group.
 %%
 %% For information about resource policies, see Identity-based policies and
-%% resource-based policies in the AWS Identity and Access Management User
-%% Guide..
+%% resource-based policies in the Amazon Web Services Identity and Access
+%% Management User Guide..
 get_model_package_group_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_model_package_group_policy(Client, Input, []).
@@ -2442,7 +2534,7 @@ list_auto_ml_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAutoMLJobs">>, Input, Options).
 
-%% @doc List the Candidates created for the job.
+%% @doc List the candidates created for the job.
 list_candidates_for_auto_ml_job(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_candidates_for_auto_ml_job(Client, Input, []).
@@ -2634,7 +2726,7 @@ list_model_explainability_job_definitions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListModelExplainabilityJobDefinitions">>, Input, Options).
 
-%% @doc Gets a list of the model groups in your AWS account.
+%% @doc Gets a list of the model groups in your Amazon Web Services account.
 list_model_package_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_model_package_groups(Client, Input, []).
@@ -2693,7 +2785,7 @@ list_notebook_instance_lifecycle_configs(Client, Input, Options)
     request(Client, <<"ListNotebookInstanceLifecycleConfigs">>, Input, Options).
 
 %% @doc Returns a list of the Amazon SageMaker notebook instances in the
-%% requester's account in an AWS Region.
+%% requester's account in an Amazon Web Services Region.
 list_notebook_instances(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_notebook_instances(Client, Input, []).
@@ -2741,7 +2833,7 @@ list_processing_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListProcessingJobs">>, Input, Options).
 
-%% @doc Gets a list of the projects in an AWS account.
+%% @doc Gets a list of the projects in an Amazon Web Services account.
 list_projects(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_projects(Client, Input, []).
@@ -2749,8 +2841,17 @@ list_projects(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListProjects">>, Input, Options).
 
-%% @doc Gets a list of the work teams that you are subscribed to in the AWS
-%% Marketplace.
+%% @doc Lists the Studio Lifecycle Configurations in your Amazon Web Services
+%% Account.
+list_studio_lifecycle_configs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_studio_lifecycle_configs(Client, Input, []).
+list_studio_lifecycle_configs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListStudioLifecycleConfigs">>, Input, Options).
+
+%% @doc Gets a list of the work teams that you are subscribed to in the
+%% Amazon Web Services Marketplace.
 %%
 %% The list may be empty if no work team satisfies the filter specified in
 %% the `NameContains' parameter.
@@ -2774,16 +2875,20 @@ list_tags(Client, Input, Options)
 %% When `StatusEquals' and `MaxResults' are set at the same time, the
 %% `MaxResults' number of training jobs are first retrieved ignoring the
 %% `StatusEquals' parameter and then they are filtered by the `StatusEquals'
-%% parameter, which is returned as a response. For example, if
-%% `ListTrainingJobs' is invoked with the following parameters:
+%% parameter, which is returned as a response.
+%%
+%% For example, if `ListTrainingJobs' is invoked with the following
+%% parameters:
 %%
 %% `{ ... MaxResults: 100, StatusEquals: InProgress ... }'
 %%
-%% Then, 100 trainings jobs with any status including those other than
-%% `InProgress' are selected first (sorted according the creation time, from
-%% the latest to the oldest) and those with status `InProgress' are returned.
+%% First, 100 trainings jobs with any status, including those other than
+%% `InProgress', are selected (sorted according to the creation time, from
+%% the most current to the oldest). Next, those with a status of `InProgress'
+%% are returned.
 %%
-%% You can quickly test the API using the following AWS CLI code.
+%% You can quickly test the API using the following Amazon Web Services CLI
+%% code.
 %%
 %% `aws sagemaker list-training-jobs --max-results 100 --status-equals
 %% InProgress'
@@ -2854,9 +2959,10 @@ list_user_profiles(Client, Input, Options)
     request(Client, <<"ListUserProfiles">>, Input, Options).
 
 %% @doc Use this operation to list all private and vendor workforces in an
-%% AWS Region.
+%% Amazon Web Services Region.
 %%
-%% Note that you can only have one private workforce per AWS Region.
+%% Note that you can only have one private workforce per Amazon Web Services
+%% Region.
 list_workforces(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_workforces(Client, Input, []).
@@ -2878,8 +2984,8 @@ list_workteams(Client, Input, Options)
 %% @doc Adds a resouce policy to control access to a model group.
 %%
 %% For information about resoure policies, see Identity-based policies and
-%% resource-based policies in the AWS Identity and Access Management User
-%% Guide..
+%% resource-based policies in the Amazon Web Services Identity and Access
+%% Management User Guide..
 put_model_package_group_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_model_package_group_policy(Client, Input, []).
@@ -2904,6 +3010,14 @@ render_ui_template(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RenderUiTemplate">>, Input, Options).
 
+%% @doc Retry the execution of the pipeline.
+retry_pipeline_execution(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    retry_pipeline_execution(Client, Input, []).
+retry_pipeline_execution(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RetryPipelineExecution">>, Input, Options).
+
 %% @doc Finds Amazon SageMaker resources that match a search query.
 %%
 %% Matching resources are returned as a list of `SearchRecord' objects in the
@@ -2918,6 +3032,32 @@ search(Client, Input)
 search(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"Search">>, Input, Options).
+
+%% @doc Notifies the pipeline that the execution of a callback step failed,
+%% along with a message describing why.
+%%
+%% When a callback step is run, the pipeline generates a callback token and
+%% includes the token in a message sent to Amazon Simple Queue Service
+%% (Amazon SQS).
+send_pipeline_execution_step_failure(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_pipeline_execution_step_failure(Client, Input, []).
+send_pipeline_execution_step_failure(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendPipelineExecutionStepFailure">>, Input, Options).
+
+%% @doc Notifies the pipeline that the execution of a callback step succeeded
+%% and provides a list of the step's output parameters.
+%%
+%% When a callback step is run, the pipeline generates a callback token and
+%% includes the token in a message sent to Amazon Simple Queue Service
+%% (Amazon SQS).
+send_pipeline_execution_step_success(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_pipeline_execution_step_success(Client, Input, []).
+send_pipeline_execution_step_success(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendPipelineExecutionStepSuccess">>, Input, Options).
 
 %% @doc Starts a previously stopped monitoring schedule.
 %%
@@ -3038,6 +3178,32 @@ stop_notebook_instance(Client, Input, Options)
     request(Client, <<"StopNotebookInstance">>, Input, Options).
 
 %% @doc Stops a pipeline execution.
+%%
+%% Callback Step
+%%
+%% A pipeline execution won't stop while a callback step is running. When you
+%% call `StopPipelineExecution' on a pipeline execution with a running
+%% callback step, SageMaker Pipelines sends an additional Amazon SQS message
+%% to the specified SQS queue. The body of the SQS message contains a
+%% "Status" field which is set to "Stopping".
+%%
+%% You should add logic to your Amazon SQS message consumer to take any
+%% needed action (for example, resource cleanup) upon receipt of the message
+%% followed by a call to `SendPipelineExecutionStepSuccess' or
+%% `SendPipelineExecutionStepFailure'.
+%%
+%% Only when SageMaker Pipelines receives one of these calls will it stop the
+%% pipeline execution.
+%%
+%% Lambda Step
+%%
+%% A pipeline execution can't be stopped while a lambda step is running
+%% because the Lambda function invoked by the lambda step can't be stopped.
+%% If you attempt to stop the execution while the Lambda function is running,
+%% the pipeline waits for the Lambda function to finish or until the timeout
+%% is hit, whichever occurs first, and then stops. If the Lambda function
+%% finishes, the pipeline execution status is `Stopped'. If the timeout is
+%% hit the pipeline execution status is `Failed'.
 stop_pipeline_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_pipeline_execution(Client, Input, []).
@@ -3260,6 +3426,21 @@ update_pipeline_execution(Client, Input)
 update_pipeline_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdatePipelineExecution">>, Input, Options).
+
+%% @doc Updates a machine learning (ML) project that is created from a
+%% template that sets up an ML pipeline from training to deploying an
+%% approved model.
+%%
+%% You must not update a project that is in use. If you update the
+%% `ServiceCatalogProvisioningUpdateDetails' of a project that is active or
+%% being created, or updated, you may lose resources already created by the
+%% project.
+update_project(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_project(Client, Input, []).
+update_project(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateProject">>, Input, Options).
 
 %% @doc Update a model training job to request a new Debugger profiling
 %% configuration.

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -1,16 +1,14 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Amazon Augmented AI is in preview release and is subject to change.
+%% @doc Amazon Augmented AI (Amazon A2I) adds the benefit of human judgment
+%% to any machine learning application.
 %%
-%% We do not recommend using this product in production environments.
-%%
-%% Amazon Augmented AI (Amazon A2I) adds the benefit of human judgment to any
-%% machine learning application. When an AI application can't evaluate data
-%% with a high degree of confidence, human reviewers can take over. This
-%% human review is called a human review workflow. To create and start a
-%% human review workflow, you need three resources: a worker task template, a
-%% flow definition, and a human loop.
+%% When an AI application can't evaluate data with a high degree of
+%% confidence, human reviewers can take over. This human review is called a
+%% human review workflow. To create and start a human review workflow, you
+%% need three resources: a worker task template, a flow definition, and a
+%% human loop.
 %%
 %% For information about these resources and prerequisites for using Amazon
 %% A2I, see Get Started with Amazon Augmented AI in the Amazon SageMaker
@@ -57,6 +55,9 @@
 %%====================================================================
 
 %% @doc Deletes the specified human loop for a flow definition.
+%%
+%% If the human loop was deleted, this operation will return a
+%% `ResourceNotFoundException'.
 delete_human_loop(Client, HumanLoopName, Input) ->
     delete_human_loop(Client, HumanLoopName, Input, []).
 delete_human_loop(Client, HumanLoopName, Input0, Options0) ->
@@ -80,6 +81,9 @@ delete_human_loop(Client, HumanLoopName, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Returns information about the specified human loop.
+%%
+%% If the human loop was deleted, this operation will return a
+%% `ResourceNotFoundException' error.
 describe_human_loop(Client, HumanLoopName)
   when is_map(Client) ->
     describe_human_loop(Client, HumanLoopName, #{}, #{}).
@@ -219,6 +223,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_sagemaker_edge.erl
+++ b/src/aws_sagemaker_edge.erl
@@ -98,6 +98,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_sagemaker_featurestore_runtime.erl
+++ b/src/aws_sagemaker_featurestore_runtime.erl
@@ -21,7 +21,9 @@
 %% </li> </ul>
 -module(aws_sagemaker_featurestore_runtime).
 
--export([delete_record/3,
+-export([batch_get_record/2,
+         batch_get_record/3,
+         delete_record/3,
          delete_record/4,
          get_record/3,
          get_record/5,
@@ -34,6 +36,29 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Retrieves a batch of `Records' from a `FeatureGroup'.
+batch_get_record(Client, Input) ->
+    batch_get_record(Client, Input, []).
+batch_get_record(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/BatchGetRecord"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes a `Record' from a `FeatureGroup'.
 %%
@@ -159,6 +184,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -277,6 +277,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -894,6 +894,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_secrets_manager.erl
+++ b/src/aws_secrets_manager.erl
@@ -1,69 +1,73 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Secrets Manager API Reference
+%% @doc Amazon Web Services Secrets Manager
 %%
-%% AWS Secrets Manager provides a service to enable you to store, manage, and
-%% retrieve, secrets.
+%% Amazon Web Services Secrets Manager provides a service to enable you to
+%% store, manage, and retrieve, secrets.
 %%
 %% This guide provides descriptions of the Secrets Manager API. For more
-%% information about using this service, see the AWS Secrets Manager User
-%% Guide.
+%% information about using this service, see the Amazon Web Services Secrets
+%% Manager User Guide.
 %%
 %% API Version
 %%
 %% This version of the Secrets Manager API Reference documents the Secrets
 %% Manager API version 2017-10-17.
 %%
-%% As an alternative to using the API, you can use one of the AWS SDKs, which
-%% consist of libraries and sample code for various programming languages and
-%% platforms such as Java, Ruby, .NET, iOS, and Android. The SDKs provide a
-%% convenient way to create programmatic access to AWS Secrets Manager. For
-%% example, the SDKs provide cryptographically signing requests, managing
-%% errors, and retrying requests automatically. For more information about
-%% the AWS SDKs, including downloading and installing them, see Tools for
-%% Amazon Web Services.
+%% As an alternative to using the API, you can use one of the Amazon Web
+%% Services SDKs, which consist of libraries and sample code for various
+%% programming languages and platforms such as Java, Ruby, .NET, iOS, and
+%% Android. The SDKs provide a convenient way to create programmatic access
+%% to Amazon Web Services Secrets Manager. For example, the SDKs provide
+%% cryptographically signing requests, managing errors, and retrying requests
+%% automatically. For more information about the Amazon Web Services SDKs,
+%% including downloading and installing them, see Tools for Amazon Web
+%% Services.
 %%
-%% We recommend you use the AWS SDKs to make programmatic API calls to
-%% Secrets Manager. However, you also can use the Secrets Manager HTTP Query
-%% API to make direct calls to the Secrets Manager web service. To learn more
-%% about the Secrets Manager HTTP Query API, see Making Query Requests in the
-%% AWS Secrets Manager User Guide.
+%% We recommend you use the Amazon Web Services SDKs to make programmatic API
+%% calls to Secrets Manager. However, you also can use the Secrets Manager
+%% HTTP Query API to make direct calls to the Secrets Manager web service. To
+%% learn more about the Secrets Manager HTTP Query API, see Making Query
+%% Requests in the Amazon Web Services Secrets Manager User Guide.
 %%
 %% Secrets Manager API supports GET and POST requests for all actions, and
 %% doesn't require you to use GET for some actions and POST for others.
 %% However, GET requests are subject to the limitation size of a URL.
 %% Therefore, for operations that require larger sizes, use a POST request.
 %%
-%% Support and Feedback for AWS Secrets Manager
+%% Support and Feedback for Amazon Web Services Secrets Manager
 %%
 %% We welcome your feedback. Send your comments to
 %% awssecretsmanager-feedback@amazon.com, or post your feedback and questions
-%% in the AWS Secrets Manager Discussion Forum. For more information about
-%% the AWS Discussion Forums, see Forums Help.
+%% in the Amazon Web Services Secrets Manager Discussion Forum. For more
+%% information about the Amazon Web Services Discussion Forums, see Forums
+%% Help.
 %%
 %% How examples are presented
 %%
-%% The JSON that AWS Secrets Manager expects as your request parameters and
-%% the service returns as a response to HTTP query requests contain single,
-%% long strings without line breaks or white space formatting. The JSON shown
-%% in the examples displays the code formatted with both line breaks and
-%% white space to improve readability. When example input parameters can also
-%% cause long strings extending beyond the screen, you can insert line breaks
-%% to enhance readability. You should always submit the input as a single
-%% JSON text string.
+%% The JSON that Amazon Web Services Secrets Manager expects as your request
+%% parameters and the service returns as a response to HTTP query requests
+%% contain single, long strings without line breaks or white space
+%% formatting. The JSON shown in the examples displays the code formatted
+%% with both line breaks and white space to improve readability. When example
+%% input parameters can also cause long strings extending beyond the screen,
+%% you can insert line breaks to enhance readability. You should always
+%% submit the input as a single JSON text string.
 %%
 %% Logging API Requests
 %%
-%% AWS Secrets Manager supports AWS CloudTrail, a service that records AWS
-%% API calls for your AWS account and delivers log files to an Amazon S3
-%% bucket. By using information that's collected by AWS CloudTrail, you can
-%% determine the requests successfully made to Secrets Manager, who made the
-%% request, when it was made, and so on. For more about AWS Secrets Manager
-%% and support for AWS CloudTrail, see Logging AWS Secrets Manager Events
-%% with AWS CloudTrail in the AWS Secrets Manager User Guide. To learn more
-%% about CloudTrail, including enabling it and find your log files, see the
-%% AWS CloudTrail User Guide.
+%% Amazon Web Services Secrets Manager supports Amazon Web Services
+%% CloudTrail, a service that records Amazon Web Services API calls for your
+%% Amazon Web Services account and delivers log files to an Amazon S3 bucket.
+%% By using information that's collected by Amazon Web Services CloudTrail,
+%% you can determine the requests successfully made to Secrets Manager, who
+%% made the request, when it was made, and so on. For more about Amazon Web
+%% Services Secrets Manager and support for Amazon Web Services CloudTrail,
+%% see Logging Amazon Web Services Secrets Manager Events with Amazon Web
+%% Services CloudTrail in the Amazon Web Services Secrets Manager User Guide.
+%% To learn more about CloudTrail, including enabling it and find your log
+%% files, see the Amazon Web Services CloudTrail User Guide.
 -module(aws_secrets_manager).
 
 -export([cancel_rotate_secret/2,
@@ -192,25 +196,27 @@ cancel_rotate_secret(Client, Input, Options)
 %%
 %% If you call an operation to encrypt or decrypt the `SecretString' or
 %% `SecretBinary' for a secret in the same account as the calling user and
-%% that secret doesn't specify a AWS KMS encryption key, Secrets Manager uses
-%% the account's default AWS managed customer master key (CMK) with the alias
-%% `aws/secretsmanager'. If this key doesn't already exist in your account
-%% then Secrets Manager creates it for you automatically. All users and roles
-%% in the same AWS account automatically have access to use the default CMK.
-%% Note that if an Secrets Manager API call results in AWS creating the
-%% account's AWS-managed CMK, it can result in a one-time significant delay
-%% in returning the result.
+%% that secret doesn't specify a Amazon Web Services KMS encryption key,
+%% Secrets Manager uses the account's default Amazon Web Services managed
+%% customer master key (CMK) with the alias `aws/secretsmanager'. If this key
+%% doesn't already exist in your account then Secrets Manager creates it for
+%% you automatically. All users and roles in the same Amazon Web Services
+%% account automatically have access to use the default CMK. Note that if an
+%% Secrets Manager API call results in Amazon Web Services creating the
+%% account's Amazon Web Services-managed CMK, it can result in a one-time
+%% significant delay in returning the result.
 %%
-%% If the secret resides in a different AWS account from the credentials
-%% calling an API that requires encryption or decryption of the secret value
-%% then you must create and use a custom AWS KMS CMK because you can't access
-%% the default CMK for the account using credentials from a different AWS
-%% account. Store the ARN of the CMK in the secret when you create the secret
-%% or when you update it by including it in the `KMSKeyId'. If you call an
-%% API that must encrypt or decrypt `SecretString' or `SecretBinary' using
-%% credentials from a different account then the AWS KMS key policy must
-%% grant cross-account access to that other account's user or role for both
-%% the kms:GenerateDataKey and kms:Decrypt operations.
+%% If the secret resides in a different Amazon Web Services account from the
+%% credentials calling an API that requires encryption or decryption of the
+%% secret value then you must create and use a custom Amazon Web Services KMS
+%% CMK because you can't access the default CMK for the account using
+%% credentials from a different Amazon Web Services account. Store the ARN of
+%% the CMK in the secret when you create the secret or when you update it by
+%% including it in the `KMSKeyId'. If you call an API that must encrypt or
+%% decrypt `SecretString' or `SecretBinary' using credentials from a
+%% different account then the Amazon Web Services KMS key policy must grant
+%% cross-account access to that other account's user or role for both the
+%% kms:GenerateDataKey and kms:Decrypt operations.
 %%
 %% Minimum permissions
 %%
@@ -219,12 +225,14 @@ cancel_rotate_secret(Client, Input, Options)
 %% <ul> <li> secretsmanager:CreateSecret
 %%
 %% </li> <li> kms:GenerateDataKey - needed only if you use a customer-managed
-%% AWS KMS key to encrypt the secret. You do not need this permission to use
-%% the account default AWS managed CMK for Secrets Manager.
+%% Amazon Web Services KMS key to encrypt the secret. You do not need this
+%% permission to use the account default Amazon Web Services managed CMK for
+%% Secrets Manager.
 %%
-%% </li> <li> kms:Decrypt - needed only if you use a customer-managed AWS KMS
-%% key to encrypt the secret. You do not need this permission to use the
-%% account default AWS managed CMK for Secrets Manager.
+%% </li> <li> kms:Decrypt - needed only if you use a customer-managed Amazon
+%% Web Services KMS key to encrypt the secret. You do not need this
+%% permission to use the account default Amazon Web Services managed CMK for
+%% Secrets Manager.
 %%
 %% </li> <li> secretsmanager:TagResource - needed only if you include the
 %% `Tags' parameter.
@@ -350,8 +358,8 @@ delete_secret(Client, Input, Options)
 %% </li> <li> To retrieve the encrypted secret information in a version of
 %% the secret, use `GetSecretValue'.
 %%
-%% </li> <li> To list all of the secrets in the AWS account, use
-%% `ListSecrets'.
+%% </li> <li> To list all of the secrets in the Amazon Web Services account,
+%% use `ListSecrets'.
 %%
 %% </li> </ul>
 describe_secret(Client, Input)
@@ -424,9 +432,10 @@ get_resource_policy(Client, Input, Options)
 %%
 %% <ul> <li> secretsmanager:GetSecretValue
 %%
-%% </li> <li> kms:Decrypt - required only if you use a customer-managed AWS
-%% KMS key to encrypt the secret. You do not need this permission to use the
-%% account's default AWS managed CMK for Secrets Manager.
+%% </li> <li> kms:Decrypt - required only if you use a customer-managed
+%% Amazon Web Services KMS key to encrypt the secret. You do not need this
+%% permission to use the account's default Amazon Web Services managed CMK
+%% for Secrets Manager.
 %%
 %% </li> </ul> Related operations
 %%
@@ -476,7 +485,7 @@ list_secret_version_ids(Client, Input, Options)
     request(Client, <<"ListSecretVersionIds">>, Input, Options).
 
 %% @doc Lists all of the secrets that are stored by Secrets Manager in the
-%% AWS account.
+%% Amazon Web Services account.
 %%
 %% To list the versions currently stored for a specific secret, use
 %% `ListSecretVersionIds'. The encrypted fields `SecretString' and
@@ -518,9 +527,9 @@ list_secrets(Client, Input, Options)
 %% combination of both identity-based and resource-based policies. The
 %% affected users and roles receive the permissions that are permitted by all
 %% of the relevant policies. For more information, see Using Resource-Based
-%% Policies for AWS Secrets Manager. For the complete description of the AWS
-%% policy syntax and grammar, see IAM JSON Policy Reference in the IAM User
-%% Guide.
+%% Policies for Amazon Web Services Secrets Manager. For the complete
+%% description of the Amazon Web Services policy syntax and grammar, see IAM
+%% JSON Policy Reference in the IAM User Guide.
 %%
 %% Minimum permissions
 %%
@@ -554,9 +563,13 @@ put_resource_policy(Client, Input, Options)
 %% `SecretBinary' value. You can also specify the staging labels that are
 %% initially attached to the new version.
 %%
-%% The Secrets Manager console uses only the `SecretString' field. To add
-%% binary data to a secret with the `SecretBinary' field you must use the AWS
-%% CLI or one of the AWS SDKs.
+%% We recommend you avoid calling `PutSecretValue' at a sustained rate of
+%% more than once every 10 minutes. When you update the secret value, Secrets
+%% Manager creates a new version of the secret. Secrets Manager removes
+%% outdated versions when there are more than 100, but it does not remove
+%% versions created less than 24 hours ago. If you call `PutSecretValue' more
+%% than once every 10 minutes, you create more versions than Secrets Manager
+%% removes, and you will reach the quota for secret versions.
 %%
 %% <ul> <li> If this operation creates the first version for the secret then
 %% Secrets Manager automatically attaches the staging label `AWSCURRENT' to
@@ -580,25 +593,28 @@ put_resource_policy(Client, Input, Options)
 %%
 %% </li> </ul> If you call an operation to encrypt or decrypt the
 %% `SecretString' or `SecretBinary' for a secret in the same account as the
-%% calling user and that secret doesn't specify a AWS KMS encryption key,
-%% Secrets Manager uses the account's default AWS managed customer master key
-%% (CMK) with the alias `aws/secretsmanager'. If this key doesn't already
-%% exist in your account then Secrets Manager creates it for you
-%% automatically. All users and roles in the same AWS account automatically
-%% have access to use the default CMK. Note that if an Secrets Manager API
-%% call results in AWS creating the account's AWS-managed CMK, it can result
-%% in a one-time significant delay in returning the result.
+%% calling user and that secret doesn't specify a Amazon Web Services KMS
+%% encryption key, Secrets Manager uses the account's default Amazon Web
+%% Services managed customer master key (CMK) with the alias
+%% `aws/secretsmanager'. If this key doesn't already exist in your account
+%% then Secrets Manager creates it for you automatically. All users and roles
+%% in the same Amazon Web Services account automatically have access to use
+%% the default CMK. Note that if an Secrets Manager API call results in
+%% Amazon Web Services creating the account's Amazon Web Services-managed
+%% CMK, it can result in a one-time significant delay in returning the
+%% result.
 %%
-%% If the secret resides in a different AWS account from the credentials
-%% calling an API that requires encryption or decryption of the secret value
-%% then you must create and use a custom AWS KMS CMK because you can't access
-%% the default CMK for the account using credentials from a different AWS
-%% account. Store the ARN of the CMK in the secret when you create the secret
-%% or when you update it by including it in the `KMSKeyId'. If you call an
-%% API that must encrypt or decrypt `SecretString' or `SecretBinary' using
-%% credentials from a different account then the AWS KMS key policy must
-%% grant cross-account access to that other account's user or role for both
-%% the kms:GenerateDataKey and kms:Decrypt operations.
+%% If the secret resides in a different Amazon Web Services account from the
+%% credentials calling an API that requires encryption or decryption of the
+%% secret value then you must create and use a custom Amazon Web Services KMS
+%% CMK because you can't access the default CMK for the account using
+%% credentials from a different Amazon Web Services account. Store the ARN of
+%% the CMK in the secret when you create the secret or when you update it by
+%% including it in the `KMSKeyId'. If you call an API that must encrypt or
+%% decrypt `SecretString' or `SecretBinary' using credentials from a
+%% different account then the Amazon Web Services KMS key policy must grant
+%% cross-account access to that other account's user or role for both the
+%% kms:GenerateDataKey and kms:Decrypt operations.
 %%
 %% Minimum permissions
 %%
@@ -607,8 +623,9 @@ put_resource_policy(Client, Input, Options)
 %% <ul> <li> secretsmanager:PutSecretValue
 %%
 %% </li> <li> kms:GenerateDataKey - needed only if you use a customer-managed
-%% AWS KMS key to encrypt the secret. You do not need this permission to use
-%% the account's default AWS managed CMK for Secrets Manager.
+%% Amazon Web Services KMS key to encrypt the secret. You do not need this
+%% permission to use the account's default Amazon Web Services managed CMK
+%% for Secrets Manager.
 %%
 %% </li> </ul> Related operations
 %%
@@ -680,15 +697,16 @@ restore_secret(Client, Input, Options)
 %% completes, the protected service and its clients all use the new version
 %% of the secret.
 %%
-%% This required configuration information includes the ARN of an AWS Lambda
-%% function and the time between scheduled rotations. The Lambda rotation
-%% function creates a new version of the secret and creates or updates the
-%% credentials on the protected service to match. After testing the new
-%% credentials, the function marks the new secret with the staging label
-%% `AWSCURRENT' so that your clients all immediately begin to use the new
-%% version. For more information about rotating secrets and how to configure
-%% a Lambda function to rotate the secrets for your protected service, see
-%% Rotating Secrets in AWS Secrets Manager in the AWS Secrets Manager User
+%% This required configuration information includes the ARN of an Amazon Web
+%% Services Lambda function and optionally, the time between scheduled
+%% rotations. The Lambda rotation function creates a new version of the
+%% secret and creates or updates the credentials on the protected service to
+%% match. After testing the new credentials, the function marks the new
+%% secret with the staging label `AWSCURRENT' so that your clients all
+%% immediately begin to use the new version. For more information about
+%% rotating secrets and how to configure a Lambda function to rotate the
+%% secrets for your protected service, see Rotating Secrets in Amazon Web
+%% Services Secrets Manager in the Amazon Web Services Secrets Manager User
 %% Guide.
 %%
 %% Secrets Manager schedules the next rotation when the previous one
@@ -769,9 +787,9 @@ stop_replication_to_replica(Client, Input, Options)
 %% </li> <li> Tag keys and values are case sensitive.
 %%
 %% </li> <li> Do not use the `aws:' prefix in your tag names or values
-%% because AWS reserves it for AWS use. You can't edit or delete tag names or
-%% values with this prefix. Tags with this prefix do not count against your
-%% tags per secret limit.
+%% because Amazon Web Services reserves it for Amazon Web Services use. You
+%% can't edit or delete tag names or values with this prefix. Tags with this
+%% prefix do not count against your tags per secret limit.
 %%
 %% </li> <li> If you use your tagging schema across multiple services and
 %% resources, remember other services might have restrictions on allowed
@@ -840,16 +858,25 @@ untag_resource(Client, Input, Options)
 
 %% @doc Modifies many of the details of the specified secret.
 %%
-%% If you include a `ClientRequestToken' and either `SecretString' or
-%% `SecretBinary' then it also creates a new version attached to the secret.
+%% To change the secret value, you can also use `PutSecretValue'.
 %%
-%% To modify the rotation configuration of a secret, use `RotateSecret'
+%% To change the rotation configuration of a secret, use `RotateSecret'
 %% instead.
+%%
+%% We recommend you avoid calling `UpdateSecret' at a sustained rate of more
+%% than once every 10 minutes. When you call `UpdateSecret' to update the
+%% secret value, Secrets Manager creates a new version of the secret. Secrets
+%% Manager removes outdated versions when there are more than 100, but it
+%% does not remove versions created less than 24 hours ago. If you update the
+%% secret value more than once every 10 minutes, you create more versions
+%% than Secrets Manager removes, and you will reach the quota for secret
+%% versions.
 %%
 %% The Secrets Manager console uses only the `SecretString' parameter and
 %% therefore limits you to encrypting and storing only a text string. To
 %% encrypt and store binary data as part of the version of a secret, you must
-%% use either the AWS CLI or one of the AWS SDKs.
+%% use either the Amazon Web Services CLI or one of the Amazon Web Services
+%% SDKs.
 %%
 %% <ul> <li> If a version with a `VersionId' with the same value as the
 %% `ClientRequestToken' parameter already exists, the operation results in an
@@ -862,25 +889,28 @@ untag_resource(Client, Input, Options)
 %%
 %% </li> </ul> If you call an operation to encrypt or decrypt the
 %% `SecretString' or `SecretBinary' for a secret in the same account as the
-%% calling user and that secret doesn't specify a AWS KMS encryption key,
-%% Secrets Manager uses the account's default AWS managed customer master key
-%% (CMK) with the alias `aws/secretsmanager'. If this key doesn't already
-%% exist in your account then Secrets Manager creates it for you
-%% automatically. All users and roles in the same AWS account automatically
-%% have access to use the default CMK. Note that if an Secrets Manager API
-%% call results in AWS creating the account's AWS-managed CMK, it can result
-%% in a one-time significant delay in returning the result.
+%% calling user and that secret doesn't specify a Amazon Web Services KMS
+%% encryption key, Secrets Manager uses the account's default Amazon Web
+%% Services managed customer master key (CMK) with the alias
+%% `aws/secretsmanager'. If this key doesn't already exist in your account
+%% then Secrets Manager creates it for you automatically. All users and roles
+%% in the same Amazon Web Services account automatically have access to use
+%% the default CMK. Note that if an Secrets Manager API call results in
+%% Amazon Web Services creating the account's Amazon Web Services-managed
+%% CMK, it can result in a one-time significant delay in returning the
+%% result.
 %%
-%% If the secret resides in a different AWS account from the credentials
-%% calling an API that requires encryption or decryption of the secret value
-%% then you must create and use a custom AWS KMS CMK because you can't access
-%% the default CMK for the account using credentials from a different AWS
-%% account. Store the ARN of the CMK in the secret when you create the secret
-%% or when you update it by including it in the `KMSKeyId'. If you call an
-%% API that must encrypt or decrypt `SecretString' or `SecretBinary' using
-%% credentials from a different account then the AWS KMS key policy must
-%% grant cross-account access to that other account's user or role for both
-%% the kms:GenerateDataKey and kms:Decrypt operations.
+%% If the secret resides in a different Amazon Web Services account from the
+%% credentials calling an API that requires encryption or decryption of the
+%% secret value then you must create and use a custom Amazon Web Services KMS
+%% CMK because you can't access the default CMK for the account using
+%% credentials from a different Amazon Web Services account. Store the ARN of
+%% the CMK in the secret when you create the secret or when you update it by
+%% including it in the `KMSKeyId'. If you call an API that must encrypt or
+%% decrypt `SecretString' or `SecretBinary' using credentials from a
+%% different account then the Amazon Web Services KMS key policy must grant
+%% cross-account access to that other account's user or role for both the
+%% kms:GenerateDataKey and kms:Decrypt operations.
 %%
 %% Minimum permissions
 %%
@@ -888,13 +918,14 @@ untag_resource(Client, Input, Options)
 %%
 %% <ul> <li> secretsmanager:UpdateSecret
 %%
-%% </li> <li> kms:GenerateDataKey - needed only if you use a custom AWS KMS
-%% key to encrypt the secret. You do not need this permission to use the
-%% account's AWS managed CMK for Secrets Manager.
+%% </li> <li> kms:GenerateDataKey - needed only if you use a custom Amazon
+%% Web Services KMS key to encrypt the secret. You do not need this
+%% permission to use the account's Amazon Web Services managed CMK for
+%% Secrets Manager.
 %%
-%% </li> <li> kms:Decrypt - needed only if you use a custom AWS KMS key to
-%% encrypt the secret. You do not need this permission to use the account's
-%% AWS managed CMK for Secrets Manager.
+%% </li> <li> kms:Decrypt - needed only if you use a custom Amazon Web
+%% Services KMS key to encrypt the secret. You do not need this permission to
+%% use the account's Amazon Web Services managed CMK for Secrets Manager.
 %%
 %% </li> </ul> Related operations
 %%
@@ -923,7 +954,8 @@ update_secret(Client, Input, Options)
 %% version of a secret at a time. If a staging label to be added is already
 %% attached to another version, then it is moved--removed from the other
 %% version first and then attached to this one. For more information about
-%% staging labels, see Staging Labels in the AWS Secrets Manager User Guide.
+%% staging labels, see Staging Labels in the Amazon Web Services Secrets
+%% Manager User Guide.
 %%
 %% The staging labels that you specify in the `VersionStage' parameter are
 %% added to the existing list of staging labels--they don't replace it.

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -2,42 +2,42 @@
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
 %% @doc Security Hub provides you with a comprehensive view of the security
-%% state of your AWS environment and resources.
+%% state of your Amazon Web Services environment and resources.
 %%
 %% It also provides you with the readiness status of your environment based
 %% on controls from supported security standards. Security Hub collects
-%% security data from AWS accounts, services, and integrated third-party
-%% products and helps you analyze security trends in your environment to
-%% identify the highest priority security issues. For more information about
-%% Security Hub, see the AWS Security Hub User Guide .
+%% security data from Amazon Web Services accounts, services, and integrated
+%% third-party products and helps you analyze security trends in your
+%% environment to identify the highest priority security issues. For more
+%% information about Security Hub, see the Security HubUser Guide .
 %%
 %% When you use operations in the Security Hub API, the requests are executed
-%% only in the AWS Region that is currently active or in the specific AWS
-%% Region that you specify in your request. Any configuration or settings
-%% change that results from the operation is applied only to that Region. To
-%% make the same change in other Regions, execute the same command for each
-%% Region to apply the change to.
+%% only in the Amazon Web Services Region that is currently active or in the
+%% specific Amazon Web Services Region that you specify in your request. Any
+%% configuration or settings change that results from the operation is
+%% applied only to that Region. To make the same change in other Regions,
+%% execute the same command for each Region to apply the change to.
 %%
-%% For example, if your Region is set to `us-west-2', when you use `
-%% `CreateMembers' ' to add a member account to Security Hub, the association
-%% of the member account with the master account is created only in the
-%% `us-west-2' Region. Security Hub must be enabled for the member account in
-%% the same Region that the invitation was sent from.
+%% For example, if your Region is set to `us-west-2', when you use
+%% `CreateMembers' to add a member account to Security Hub, the association
+%% of the member account with the administrator account is created only in
+%% the `us-west-2' Region. Security Hub must be enabled for the member
+%% account in the same Region that the invitation was sent from.
 %%
 %% The following throttling limits apply to using Security Hub API
 %% operations.
 %%
-%% <ul> <li> ` `BatchEnableStandards' ' - `RateLimit' of 1 request per
-%% second, `BurstLimit' of 1 request per second.
+%% <ul> <li> `BatchEnableStandards' - `RateLimit' of 1 request per second,
+%% `BurstLimit' of 1 request per second.
 %%
-%% </li> <li> ` `GetFindings' ' - `RateLimit' of 3 requests per second.
+%% </li> <li> `GetFindings' - `RateLimit' of 3 requests per second.
 %% `BurstLimit' of 6 requests per second.
 %%
-%% </li> <li> ` `UpdateFindings' ' - `RateLimit' of 1 request per second.
+%% </li> <li> `UpdateFindings' - `RateLimit' of 1 request per second.
 %% `BurstLimit' of 5 requests per second.
 %%
-%% </li> <li> ` `UpdateStandardsControl' ' - `RateLimit' of 1 request per
-%% second, `BurstLimit' of 5 requests per second.
+%% </li> <li> `UpdateStandardsControl' - `RateLimit' of 1 request per second,
+%% `BurstLimit' of 5 requests per second.
 %%
 %% </li> <li> All other operations - `RateLimit' of 10 requests per second.
 %% `BurstLimit' of 30 requests per second.
@@ -45,7 +45,9 @@
 %% </li> </ul>
 -module(aws_securityhub).
 
--export([accept_invitation/2,
+-export([accept_administrator_invitation/2,
+         accept_administrator_invitation/3,
+         accept_invitation/2,
          accept_invitation/3,
          batch_disable_standards/2,
          batch_disable_standards/3,
@@ -57,6 +59,8 @@
          batch_update_findings/3,
          create_action_target/2,
          create_action_target/3,
+         create_finding_aggregator/2,
+         create_finding_aggregator/3,
          create_insight/2,
          create_insight/3,
          create_members/2,
@@ -65,6 +69,8 @@
          decline_invitations/3,
          delete_action_target/3,
          delete_action_target/4,
+         delete_finding_aggregator/3,
+         delete_finding_aggregator/4,
          delete_insight/3,
          delete_insight/4,
          delete_invitations/2,
@@ -94,6 +100,8 @@
          disable_organization_admin_account/3,
          disable_security_hub/2,
          disable_security_hub/3,
+         disassociate_from_administrator_account/2,
+         disassociate_from_administrator_account/3,
          disassociate_from_master_account/2,
          disassociate_from_master_account/3,
          disassociate_members/2,
@@ -104,8 +112,14 @@
          enable_organization_admin_account/3,
          enable_security_hub/2,
          enable_security_hub/3,
+         get_administrator_account/1,
+         get_administrator_account/3,
+         get_administrator_account/4,
          get_enabled_standards/2,
          get_enabled_standards/3,
+         get_finding_aggregator/2,
+         get_finding_aggregator/4,
+         get_finding_aggregator/5,
          get_findings/2,
          get_findings/3,
          get_insight_results/2,
@@ -126,6 +140,9 @@
          list_enabled_products_for_import/1,
          list_enabled_products_for_import/3,
          list_enabled_products_for_import/4,
+         list_finding_aggregators/1,
+         list_finding_aggregators/3,
+         list_finding_aggregators/4,
          list_invitations/1,
          list_invitations/3,
          list_invitations/4,
@@ -144,6 +161,8 @@
          untag_resource/4,
          update_action_target/3,
          update_action_target/4,
+         update_finding_aggregator/2,
+         update_finding_aggregator/3,
          update_findings/2,
          update_findings/3,
          update_insight/3,
@@ -162,13 +181,56 @@
 %%====================================================================
 
 %% @doc Accepts the invitation to be a member account and be monitored by the
-%% Security Hub master account that the invitation was sent from.
+%% Security Hub administrator account that the invitation was sent from.
 %%
 %% This operation is only used by member accounts that are not added through
 %% Organizations.
 %%
 %% When the member account accepts the invitation, permission is granted to
-%% the master account to view findings generated in the member account.
+%% the administrator account to view findings generated in the member
+%% account.
+accept_administrator_invitation(Client, Input) ->
+    accept_administrator_invitation(Client, Input, []).
+accept_administrator_invitation(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/administrator"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This method is deprecated.
+%%
+%% Instead, use `AcceptAdministratorInvitation'.
+%%
+%% The Security Hub console continues to use `AcceptInvitation'. It will
+%% eventually change to use `AcceptAdministratorInvitation'. Any IAM policies
+%% that specifically control access to this function must continue to use
+%% `AcceptInvitation'. You should also add `AcceptAdministratorInvitation' to
+%% your policies to ensure that the correct permissions are in place after
+%% the console begins to use `AcceptAdministratorInvitation'.
+%%
+%% Accepts the invitation to be a member account and be monitored by the
+%% Security Hub administrator account that the invitation was sent from.
+%%
+%% This operation is only used by member accounts that are not added through
+%% Organizations.
+%%
+%% When the member account accepts the invitation, permission is granted to
+%% the administrator account to view findings generated in the member
+%% account.
 accept_invitation(Client, Input) ->
     accept_invitation(Client, Input, []).
 accept_invitation(Client, Input0, Options0) ->
@@ -194,8 +256,8 @@ accept_invitation(Client, Input0, Options0) ->
 %% @doc Disables the standards specified by the provided
 %% `StandardsSubscriptionArns'.
 %%
-%% For more information, see Security Standards section of the AWS Security
-%% Hub User Guide.
+%% For more information, see Security Standards section of the Security Hub
+%% User Guide.
 batch_disable_standards(Client, Input) ->
     batch_disable_standards(Client, Input, []).
 batch_disable_standards(Client, Input0, Options0) ->
@@ -220,11 +282,10 @@ batch_disable_standards(Client, Input0, Options0) ->
 
 %% @doc Enables the standards specified by the provided `StandardsArn'.
 %%
-%% To obtain the ARN for a standard, use the ` `DescribeStandards' '
-%% operation.
+%% To obtain the ARN for a standard, use the `DescribeStandards' operation.
 %%
-%% For more information, see the Security Standards section of the AWS
-%% Security Hub User Guide.
+%% For more information, see the Security Standards section of the Security
+%% Hub User Guide.
 batch_enable_standards(Client, Input) ->
     batch_enable_standards(Client, Input, []).
 batch_enable_standards(Client, Input0, Options0) ->
@@ -247,8 +308,8 @@ batch_enable_standards(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Imports security findings generated from an integrated third-party
-%% product into Security Hub.
+%% @doc Imports security findings generated from an integrated product into
+%% Security Hub.
 %%
 %% This action is requested by the integrated product to import its findings
 %% into Security Hub.
@@ -268,10 +329,8 @@ batch_enable_standards(Client, Input0, Options0) ->
 %%
 %% </li> <li> `Workflow'
 %%
-%% </li> </ul> `BatchImportFindings' can be used to update the following
-%% finding fields and objects only if they have not been updated using
-%% `BatchUpdateFindings'. After they are updated using `BatchUpdateFindings',
-%% these fields cannot be updated using `BatchImportFindings'.
+%% </li> </ul> Finding providers also should not use `BatchImportFindings' to
+%% update the following attributes.
 %%
 %% <ul> <li> `Confidence'
 %%
@@ -283,7 +342,8 @@ batch_enable_standards(Client, Input0, Options0) ->
 %%
 %% </li> <li> `Types'
 %%
-%% </li> </ul>
+%% </li> </ul> Instead, finding providers use `FindingProviderFields' to
+%% provide values for these attributes.
 batch_import_findings(Client, Input) ->
     batch_import_findings(Client, Input, []).
 batch_import_findings(Client, Input0, Options0) ->
@@ -309,15 +369,15 @@ batch_import_findings(Client, Input0, Options0) ->
 %% @doc Used by Security Hub customers to update information about their
 %% investigation into a finding.
 %%
-%% Requested by master accounts or member accounts. Master accounts can
-%% update findings for their account and their member accounts. Member
-%% accounts can update findings for their account.
+%% Requested by administrator accounts or member accounts. Administrator
+%% accounts can update findings for their account and their member accounts.
+%% Member accounts can update findings for their account.
 %%
 %% Updates from `BatchUpdateFindings' do not affect the value of `UpdatedAt'
 %% for a finding.
 %%
-%% Master and member accounts can use `BatchUpdateFindings' to update the
-%% following finding fields and objects.
+%% Administrator and member accounts can use `BatchUpdateFindings' to update
+%% the following finding fields and objects.
 %%
 %% <ul> <li> `Confidence'
 %%
@@ -340,7 +400,7 @@ batch_import_findings(Client, Input0, Options0) ->
 %% </li> </ul> You can configure IAM policies to restrict access to fields
 %% and field values. For example, you might not want member accounts to be
 %% able to suppress findings or change the finding severity. See Configuring
-%% access to BatchUpdateFindings in the AWS Security Hub User Guide.
+%% access to BatchUpdateFindings in the Security Hub User Guide.
 batch_update_findings(Client, Input) ->
     batch_update_findings(Client, Input, []).
 batch_update_findings(Client, Input0, Options0) ->
@@ -389,6 +449,34 @@ create_action_target(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Used to enable finding aggregation.
+%%
+%% Must be called from the aggregation Region.
+%%
+%% For more details about cross-Region replication, see Configuring finding
+%% aggregation in the Security Hub User Guide.
+create_finding_aggregator(Client, Input) ->
+    create_finding_aggregator(Client, Input, []).
+create_finding_aggregator(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/findingAggregator/create"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates a custom insight in Security Hub.
 %%
 %% An insight is a consolidation of findings that relate to a security issue
@@ -418,44 +506,52 @@ create_insight(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Creates a member association in Security Hub between the specified
-%% accounts and the account used to make the request, which is the master
-%% account.
+%% accounts and the account used to make the request, which is the
+%% administrator account.
 %%
-%% If you are integrated with Organizations, then the master account is the
-%% Security Hub administrator account that is designated by the organization
-%% management account.
+%% If you are integrated with Organizations, then the administrator account
+%% is designated by the organization management account.
 %%
 %% `CreateMembers' is always used to add accounts that are not organization
 %% members.
 %%
-%% For accounts that are part of an organization, `CreateMembers' is only
+%% For accounts that are managed using Organizations, `CreateMembers' is only
 %% used in the following cases:
 %%
-%% <ul> <li> Security Hub is not configured to automatically add new accounts
-%% in an organization.
+%% <ul> <li> Security Hub is not configured to automatically add new
+%% organization accounts.
 %%
 %% </li> <li> The account was disassociated or deleted in Security Hub.
 %%
 %% </li> </ul> This action can only be used by an account that has Security
-%% Hub enabled. To enable Security Hub, you can use the ` `EnableSecurityHub'
-%% ' operation.
+%% Hub enabled. To enable Security Hub, you can use the `EnableSecurityHub'
+%% operation.
 %%
 %% For accounts that are not organization members, you create the account
 %% association and then send an invitation to the member account. To send the
-%% invitation, you use the ` `InviteMembers' ' operation. If the account
-%% owner accepts the invitation, the account becomes a member account in
-%% Security Hub.
+%% invitation, you use the `InviteMembers' operation. If the account owner
+%% accepts the invitation, the account becomes a member account in Security
+%% Hub.
 %%
-%% Accounts that are part of an organization do not receive an invitation.
-%% They automatically become a member account in Security Hub.
+%% Accounts that are managed using Organizations do not receive an
+%% invitation. They automatically become a member account in Security Hub.
 %%
-%% A permissions policy is added that permits the master account to view the
-%% findings generated in the member account. When Security Hub is enabled in
-%% a member account, findings are sent to both the member and master
-%% accounts.
+%% <ul> <li> If the organization account does not have Security Hub enabled,
+%% then Security Hub and the default standards are automatically enabled.
+%% Note that Security Hub cannot be enabled automatically for the
+%% organization management account. The organization management account must
+%% enable Security Hub before the administrator account enables it as a
+%% member account.
 %%
-%% To remove the association between the master and member accounts, use the
-%% ` `DisassociateFromMasterAccount' ' or ` `DisassociateMembers' '
+%% </li> <li> For organization accounts that already have Security Hub
+%% enabled, Security Hub does not make any other changes to those accounts.
+%% It does not change their enabled standards or controls.
+%%
+%% </li> </ul> A permissions policy is added that permits the administrator
+%% account to view the findings generated in the member account.
+%%
+%% To remove the association between the administrator and member accounts,
+%% use the `DisassociateFromMasterAccount' or `DisassociateMembers'
 %% operation.
 create_members(Client, Input) ->
     create_members(Client, Input, []).
@@ -532,6 +628,35 @@ delete_action_target(Client, ActionTargetArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Deletes a finding aggregator.
+%%
+%% When you delete the finding aggregator, you stop finding aggregation.
+%%
+%% When you stop finding aggregation, findings that were already aggregated
+%% to the aggregation Region are still visible from the aggregation Region.
+%% New findings and finding updates are not aggregated.
+delete_finding_aggregator(Client, FindingAggregatorArn, Input) ->
+    delete_finding_aggregator(Client, FindingAggregatorArn, Input, []).
+delete_finding_aggregator(Client, FindingAggregatorArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/findingAggregator/delete/", aws_util:encode_multi_segment_uri(FindingAggregatorArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes the insight specified by the `InsightArn'.
 delete_insight(Client, InsightArn, Input) ->
     delete_insight(Client, InsightArn, Input, []).
@@ -555,8 +680,8 @@ delete_insight(Client, InsightArn, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes invitations received by the AWS account to become a member
-%% account.
+%% @doc Deletes invitations received by the Amazon Web Services account to
+%% become a member account.
 %%
 %% This operation is only used by accounts that are not part of an
 %% organization. Organization accounts do not receive invitations.
@@ -839,13 +964,13 @@ disable_organization_admin_account(Client, Input0, Options0) ->
 %% To disable Security Hub in all Regions, you must submit one request per
 %% Region where you have enabled Security Hub.
 %%
-%% When you disable Security Hub for a master account, it doesn't disable
-%% Security Hub for any associated member accounts.
+%% When you disable Security Hub for an administrator account, it doesn't
+%% disable Security Hub for any associated member accounts.
 %%
 %% When you disable Security Hub, your existing findings and insights and any
 %% Security Hub configuration settings are deleted after 90 days and cannot
 %% be recovered. Any standards that were enabled are disabled, and your
-%% master and member account associations are removed.
+%% administrator and member account associations are removed.
 %%
 %% If you want to save your existing findings, you must export them before
 %% you disable Security Hub.
@@ -872,11 +997,51 @@ disable_security_hub(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Disassociates the current Security Hub member account from the
-%% associated master account.
+%% associated administrator account.
 %%
 %% This operation is only used by accounts that are not part of an
-%% organization. For organization accounts, only the master account (the
-%% designated Security Hub administrator) can disassociate a member account.
+%% organization. For organization accounts, only the administrator account
+%% can disassociate a member account.
+disassociate_from_administrator_account(Client, Input) ->
+    disassociate_from_administrator_account(Client, Input, []).
+disassociate_from_administrator_account(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/administrator/disassociate"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc This method is deprecated.
+%%
+%% Instead, use `DisassociateFromAdministratorAccount'.
+%%
+%% The Security Hub console continues to use `DisassociateFromMasterAccount'.
+%% It will eventually change to use `DisassociateFromAdministratorAccount'.
+%% Any IAM policies that specifically control access to this function must
+%% continue to use `DisassociateFromMasterAccount'. You should also add
+%% `DisassociateFromAdministratorAccount' to your policies to ensure that the
+%% correct permissions are in place after the console begins to use
+%% `DisassociateFromAdministratorAccount'.
+%%
+%% Disassociates the current Security Hub member account from the associated
+%% administrator account.
+%%
+%% This operation is only used by accounts that are not part of an
+%% organization. For organization accounts, only the administrator account
+%% can disassociate a member account.
 disassociate_from_master_account(Client, Input) ->
     disassociate_from_master_account(Client, Input, []).
 disassociate_from_master_account(Client, Input0, Options0) ->
@@ -900,10 +1065,10 @@ disassociate_from_master_account(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Disassociates the specified member accounts from the associated
-%% master account.
+%% administrator account.
 %%
-%% Can be used to disassociate both accounts that are in an organization and
-%% accounts that were invited manually.
+%% Can be used to disassociate both accounts that are managed using
+%% Organizations and accounts that were invited manually.
 disassociate_members(Client, Input) ->
     disassociate_members(Client, Input, []).
 disassociate_members(Client, Input0, Options0) ->
@@ -990,9 +1155,9 @@ enable_organization_admin_account(Client, Input0, Options0) ->
 %% When you use the `EnableSecurityHub' operation to enable Security Hub, you
 %% also automatically enable the following standards.
 %%
-%% <ul> <li> CIS AWS Foundations
+%% <ul> <li> CIS Amazon Web Services Foundations
 %%
-%% </li> <li> AWS Foundational Security Best Practices
+%% </li> <li> Amazon Web Services Foundational Security Best Practices
 %%
 %% </li> </ul> You do not enable the Payment Card Industry Data Security
 %% Standard (PCI DSS) standard.
@@ -1000,12 +1165,11 @@ enable_organization_admin_account(Client, Input0, Options0) ->
 %% To not enable the automatically enabled standards, set
 %% `EnableDefaultStandards' to `false'.
 %%
-%% After you enable Security Hub, to enable a standard, use the `
-%% `BatchEnableStandards' ' operation. To disable a standard, use the `
-%% `BatchDisableStandards' ' operation.
+%% After you enable Security Hub, to enable a standard, use the
+%% `BatchEnableStandards' operation. To disable a standard, use the
+%% `BatchDisableStandards' operation.
 %%
-%% To learn more, see Setting Up AWS Security Hub in the AWS Security Hub
-%% User Guide.
+%% To learn more, see the setup information in the Security Hub User Guide.
 enable_security_hub(Client, Input) ->
     enable_security_hub(Client, Input, []).
 enable_security_hub(Client, Input0, Options0) ->
@@ -1027,6 +1191,33 @@ enable_security_hub(Client, Input0, Options0) ->
     Input = Input2,
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Provides the details for the Security Hub administrator account for
+%% the current member account.
+%%
+%% Can be used by both member accounts that are managed using Organizations
+%% and accounts that were invited manually.
+get_administrator_account(Client)
+  when is_map(Client) ->
+    get_administrator_account(Client, #{}, #{}).
+
+get_administrator_account(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_administrator_account(Client, QueryMap, HeadersMap, []).
+
+get_administrator_account(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/administrator"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns a list of the standards that are currently enabled.
 get_enabled_standards(Client, Input) ->
@@ -1051,7 +1242,34 @@ get_enabled_standards(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Returns the current finding aggregation configuration.
+get_finding_aggregator(Client, FindingAggregatorArn)
+  when is_map(Client) ->
+    get_finding_aggregator(Client, FindingAggregatorArn, #{}, #{}).
+
+get_finding_aggregator(Client, FindingAggregatorArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_finding_aggregator(Client, FindingAggregatorArn, QueryMap, HeadersMap, []).
+
+get_finding_aggregator(Client, FindingAggregatorArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/findingAggregator/get/", aws_util:encode_multi_segment_uri(FindingAggregatorArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Returns a list of findings that match the specified criteria.
+%%
+%% If finding aggregation is enabled, then when you call `GetFindings' from
+%% the aggregation Region, the results include all of the matching findings
+%% from both the aggregation Region and the linked Regions.
 get_findings(Client, Input) ->
     get_findings(Client, Input, []).
 get_findings(Client, Input0, Options0) ->
@@ -1146,11 +1364,22 @@ get_invitations_count(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Provides the details for the Security Hub master account for the
+%% @doc This method is deprecated.
+%%
+%% Instead, use `GetAdministratorAccount'.
+%%
+%% The Security Hub console continues to use `GetMasterAccount'. It will
+%% eventually change to use `GetAdministratorAccount'. Any IAM policies that
+%% specifically control access to this function must continue to use
+%% `GetMasterAccount'. You should also add `GetAdministratorAccount' to your
+%% policies to ensure that the correct permissions are in place after the
+%% console begins to use `GetAdministratorAccount'.
+%%
+%% Provides the details for the Security Hub administrator account for the
 %% current member account.
 %%
-%% Can be used by both member accounts that are in an organization and
-%% accounts that were invited manually.
+%% Can be used by both member accounts that are managed using Organizations
+%% and accounts that were invited manually.
 get_master_account(Client)
   when is_map(Client) ->
     get_master_account(Client, #{}, #{}).
@@ -1176,12 +1405,12 @@ get_master_account(Client, QueryMap, HeadersMap, Options0)
 %% @doc Returns the details for the Security Hub member accounts for the
 %% specified account IDs.
 %%
-%% A master account can be either a delegated Security Hub administrator
-%% account for an organization or a master account that enabled Security Hub
-%% manually.
+%% An administrator account can be either the delegated Security Hub
+%% administrator account for an organization or an administrator account that
+%% enabled Security Hub manually.
 %%
-%% The results include both member accounts that are in an organization and
-%% accounts that were invited manually.
+%% The results include both member accounts that are managed using
+%% Organizations and accounts that were invited manually.
 get_members(Client, Input) ->
     get_members(Client, Input, []).
 get_members(Client, Input0, Options0) ->
@@ -1204,17 +1433,18 @@ get_members(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Invites other AWS accounts to become member accounts for the Security
-%% Hub master account that the invitation is sent from.
+%% @doc Invites other Amazon Web Services accounts to become member accounts
+%% for the Security Hub administrator account that the invitation is sent
+%% from.
 %%
 %% This operation is only used to invite accounts that do not belong to an
 %% organization. Organization accounts do not receive invitations.
 %%
 %% Before you can use this action to invite a member, you must first use the
-%% ` `CreateMembers' ' action to create the member account in Security Hub.
+%% `CreateMembers' action to create the member account in Security Hub.
 %%
 %% When the account owner enables Security Hub and accepts the invitation to
-%% become a member account, the master account can view the findings
+%% become a member account, the administrator account can view the findings
 %% generated from the member account.
 invite_members(Client, Input) ->
     invite_members(Client, Input, []).
@@ -1267,11 +1497,43 @@ list_enabled_products_for_import(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Lists all Security Hub membership invitations that were sent to the
-%% current AWS account.
+%% @doc If finding aggregation is enabled, then `ListFindingAggregators'
+%% returns the ARN of the finding aggregator.
 %%
-%% This operation is only used by accounts that do not belong to an
-%% organization. Organization accounts do not receive invitations.
+%% You can run this operation from any Region.
+list_finding_aggregators(Client)
+  when is_map(Client) ->
+    list_finding_aggregators(Client, #{}, #{}).
+
+list_finding_aggregators(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_finding_aggregators(Client, QueryMap, HeadersMap, []).
+
+list_finding_aggregators(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/findingAggregator/list"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"MaxResults">>, maps:get(<<"MaxResults">>, QueryMap, undefined)},
+        {<<"NextToken">>, maps:get(<<"NextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all Security Hub membership invitations that were sent to the
+%% current Amazon Web Services account.
+%%
+%% This operation is only used by accounts that are managed by invitation.
+%% Accounts that are managed using the integration with Organizations do not
+%% receive invitations.
 list_invitations(Client)
   when is_map(Client) ->
     list_invitations(Client, #{}, #{}).
@@ -1300,7 +1562,7 @@ list_invitations(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists details about all member accounts for the current Security Hub
-%% master account.
+%% administrator account.
 %%
 %% The results include both member accounts that belong to an organization
 %% and member accounts that were invited manually.
@@ -1439,6 +1701,36 @@ update_action_target(Client, ActionTargetArn, Input) ->
 update_action_target(Client, ActionTargetArn, Input0, Options0) ->
     Method = patch,
     Path = ["/actionTargets/", aws_util:encode_multi_segment_uri(ActionTargetArn), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the finding aggregation configuration.
+%%
+%% Used to update the Region linking mode and the list of included or
+%% excluded Regions. You cannot use `UpdateFindingAggregator' to change the
+%% aggregation Region.
+%%
+%% You must run `UpdateFindingAggregator' from the current aggregation
+%% Region.
+update_finding_aggregator(Client, Input) ->
+    update_finding_aggregator(Client, Input, []).
+update_finding_aggregator(Client, Input0, Options0) ->
+    Method = patch,
+    Path = ["/findingAggregator/update"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1616,6 +1908,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -476,6 +476,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -1,8 +1,9 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Service Catalog AppRegistry enables organizations to understand
-%% the application context of their AWS resources.
+%% @doc Amazon Web Services Service Catalog AppRegistry enables organizations
+%% to understand the application context of their Amazon Web Services
+%% resources.
 %%
 %% AppRegistry provides a repository of your applications, their resources,
 %% and the application metadata that you use within your enterprise.
@@ -27,6 +28,9 @@
          get_application/2,
          get_application/4,
          get_application/5,
+         get_associated_resource/4,
+         get_associated_resource/6,
+         get_associated_resource/7,
          get_attribute_group/2,
          get_attribute_group/4,
          get_attribute_group/5,
@@ -300,6 +304,29 @@ get_application(Client, Application, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc Gets the resource associated with the application.
+get_associated_resource(Client, Application, Resource, ResourceType)
+  when is_map(Client) ->
+    get_associated_resource(Client, Application, Resource, ResourceType, #{}, #{}).
+
+get_associated_resource(Client, Application, Resource, ResourceType, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_associated_resource(Client, Application, Resource, ResourceType, QueryMap, HeadersMap, []).
+
+get_associated_resource(Client, Application, Resource, ResourceType, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/applications/", aws_util:encode_uri(Application), "/resources/", aws_util:encode_uri(ResourceType), "/", aws_util:encode_uri(Resource), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Retrieves an attribute group, either by its name or its ID.
 %%
 %% The attribute group can be specified either by its unique ID or by its
@@ -470,12 +497,12 @@ list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Syncs the resource with what is currently recorded in App registry.
+%% @doc Syncs the resource with current AppRegistry records.
 %%
-%% Specifically, the resource’s App registry system tags are synced with its
-%% associated application. The resource is removed if it is not associated
-%% with the application. The caller must have permissions to read and update
-%% the resource.
+%% Specifically, the resource’s AppRegistry system tags sync with its
+%% associated application. We remove the resource's AppRegistry system tags
+%% if it does not associate with the application. The caller must have
+%% permissions to read and update the resource.
 sync_resource(Client, Resource, ResourceType, Input) ->
     sync_resource(Client, Resource, ResourceType, Input, []).
 sync_resource(Client, Resource, ResourceType, Input0, Options0) ->
@@ -634,6 +661,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_servicediscovery.erl
+++ b/src/aws_servicediscovery.erl
@@ -1,15 +1,17 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Cloud Map lets you configure public DNS, private DNS, or HTTP
+%% @doc Cloud Map
+%%
+%% With Cloud Map, you can configure public DNS, private DNS, or HTTP
 %% namespaces that your microservice applications run in.
 %%
-%% When an instance of the service becomes available, you can call the AWS
-%% Cloud Map API to register the instance with AWS Cloud Map. For public or
-%% private DNS namespaces, AWS Cloud Map automatically creates DNS records
-%% and an optional health check. Clients that submit public or private DNS
-%% queries, or HTTP requests, for the service receive an answer that contains
-%% up to eight healthy records.
+%% When an instance becomes available, you can call the Cloud Map API to
+%% register the instance with Cloud Map. For public or private DNS
+%% namespaces, Cloud Map automatically creates DNS records and an optional
+%% health check. Clients that submit public or private DNS queries, or HTTP
+%% requests, for the service receive an answer that contains up to eight
+%% healthy records.
 -module(aws_servicediscovery).
 
 -export([create_http_namespace/2,
@@ -54,8 +56,14 @@
          tag_resource/3,
          untag_resource/2,
          untag_resource/3,
+         update_http_namespace/2,
+         update_http_namespace/3,
          update_instance_custom_health_status/2,
          update_instance_custom_health_status/3,
+         update_private_dns_namespace/2,
+         update_private_dns_namespace/3,
+         update_public_dns_namespace/2,
+         update_public_dns_namespace/3,
          update_service/2,
          update_service/3]).
 
@@ -67,13 +75,12 @@
 
 %% @doc Creates an HTTP namespace.
 %%
-%% Service instances that you register using an HTTP namespace can be
-%% discovered using a `DiscoverInstances' request but can't be discovered
-%% using DNS.
+%% Service instances registered using an HTTP namespace can be discovered
+%% using a `DiscoverInstances' request but can't be discovered using DNS.
 %%
 %% For the current quota on the number of namespaces that you can create
-%% using the same AWS account, see AWS Cloud Map quotas in the AWS Cloud Map
-%% Developer Guide.
+%% using the same account, see Cloud Map quotas in the Cloud Map Developer
+%% Guide.
 create_http_namespace(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_http_namespace(Client, Input, []).
@@ -81,15 +88,16 @@ create_http_namespace(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateHttpNamespace">>, Input, Options).
 
-%% @doc Creates a private namespace based on DNS, which will be visible only
+%% @doc Creates a private namespace based on DNS, which is visible only
 %% inside a specified Amazon VPC.
 %%
 %% The namespace defines your service naming scheme. For example, if you name
 %% your namespace `example.com' and name your service `backend', the
-%% resulting DNS name for the service will be `backend.example.com'. For the
-%% current quota on the number of namespaces that you can create using the
-%% same AWS account, see AWS Cloud Map Limits in the AWS Cloud Map Developer
-%% Guide.
+%% resulting DNS name for the service is `backend.example.com'. Service
+%% instances that are registered using a private DNS namespace can be
+%% discovered using either a `DiscoverInstances' request or using DNS. For
+%% the current quota on the number of namespaces that you can create using
+%% the same account, see Cloud Map quotas in the Cloud Map Developer Guide.
 create_private_dns_namespace(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_private_dns_namespace(Client, Input, []).
@@ -97,15 +105,16 @@ create_private_dns_namespace(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreatePrivateDnsNamespace">>, Input, Options).
 
-%% @doc Creates a public namespace based on DNS, which will be visible on the
+%% @doc Creates a public namespace based on DNS, which is visible on the
 %% internet.
 %%
 %% The namespace defines your service naming scheme. For example, if you name
 %% your namespace `example.com' and name your service `backend', the
-%% resulting DNS name for the service will be `backend.example.com'. For the
-%% current quota on the number of namespaces that you can create using the
-%% same AWS account, see AWS Cloud Map Limits in the AWS Cloud Map Developer
-%% Guide.
+%% resulting DNS name for the service is `backend.example.com'. You can
+%% discover instances that were registered with a public DNS namespace by
+%% using either a `DiscoverInstances' request or using DNS. For the current
+%% quota on the number of namespaces that you can create using the same
+%% account, see Cloud Map quotas in the Cloud Map Developer Guide.
 create_public_dns_namespace(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_public_dns_namespace(Client, Input, []).
@@ -113,11 +122,12 @@ create_public_dns_namespace(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreatePublicDnsNamespace">>, Input, Options).
 
-%% @doc Creates a service, which defines the configuration for the following
-%% entities:
+%% @doc Creates a service.
+%%
+%% This action defines the configuration for the following entities:
 %%
 %% <ul> <li> For public and private DNS namespaces, one of the following
-%% combinations of DNS records in Amazon Route 53:
+%% combinations of DNS records in Amazon Route 53:
 %%
 %% <ul> <li> `A'
 %%
@@ -132,12 +142,12 @@ create_public_dns_namespace(Client, Input, Options)
 %% </li> </ul> </li> <li> Optionally, a health check
 %%
 %% </li> </ul> After you create the service, you can submit a
-%% RegisterInstance request, and AWS Cloud Map uses the values in the
+%% RegisterInstance request, and Cloud Map uses the values in the
 %% configuration to create the specified entities.
 %%
 %% For the current quota on the number of instances that you can register
-%% using the same namespace and using the same service, see AWS Cloud Map
-%% Limits in the AWS Cloud Map Developer Guide.
+%% using the same namespace and using the same service, see Cloud Map quotas
+%% in the Cloud Map Developer Guide.
 create_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_service(Client, Input, []).
@@ -166,8 +176,8 @@ delete_service(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteService">>, Input, Options).
 
-%% @doc Deletes the Amazon Route 53 DNS records and health check, if any,
-%% that AWS Cloud Map created for the specified instance.
+%% @doc Deletes the Amazon Route 53 DNS records and health check, if any,
+%% that Cloud Map created for the specified instance.
 deregister_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     deregister_instance(Client, Input, []).
@@ -198,7 +208,7 @@ get_instance(Client, Input, Options)
 %% @doc Gets the current health status (`Healthy', `Unhealthy', or `Unknown')
 %% of one or more instances that are associated with a specified service.
 %%
-%% There is a brief delay between when you register an instance and when the
+%% There's a brief delay between when you register an instance and when the
 %% health status for the instance is available.
 get_instances_health_status(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -245,7 +255,7 @@ list_instances(Client, Input, Options)
     request(Client, <<"ListInstances">>, Input, Options).
 
 %% @doc Lists summary information about the namespaces that were created by
-%% the current AWS account.
+%% the current account.
 list_namespaces(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_namespaces(Client, Input, []).
@@ -283,9 +293,9 @@ list_tags_for_resource(Client, Input, Options)
 %%
 %% When you submit a `RegisterInstance' request, the following occurs:
 %%
-%% <ul> <li> For each DNS record that you define in the service that is
+%% <ul> <li> For each DNS record that you define in the service that's
 %% specified by `ServiceId', a record is created or updated in the hosted
-%% zone that is associated with the corresponding namespace.
+%% zone that's associated with the corresponding namespace.
 %%
 %% </li> <li> If the service includes `HealthCheckConfig', a health check is
 %% created based on the settings in the health check configuration.
@@ -298,8 +308,8 @@ list_tags_for_resource(Client, Input, Options)
 %%
 %% For more information, see CreateService.
 %%
-%% When AWS Cloud Map receives a DNS query for the specified DNS name, it
-%% returns the applicable value:
+%% When Cloud Map receives a DNS query for the specified DNS name, it returns
+%% the applicable value:
 %%
 %% <ul> <li> If the health check is healthy: returns all the records
 %%
@@ -310,8 +320,8 @@ list_tags_for_resource(Client, Input, Options)
 %% the records
 %%
 %% </li> </ul> For the current quota on the number of instances that you can
-%% register using the same namespace and using the same service, see AWS
-%% Cloud Map Limits in the AWS Cloud Map Developer Guide.
+%% register using the same namespace and using the same service, see Cloud
+%% Map quotas in the Cloud Map Developer Guide.
 register_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_instance(Client, Input, []).
@@ -335,13 +345,21 @@ untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
 
+%% @doc Updates an HTTP namespace.
+update_http_namespace(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_http_namespace(Client, Input, []).
+update_http_namespace(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateHttpNamespace">>, Input, Options).
+
 %% @doc Submits a request to change the health status of a custom health
 %% check to healthy or unhealthy.
 %%
 %% You can use `UpdateInstanceCustomHealthStatus' to change the status only
 %% for custom health checks, which you define using `HealthCheckCustomConfig'
-%% when you create a service. You can't use it to change the status for
-%% Route 53 health checks, which you define using `HealthCheckConfig'.
+%% when you create a service. You can't use it to change the status for Route
+%% 53 health checks, which you define using `HealthCheckConfig'.
 %%
 %% For more information, see HealthCheckCustomConfig.
 update_instance_custom_health_status(Client, Input)
@@ -350,6 +368,22 @@ update_instance_custom_health_status(Client, Input)
 update_instance_custom_health_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateInstanceCustomHealthStatus">>, Input, Options).
+
+%% @doc Updates a private DNS namespace.
+update_private_dns_namespace(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_private_dns_namespace(Client, Input, []).
+update_private_dns_namespace(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdatePrivateDnsNamespace">>, Input, Options).
+
+%% @doc Updates a public DNS namespace.
+update_public_dns_namespace(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_public_dns_namespace(Client, Input, []).
+update_public_dns_namespace(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdatePublicDnsNamespace">>, Input, Options).
 
 %% @doc Submits a request to perform the following operations:
 %%
@@ -368,12 +402,12 @@ update_instance_custom_health_status(Client, Input, Options)
 %% deleted from the service.
 %%
 %% </li> <li> If you omit an existing `HealthCheckCustomConfig' configuration
-%% from an `UpdateService' request, the configuration is not deleted from the
+%% from an `UpdateService' request, the configuration isn't deleted from the
 %% service.
 %%
-%% </li> </ul> When you update settings for a service, AWS Cloud Map also
-%% updates the corresponding settings in all the records and health checks
-%% that were created by using the specified service.
+%% </li> </ul> When you update settings for a service, Cloud Map also updates
+%% the corresponding settings in all the records and health checks that were
+%% created by using the specified service.
 update_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_service(Client, Input, []).

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -3,33 +3,13 @@
 
 %% @doc Amazon SES API v2
 %%
-%% Welcome to the Amazon SES API v2 Reference.
+%% Amazon SES is an Amazon Web Services service that you can use to send
+%% email messages to your customers.
 %%
-%% This guide provides information about the Amazon SES API v2, including
-%% supported operations, data types, parameters, and schemas.
-%%
-%% Amazon SES is an AWS service that you can use to send email messages to
-%% your customers.
-%%
-%% If you're new to Amazon SES API v2, you might find it helpful to also
-%% review the Amazon Simple Email Service Developer Guide. The Amazon SES
-%% Developer Guide provides information and code samples that demonstrate how
-%% to use Amazon SES API v2 features programmatically.
-%%
-%% The Amazon SES API v2 is available in several AWS Regions and it provides
-%% an endpoint for each of these Regions. For a list of all the Regions and
-%% endpoints where the API is currently available, see AWS Service Endpoints
-%% in the Amazon Web Services General Reference. To learn more about AWS
-%% Regions, see Managing AWS Regions in the Amazon Web Services General
-%% Reference.
-%%
-%% In each Region, AWS maintains multiple Availability Zones. These
-%% Availability Zones are physically isolated from each other, but are united
-%% by private, low-latency, high-throughput, and highly redundant network
-%% connections. These Availability Zones enable us to provide very high
-%% levels of availability and redundancy, while also minimizing latency. To
-%% learn more about the number of Availability Zones that are available in
-%% each Region, see AWS Global Infrastructure.
+%% If you're new to Amazon SES API v2, you might find it helpful to review
+%% the Amazon Simple Email Service Developer Guide. The Amazon SES Developer
+%% Guide provides information and code samples that demonstrate how to use
+%% Amazon SES API v2 features programmatically.
 -module(aws_sesv2).
 
 -export([create_configuration_set/2,
@@ -370,9 +350,9 @@ create_custom_verification_email_template(Client, Input0, Options0) ->
 %% @doc Create a new pool of dedicated IP addresses.
 %%
 %% A pool can include one or more dedicated IP addresses that are associated
-%% with your AWS account. You can associate a pool with a configuration set.
-%% When you send an email that uses that configuration set, the message is
-%% sent from one of the addresses in the associated pool.
+%% with your Amazon Web Services account. You can associate a pool with a
+%% configuration set. When you send an email that uses that configuration
+%% set, the message is sent from one of the addresses in the associated pool.
 create_dedicated_ip_pool(Client, Input) ->
     create_dedicated_ip_pool(Client, Input, []).
 create_dedicated_ip_pool(Client, Input0, Options0) ->
@@ -451,8 +431,8 @@ create_deliverability_test_report(Client, Input0, Options0) ->
 %% Your Own DKIM (BYODKIM). To use BYODKIM, your call to the
 %% `CreateEmailIdentity' operation has to include the `DkimSigningAttributes'
 %% object. When you specify this object, you provide a selector (a component
-%% of the DNS record name that identifies the public key that you want to use
-%% for DKIM authentication) and a private key.
+%% of the DNS record name that identifies the public key to use for DKIM
+%% authentication) and a private key.
 %%
 %% When you verify a domain, this operation provides a set of DKIM tokens,
 %% which you can convert into CNAME tokens. You add these CNAME tokens to the
@@ -836,7 +816,7 @@ delete_suppressed_destination(Client, EmailAddress, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Obtain information about the email-sending status and capabilities of
-%% your Amazon SES account in the current AWS Region.
+%% your Amazon SES account in the current Amazon Web Services Region.
 get_account(Client)
   when is_map(Client) ->
     get_account(Client, #{}, #{}).
@@ -1051,8 +1031,8 @@ get_dedicated_ip(Client, Ip, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc List the dedicated IP addresses that are associated with your AWS
-%% account.
+%% @doc List the dedicated IP addresses that are associated with your Amazon
+%% Web Services account.
 get_dedicated_ips(Client)
   when is_map(Client) ->
     get_dedicated_ips(Client, #{}, #{}).
@@ -1091,8 +1071,9 @@ get_dedicated_ips(Client, QueryMap, HeadersMap, Options0)
 %%
 %% When you use the Deliverability dashboard, you pay a monthly subscription
 %% charge, in addition to any other fees that you accrue by using Amazon SES
-%% and other AWS services. For more information about the features and cost
-%% of a Deliverability dashboard subscription, see Amazon SES Pricing.
+%% and other Amazon Web Services services. For more information about the
+%% features and cost of a Deliverability dashboard subscription, see Amazon
+%% SES Pricing.
 get_deliverability_dashboard_options(Client)
   when is_map(Client) ->
     get_deliverability_dashboard_options(Client, #{}, #{}).
@@ -1419,7 +1400,7 @@ list_contacts(Client, ContactListName, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the existing custom verification email templates for your
-%% account in the current AWS Region.
+%% account in the current Amazon Web Services Region.
 %%
 %% For more information about custom verification email templates, see Using
 %% Custom Verification Email Templates in the Amazon SES Developer Guide.
@@ -1452,8 +1433,8 @@ list_custom_verification_email_templates(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc List all of the dedicated IP pools that exist in your AWS account in
-%% the current Region.
+%% @doc List all of the dedicated IP pools that exist in your Amazon Web
+%% Services account in the current Region.
 list_dedicated_ip_pools(Client)
   when is_map(Client) ->
     list_dedicated_ip_pools(Client, #{}, #{}).
@@ -1548,7 +1529,7 @@ list_domain_deliverability_campaigns(Client, SubscribedDomain, EndDate, StartDat
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns a list of all of the email identities that are associated
-%% with your AWS account.
+%% with your Amazon Web Services account.
 %%
 %% An identity can be either an email address or a domain. This operation
 %% returns identities that are verified as well as those that aren't. This
@@ -1582,7 +1563,7 @@ list_email_identities(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Lists the email templates present in your Amazon SES account in the
-%% current AWS Region.
+%% current Amazon Web Services Region.
 %%
 %% You can execute this operation no more than once per second.
 list_email_templates(Client)
@@ -1825,7 +1806,8 @@ put_configuration_set_delivery_options(Client, ConfigurationSetName, Input0, Opt
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Enable or disable collection of reputation metrics for emails that
-%% you send using a particular configuration set in a specific AWS Region.
+%% you send using a particular configuration set in a specific Amazon Web
+%% Services Region.
 put_configuration_set_reputation_options(Client, ConfigurationSetName, Input) ->
     put_configuration_set_reputation_options(Client, ConfigurationSetName, Input, []).
 put_configuration_set_reputation_options(Client, ConfigurationSetName, Input0, Options0) ->
@@ -1849,7 +1831,7 @@ put_configuration_set_reputation_options(Client, ConfigurationSetName, Input0, O
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Enable or disable email sending for messages that use a particular
-%% configuration set in a specific AWS Region.
+%% configuration set in a specific Amazon Web Services Region.
 put_configuration_set_sending_options(Client, ConfigurationSetName, Input) ->
     put_configuration_set_sending_options(Client, ConfigurationSetName, Input, []).
 put_configuration_set_sending_options(Client, ConfigurationSetName, Input0, Options0) ->
@@ -1923,7 +1905,7 @@ put_configuration_set_tracking_options(Client, ConfigurationSetName, Input0, Opt
 %% @doc Move a dedicated IP address to an existing dedicated IP pool.
 %%
 %% The dedicated IP address that you specify must already exist, and must be
-%% associated with your AWS account.
+%% associated with your Amazon Web Services account.
 %%
 %% The dedicated IP pool you specify must already exist. You can create a new
 %% pool by using the `CreateDedicatedIpPool' operation.
@@ -1981,8 +1963,9 @@ put_dedicated_ip_warmup_attributes(Client, Ip, Input0, Options0) ->
 %%
 %% When you use the Deliverability dashboard, you pay a monthly subscription
 %% charge, in addition to any other fees that you accrue by using Amazon SES
-%% and other AWS services. For more information about the features and cost
-%% of a Deliverability dashboard subscription, see Amazon SES Pricing.
+%% and other Amazon Web Services services. For more information about the
+%% features and cost of a Deliverability dashboard subscription, see Amazon
+%% SES Pricing.
 put_deliverability_dashboard_option(Client, Input) ->
     put_deliverability_dashboard_option(Client, Input, []).
 put_deliverability_dashboard_option(Client, Input0, Options0) ->
@@ -2058,6 +2041,8 @@ put_email_identity_dkim_attributes(Client, EmailIdentity, Input0, Options0) ->
 %%
 %% <ul> <li> Update the signing attributes for an identity that uses Bring
 %% Your Own DKIM (BYODKIM).
+%%
+%% </li> <li> Update the key length that should be used for Easy DKIM.
 %%
 %% </li> <li> Change from using no DKIM authentication to using Easy DKIM.
 %%
@@ -2197,7 +2182,8 @@ send_bulk_email(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Adds an email address to the list of identities for your Amazon SES
-%% account in the current AWS Region and attempts to verify it.
+%% account in the current Amazon Web Services Region and attempts to verify
+%% it.
 %%
 %% As a result of executing this operation, a customized verification email
 %% is sent to the specified address.
@@ -2232,7 +2218,7 @@ send_custom_verification_email(Client, Input0, Options0) ->
 
 %% @doc Sends an email message.
 %%
-%% You can use the Amazon SES API v2 to send two types of messages:
+%% You can use the Amazon SES API v2 to send the following types of messages:
 %%
 %% <ul> <li> Simple – A standard email message. When you create this type of
 %% message, you specify the sender, the recipient, and the message body, and
@@ -2565,6 +2551,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_shield.erl
+++ b/src/aws_shield.erl
@@ -1,15 +1,15 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Shield Advanced
+%% @doc Shield Advanced
 %%
-%% This is the AWS Shield Advanced API Reference.
+%% This is the Shield Advanced API Reference.
 %%
-%% This guide is for developers who need detailed information about the AWS
+%% This guide is for developers who need detailed information about the
 %% Shield Advanced API actions, data types, and errors. For detailed
-%% information about AWS WAF and AWS Shield Advanced features and an overview
-%% of how to use the AWS WAF and AWS Shield Advanced APIs, see the AWS WAF
-%% and AWS Shield Developer Guide.
+%% information about WAF and Shield Advanced features and an overview of how
+%% to use the WAF and Shield Advanced APIs, see the WAF and Shield Developer
+%% Guide.
 -module(aws_shield).
 
 -export([associate_drt_log_bucket/2,
@@ -66,6 +66,12 @@
          list_protections/3,
          list_resources_in_protection_group/2,
          list_resources_in_protection_group/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
          update_emergency_contact_settings/2,
          update_emergency_contact_settings/3,
          update_protection_group/2,
@@ -79,12 +85,13 @@
 %% API
 %%====================================================================
 
-%% @doc Authorizes the DDoS Response Team (DRT) to access the specified
-%% Amazon S3 bucket containing your AWS WAF logs.
+%% @doc Authorizes the Shield Response Team (SRT) to access the specified
+%% Amazon S3 bucket containing log data such as Application Load Balancer
+%% access logs, CloudFront logs, or logs from third party sources.
 %%
 %% You can associate up to 10 Amazon S3 buckets with your subscription.
 %%
-%% To use the services of the DRT and make an `AssociateDRTLogBucket'
+%% To use the services of the SRT and make an `AssociateDRTLogBucket'
 %% request, you must be subscribed to the Business Support plan or the
 %% Enterprise Support plan.
 associate_drt_log_bucket(Client, Input)
@@ -94,12 +101,12 @@ associate_drt_log_bucket(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssociateDRTLogBucket">>, Input, Options).
 
-%% @doc Authorizes the DDoS Response Team (DRT), using the specified role, to
-%% access your AWS account to assist with DDoS attack mitigation during
-%% potential attacks.
+%% @doc Authorizes the Shield Response Team (SRT) using the specified role,
+%% to access your Amazon Web Services account to assist with DDoS attack
+%% mitigation during potential attacks.
 %%
-%% This enables the DRT to inspect your AWS WAF configuration and create or
-%% update AWS WAF rules and web ACLs.
+%% This enables the SRT to inspect your WAF configuration and create or
+%% update WAF rules and web ACLs.
 %%
 %% You can associate only one `RoleArn' with your subscription. If you submit
 %% an `AssociateDRTRole' request for an account that already has an
@@ -112,17 +119,16 @@ associate_drt_log_bucket(Client, Input, Options)
 %% drt.shield.amazonaws.com'. For more information, see IAM JSON Policy
 %% Elements: Principal.
 %%
-%% The DRT will have access only to your AWS WAF and Shield resources. By
-%% submitting this request, you authorize the DRT to inspect your AWS WAF and
-%% Shield configuration and create and update AWS WAF rules and web ACLs on
-%% your behalf. The DRT takes these actions only if explicitly authorized by
-%% you.
+%% The SRT will have access only to your WAF and Shield resources. By
+%% submitting this request, you authorize the SRT to inspect your WAF and
+%% Shield configuration and create and update WAF rules and web ACLs on your
+%% behalf. The SRT takes these actions only if explicitly authorized by you.
 %%
 %% You must have the `iam:PassRole' permission to make an `AssociateDRTRole'
 %% request. For more information, see Granting a User Permissions to Pass a
-%% Role to an AWS Service.
+%% Role to an Amazon Web Services Service.
 %%
-%% To use the services of the DRT and make an `AssociateDRTRole' request, you
+%% To use the services of the SRT and make an `AssociateDRTRole' request, you
 %% must be subscribed to the Business Support plan or the Enterprise Support
 %% plan.
 associate_drt_role(Client, Input)
@@ -135,13 +141,13 @@ associate_drt_role(Client, Input, Options)
 %% @doc Adds health-based detection to the Shield Advanced protection for a
 %% resource.
 %%
-%% Shield Advanced health-based detection uses the health of your AWS
-%% resource to improve responsiveness and accuracy in attack detection and
-%% mitigation.
+%% Shield Advanced health-based detection uses the health of your Amazon Web
+%% Services resource to improve responsiveness and accuracy in attack
+%% detection and mitigation.
 %%
 %% You define the health check in Route 53 and then associate it with your
 %% Shield Advanced protection. For more information, see Shield Advanced
-%% Health-Based Detection in the AWS WAF and AWS Shield Developer Guide.
+%% Health-Based Detection in the WAF Developer Guide.
 associate_health_check(Client, Input)
   when is_map(Client), is_map(Input) ->
     associate_health_check(Client, Input, []).
@@ -150,7 +156,7 @@ associate_health_check(Client, Input, Options)
     request(Client, <<"AssociateHealthCheck">>, Input, Options).
 
 %% @doc Initializes proactive engagement and sets the list of contacts for
-%% the DDoS Response Team (DRT) to use.
+%% the Shield Response Team (SRT) to use.
 %%
 %% You must provide at least one phone number in the emergency contact list.
 %%
@@ -159,8 +165,8 @@ associate_health_check(Client, Input, Options)
 %% `DisableProactiveEngagement' and `EnableProactiveEngagement'.
 %%
 %% This call defines the list of email addresses and phone numbers that the
-%% DDoS Response Team (DRT) can use to contact you for escalations to the DRT
-%% and to initiate proactive customer support.
+%% SRT can use to contact you for escalations to the SRT and to initiate
+%% proactive customer support.
 %%
 %% The contacts that you provide in the request replace any contacts that
 %% were already defined. If you already have contacts defined and want to use
@@ -173,17 +179,17 @@ associate_proactive_engagement_details(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssociateProactiveEngagementDetails">>, Input, Options).
 
-%% @doc Enables AWS Shield Advanced for a specific AWS resource.
+%% @doc Enables Shield Advanced for a specific Amazon Web Services resource.
 %%
 %% The resource can be an Amazon CloudFront distribution, Elastic Load
-%% Balancing load balancer, AWS Global Accelerator accelerator, Elastic IP
+%% Balancing load balancer, Global Accelerator accelerator, Elastic IP
 %% Address, or an Amazon Route 53 hosted zone.
 %%
 %% You can add protection to only a single resource with each
 %% CreateProtection request. If you want to add protection to multiple
-%% resources at once, use the AWS WAF console. For more information see
-%% Getting Started with AWS Shield Advanced and Add AWS Shield Advanced
-%% Protection to more AWS Resources.
+%% resources at once, use the WAF console. For more information see Getting
+%% Started with Shield Advanced and Add Shield Advanced Protection to more
+%% Amazon Web Services Resources.
 create_protection(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_protection(Client, Input, []).
@@ -203,7 +209,7 @@ create_protection_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateProtectionGroup">>, Input, Options).
 
-%% @doc Activates AWS Shield Advanced for an account.
+%% @doc Activates Shield Advanced for an account.
 %%
 %% When you initally create a subscription, your subscription is set to be
 %% automatically renewed at the end of the existing subscription period. You
@@ -215,7 +221,7 @@ create_subscription(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateSubscription">>, Input, Options).
 
-%% @doc Deletes an AWS Shield Advanced `Protection'.
+%% @doc Deletes an Shield Advanced `Protection'.
 delete_protection(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_protection(Client, Input, []).
@@ -231,9 +237,9 @@ delete_protection_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteProtectionGroup">>, Input, Options).
 
-%% @doc Removes AWS Shield Advanced from an account.
+%% @doc Removes Shield Advanced from an account.
 %%
-%% AWS Shield Advanced requires a 1-year subscription commitment. You cannot
+%% Shield Advanced requires a 1-year subscription commitment. You cannot
 %% delete a subscription prior to the completion of that commitment.
 delete_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -250,9 +256,9 @@ describe_attack(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAttack">>, Input, Options).
 
-%% @doc Provides information about the number and type of attacks AWS Shield
-%% has detected in the last year for all resources that belong to your
-%% account, regardless of whether you've defined Shield protections for them.
+%% @doc Provides information about the number and type of attacks Shield has
+%% detected in the last year for all resources that belong to your account,
+%% regardless of whether you've defined Shield protections for them.
 %%
 %% This operation is available to Shield customers as well as to Shield
 %% Advanced customers.
@@ -273,8 +279,8 @@ describe_attack_statistics(Client, Input, Options)
     request(Client, <<"DescribeAttackStatistics">>, Input, Options).
 
 %% @doc Returns the current role and list of Amazon S3 log buckets used by
-%% the DDoS Response Team (DRT) to access your AWS account while assisting
-%% with attack mitigation.
+%% the Shield Response Team (SRT) to access your Amazon Web Services account
+%% while assisting with attack mitigation.
 describe_drt_access(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_drt_access(Client, Input, []).
@@ -282,9 +288,9 @@ describe_drt_access(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDRTAccess">>, Input, Options).
 
-%% @doc A list of email addresses and phone numbers that the DDoS Response
-%% Team (DRT) can use to contact you if you have proactive engagement
-%% enabled, for escalations to the DRT and to initiate proactive customer
+%% @doc A list of email addresses and phone numbers that the Shield Response
+%% Team (SRT) can use to contact you if you have proactive engagement
+%% enabled, for escalations to the SRT and to initiate proactive customer
 %% support.
 describe_emergency_contact_settings(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -309,7 +315,7 @@ describe_protection_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeProtectionGroup">>, Input, Options).
 
-%% @doc Provides details about the AWS Shield Advanced subscription for an
+%% @doc Provides details about the Shield Advanced subscription for an
 %% account.
 describe_subscription(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -318,8 +324,8 @@ describe_subscription(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeSubscription">>, Input, Options).
 
-%% @doc Removes authorization from the DDoS Response Team (DRT) to notify
-%% contacts about escalations to the DRT and to initiate proactive customer
+%% @doc Removes authorization from the Shield Response Team (SRT) to notify
+%% contacts about escalations to the SRT and to initiate proactive customer
 %% support.
 disable_proactive_engagement(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -328,13 +334,13 @@ disable_proactive_engagement(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableProactiveEngagement">>, Input, Options).
 
-%% @doc Removes the DDoS Response Team's (DRT) access to the specified Amazon
-%% S3 bucket containing your AWS WAF logs.
+%% @doc Removes the Shield Response Team's (SRT) access to the specified
+%% Amazon S3 bucket containing the logs that you shared previously.
 %%
 %% To make a `DisassociateDRTLogBucket' request, you must be subscribed to
 %% the Business Support plan or the Enterprise Support plan. However, if you
 %% are not subscribed to one of these support plans, but had been previously
-%% and had granted the DRT access to your account, you can submit a
+%% and had granted the SRT access to your account, you can submit a
 %% `DisassociateDRTLogBucket' request to remove this access.
 disassociate_drt_log_bucket(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -343,12 +349,13 @@ disassociate_drt_log_bucket(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisassociateDRTLogBucket">>, Input, Options).
 
-%% @doc Removes the DDoS Response Team's (DRT) access to your AWS account.
+%% @doc Removes the Shield Response Team's (SRT) access to your Amazon Web
+%% Services account.
 %%
 %% To make a `DisassociateDRTRole' request, you must be subscribed to the
 %% Business Support plan or the Enterprise Support plan. However, if you are
 %% not subscribed to one of these support plans, but had been previously and
-%% had granted the DRT access to your account, you can submit a
+%% had granted the SRT access to your account, you can submit a
 %% `DisassociateDRTRole' request to remove this access.
 disassociate_drt_role(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -360,14 +367,13 @@ disassociate_drt_role(Client, Input, Options)
 %% @doc Removes health-based detection from the Shield Advanced protection
 %% for a resource.
 %%
-%% Shield Advanced health-based detection uses the health of your AWS
-%% resource to improve responsiveness and accuracy in attack detection and
-%% mitigation.
+%% Shield Advanced health-based detection uses the health of your Amazon Web
+%% Services resource to improve responsiveness and accuracy in attack
+%% detection and mitigation.
 %%
 %% You define the health check in Route 53 and then associate or disassociate
 %% it with your Shield Advanced protection. For more information, see Shield
-%% Advanced Health-Based Detection in the AWS WAF and AWS Shield Developer
-%% Guide.
+%% Advanced Health-Based Detection in the WAF Developer Guide.
 disassociate_health_check(Client, Input)
   when is_map(Client), is_map(Input) ->
     disassociate_health_check(Client, Input, []).
@@ -375,8 +381,8 @@ disassociate_health_check(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisassociateHealthCheck">>, Input, Options).
 
-%% @doc Authorizes the DDoS Response Team (DRT) to use email and phone to
-%% notify contacts about escalations to the DRT and to initiate proactive
+%% @doc Authorizes the Shield Response Team (SRT) to use email and phone to
+%% notify contacts about escalations to the SRT and to initiate proactive
 %% customer support.
 enable_proactive_engagement(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -426,9 +432,34 @@ list_resources_in_protection_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListResourcesInProtectionGroup">>, Input, Options).
 
+%% @doc Gets information about Amazon Web Services tags for a specified
+%% Amazon Resource Name (ARN) in Shield.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc Adds or updates tags for a resource in Shield.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes tags from a resource in Shield.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
 %% @doc Updates the details of the list of email addresses and phone numbers
-%% that the DDoS Response Team (DRT) can use to contact you if you have
-%% proactive engagement enabled, for escalations to the DRT and to initiate
+%% that the Shield Response Team (SRT) can use to contact you if you have
+%% proactive engagement enabled, for escalations to the SRT and to initiate
 %% proactive customer support.
 update_emergency_contact_settings(Client, Input)
   when is_map(Client), is_map(Input) ->

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -606,6 +606,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_snow_device_management.erl
+++ b/src/aws_snow_device_management.erl
@@ -1,0 +1,471 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Web Services Snow Device Management documentation.
+-module(aws_snow_device_management).
+
+-export([cancel_task/3,
+         cancel_task/4,
+         create_task/2,
+         create_task/3,
+         describe_device/3,
+         describe_device/4,
+         describe_device_ec2_instances/3,
+         describe_device_ec2_instances/4,
+         describe_execution/4,
+         describe_execution/5,
+         describe_task/3,
+         describe_task/4,
+         list_device_resources/2,
+         list_device_resources/4,
+         list_device_resources/5,
+         list_devices/1,
+         list_devices/3,
+         list_devices/4,
+         list_executions/2,
+         list_executions/4,
+         list_executions/5,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         list_tasks/1,
+         list_tasks/3,
+         list_tasks/4,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Sends a cancel request for a specified task.
+%%
+%% You can cancel a task only if it's still in a `QUEUED' state. Tasks that
+%% are already running can't be cancelled.
+%%
+%% A task might still run if it's processed from the queue before the
+%% `CancelTask' operation changes the task's state.
+cancel_task(Client, TaskId, Input) ->
+    cancel_task(Client, TaskId, Input, []).
+cancel_task(Client, TaskId, Input0, Options0) ->
+    Method = post,
+    Path = ["/task/", aws_util:encode_uri(TaskId), "/cancel"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Instructs one or more devices to start a task, such as unlocking or
+%% rebooting.
+create_task(Client, Input) ->
+    create_task(Client, Input, []).
+create_task(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/task"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Checks device-specific information, such as the device type, software
+%% version, IP addresses, and lock status.
+describe_device(Client, ManagedDeviceId, Input) ->
+    describe_device(Client, ManagedDeviceId, Input, []).
+describe_device(Client, ManagedDeviceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/managed-device/", aws_util:encode_uri(ManagedDeviceId), "/describe"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Checks the current state of the Amazon EC2 instances.
+%%
+%% The output is similar to `describeDevice', but the results are sourced
+%% from the device cache in the Amazon Web Services Cloud and include a
+%% subset of the available fields.
+describe_device_ec2_instances(Client, ManagedDeviceId, Input) ->
+    describe_device_ec2_instances(Client, ManagedDeviceId, Input, []).
+describe_device_ec2_instances(Client, ManagedDeviceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/managed-device/", aws_util:encode_uri(ManagedDeviceId), "/resources/ec2/describe"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Checks the status of a remote task running on one or more target
+%% devices.
+describe_execution(Client, ManagedDeviceId, TaskId, Input) ->
+    describe_execution(Client, ManagedDeviceId, TaskId, Input, []).
+describe_execution(Client, ManagedDeviceId, TaskId, Input0, Options0) ->
+    Method = post,
+    Path = ["/task/", aws_util:encode_uri(TaskId), "/execution/", aws_util:encode_uri(ManagedDeviceId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Checks the metadata for a given task on a device.
+describe_task(Client, TaskId, Input) ->
+    describe_task(Client, TaskId, Input, []).
+describe_task(Client, TaskId, Input0, Options0) ->
+    Method = post,
+    Path = ["/task/", aws_util:encode_uri(TaskId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a list of the Amazon Web Services resources available for a
+%% device.
+%%
+%% Currently, Amazon EC2 instances are the only supported resource type.
+list_device_resources(Client, ManagedDeviceId)
+  when is_map(Client) ->
+    list_device_resources(Client, ManagedDeviceId, #{}, #{}).
+
+list_device_resources(Client, ManagedDeviceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_device_resources(Client, ManagedDeviceId, QueryMap, HeadersMap, []).
+
+list_device_resources(Client, ManagedDeviceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/managed-device/", aws_util:encode_uri(ManagedDeviceId), "/resources"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"type">>, maps:get(<<"type">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of all devices on your Amazon Web Services account
+%% that have Amazon Web Services Snow Device Management enabled in the Amazon
+%% Web Services Region where the command is run.
+list_devices(Client)
+  when is_map(Client) ->
+    list_devices(Client, #{}, #{}).
+
+list_devices(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_devices(Client, QueryMap, HeadersMap, []).
+
+list_devices(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/managed-devices"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"jobId">>, maps:get(<<"jobId">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns the status of tasks for one or more target devices.
+list_executions(Client, TaskId)
+  when is_map(Client) ->
+    list_executions(Client, TaskId, #{}, #{}).
+
+list_executions(Client, TaskId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_executions(Client, TaskId, QueryMap, HeadersMap, []).
+
+list_executions(Client, TaskId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/executions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"state">>, maps:get(<<"state">>, QueryMap, undefined)},
+        {<<"taskId">>, TaskId}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of tags for a managed device or task.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns a list of tasks that can be filtered by state.
+list_tasks(Client)
+  when is_map(Client) ->
+    list_tasks(Client, #{}, #{}).
+
+list_tasks(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tasks(Client, QueryMap, HeadersMap, []).
+
+list_tasks(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tasks"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"state">>, maps:get(<<"state">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Adds or replaces tags on a device or task.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a tag from a device or task.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"snow-device-management">>},
+    Host = build_host(<<"snow-device-management">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_snowball.erl
+++ b/src/aws_snowball.erl
@@ -23,6 +23,8 @@
          create_cluster/3,
          create_job/2,
          create_job/3,
+         create_long_term_pricing/2,
+         create_long_term_pricing/3,
          create_return_shipping_label/2,
          create_return_shipping_label/3,
          describe_address/2,
@@ -51,12 +53,16 @@
          list_compatible_images/3,
          list_jobs/2,
          list_jobs/3,
+         list_long_term_pricing/2,
+         list_long_term_pricing/3,
          update_cluster/2,
          update_cluster/3,
          update_job/2,
          update_job/3,
          update_job_shipment_state/2,
-         update_job_shipment_state/3]).
+         update_job_shipment_state/3,
+         update_long_term_pricing/2,
+         update_long_term_pricing/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -120,12 +126,107 @@ create_cluster(Client, Input, Options)
 %% place to create a job for a Snow device. If you're creating a job for a
 %% node in a cluster, you only need to provide the `clusterId' value; the
 %% other job attributes are inherited from the cluster.
+%%
+%% Only the Snowball; Edge device type is supported when ordering clustered
+%% jobs.
+%%
+%% The device capacity is optional.
+%%
+%% Availability of device types differ by AWS Region. For more information
+%% about Region availability, see AWS Regional Services.
+%%
+%% == AWS Snow Family device types and their capacities. ==
+%%
+%% <ul> <li> Snow Family device type: SNC1_SSD
+%%
+%% <ul> <li> Capacity: T14
+%%
+%% </li> <li> Description: Snowcone
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Snow Family device type: SNC1_HDD
+%%
+%% <ul> <li> Capacity: T8
+%%
+%% </li> <li> Description: Snowcone
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: EDGE_S
+%%
+%% <ul> <li> Capacity: T98
+%%
+%% </li> <li> Description: Snowball Edge Storage Optimized for data transfer
+%% only
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: EDGE_CG
+%%
+%% <ul> <li> Capacity: T42
+%%
+%% </li> <li> Description: Snowball Edge Compute Optimized with GPU
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: EDGE_C
+%%
+%% <ul> <li> Capacity: T42
+%%
+%% </li> <li> Description: Snowball Edge Compute Optimized without GPU
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: EDGE
+%%
+%% <ul> <li> Capacity: T100
+%%
+%% </li> <li> Description: Snowball Edge Storage Optimized with EC2 Compute
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: STANDARD
+%%
+%% <ul> <li> Capacity: T50
+%%
+%% </li> <li> Description: Original Snowball device
+%%
+%% This device is only available in the Ningxia, Beijing, and Singapore AWS
+%% Regions.
+%%
+%% </li> </ul>
+%%
+%% </li> <li> Device type: STANDARD
+%%
+%% <ul> <li> Capacity: T80
+%%
+%% </li> <li> Description: Original Snowball device
+%%
+%% This device is only available in the Ningxia, Beijing, and Singapore AWS
+%% Regions.
+%%
+%% </li> </ul>
+%%
+%% </li> </ul>
 create_job(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_job(Client, Input, []).
 create_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateJob">>, Input, Options).
+
+%% @doc Creates a job with the long-term usage option for a device.
+%%
+%% The long-term usage is a 1-year or 3-year long-term pricing type for the
+%% device. You are billed upfront, and AWS provides discounts for long-term
+%% pricing.
+create_long_term_pricing(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_long_term_pricing(Client, Input, []).
+create_long_term_pricing(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateLongTermPricing">>, Input, Options).
 
 %% @doc Creates a shipping label that will be used to return the Snow device
 %% to AWS.
@@ -201,7 +302,7 @@ describe_return_shipping_label(Client, Input, Options)
 %% access to the Snow device associated with that job.
 %%
 %% The credentials of a given job, including its manifest file and unlock
-%% code, expire 90 days after the job is created.
+%% code, expire 360 days after the job is created.
 get_job_manifest(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_job_manifest(Client, Input, []).
@@ -211,7 +312,7 @@ get_job_manifest(Client, Input, Options)
 
 %% @doc Returns the `UnlockCode' code value for the specified job.
 %%
-%% A particular `UnlockCode' value can be accessed for up to 90 days after
+%% A particular `UnlockCode' value can be accessed for up to 360 days after
 %% the associated job has been created.
 %%
 %% The `UnlockCode' value is a 29-character code with 25 alphanumeric
@@ -302,6 +403,14 @@ list_jobs(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListJobs">>, Input, Options).
 
+%% @doc Lists all long-term pricing types.
+list_long_term_pricing(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_long_term_pricing(Client, Input, []).
+list_long_term_pricing(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListLongTermPricing">>, Input, Options).
+
 %% @doc While a cluster's `ClusterState' value is in the `AwaitingQuorum'
 %% state, you can update some of the information associated with a cluster.
 %%
@@ -326,14 +435,21 @@ update_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateJob">>, Input, Options).
 
-%% @doc Updates the state when a the shipment states changes to a different
-%% state.
+%% @doc Updates the state when a shipment state changes to a different state.
 update_job_shipment_state(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_job_shipment_state(Client, Input, []).
 update_job_shipment_state(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateJobShipmentState">>, Input, Options).
+
+%% @doc Updates the long-term pricing type.
+update_long_term_pricing(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_long_term_pricing(Client, Input, []).
+update_long_term_pricing(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateLongTermPricing">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_sns.erl
+++ b/src/aws_sns.erl
@@ -32,12 +32,16 @@
          create_platform_application/3,
          create_platform_endpoint/2,
          create_platform_endpoint/3,
+         create_sms_sandbox_phone_number/2,
+         create_sms_sandbox_phone_number/3,
          create_topic/2,
          create_topic/3,
          delete_endpoint/2,
          delete_endpoint/3,
          delete_platform_application/2,
          delete_platform_application/3,
+         delete_sms_sandbox_phone_number/2,
+         delete_sms_sandbox_phone_number/3,
          delete_topic/2,
          delete_topic/3,
          get_endpoint_attributes/2,
@@ -46,16 +50,22 @@
          get_platform_application_attributes/3,
          get_sms_attributes/2,
          get_sms_attributes/3,
+         get_sms_sandbox_account_status/2,
+         get_sms_sandbox_account_status/3,
          get_subscription_attributes/2,
          get_subscription_attributes/3,
          get_topic_attributes/2,
          get_topic_attributes/3,
          list_endpoints_by_platform_application/2,
          list_endpoints_by_platform_application/3,
+         list_origination_numbers/2,
+         list_origination_numbers/3,
          list_phone_numbers_opted_out/2,
          list_phone_numbers_opted_out/3,
          list_platform_applications/2,
          list_platform_applications/3,
+         list_sms_sandbox_phone_numbers/2,
+         list_sms_sandbox_phone_numbers/3,
          list_subscriptions/2,
          list_subscriptions/3,
          list_subscriptions_by_topic/2,
@@ -87,7 +97,9 @@
          unsubscribe/2,
          unsubscribe/3,
          untag_resource/2,
-         untag_resource/3]).
+         untag_resource/3,
+         verify_sms_sandbox_phone_number/2,
+         verify_sms_sandbox_phone_number/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -96,7 +108,7 @@
 %%====================================================================
 
 %% @doc Adds a statement to a topic's access control policy, granting access
-%% for the specified AWS accounts to the specified actions.
+%% for the specified accounts to the specified actions.
 add_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_permission(Client, Input, []).
@@ -192,12 +204,31 @@ create_platform_endpoint(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreatePlatformEndpoint">>, Input, Options).
 
+%% @doc Adds a destination phone number to an account in the SMS sandbox and
+%% sends a one-time password (OTP) to that phone number.
+%%
+%% When you start using Amazon SNS to send SMS messages, your account is in
+%% the SMS sandbox. The SMS sandbox provides a safe environment for you to
+%% try Amazon SNS features without risking your reputation as an SMS sender.
+%% While your account is in the SMS sandbox, you can use all of the features
+%% of Amazon SNS. However, you can send SMS messages only to verified
+%% destination phone numbers. For more information, including how to move out
+%% of the sandbox to send messages without restrictions, see SMS sandbox in
+%% the Amazon SNS Developer Guide.
+create_sms_sandbox_phone_number(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_sms_sandbox_phone_number(Client, Input, []).
+create_sms_sandbox_phone_number(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateSMSSandboxPhoneNumber">>, Input, Options).
+
 %% @doc Creates a topic to which notifications can be published.
 %%
 %% Users can create at most 100,000 standard topics (at most 1,000 FIFO
-%% topics). For more information, see https://aws.amazon.com/sns. This action
-%% is idempotent, so if the requester already owns a topic with the specified
-%% name, that topic's ARN is returned without creating a new topic.
+%% topics). For more information, see Creating an Amazon SNS topic in the
+%% Amazon SNS Developer Guide. This action is idempotent, so if the requester
+%% already owns a topic with the specified name, that topic's ARN is returned
+%% without creating a new topic.
 create_topic(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_topic(Client, Input, []).
@@ -229,6 +260,24 @@ delete_platform_application(Client, Input)
 delete_platform_application(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeletePlatformApplication">>, Input, Options).
+
+%% @doc Deletes an account's verified or pending phone number from the SMS
+%% sandbox.
+%%
+%% When you start using Amazon SNS to send SMS messages, your account is in
+%% the SMS sandbox. The SMS sandbox provides a safe environment for you to
+%% try Amazon SNS features without risking your reputation as an SMS sender.
+%% While your account is in the SMS sandbox, you can use all of the features
+%% of Amazon SNS. However, you can send SMS messages only to verified
+%% destination phone numbers. For more information, including how to move out
+%% of the sandbox to send messages without restrictions, see SMS sandbox in
+%% the Amazon SNS Developer Guide.
+delete_sms_sandbox_phone_number(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_sms_sandbox_phone_number(Client, Input, []).
+delete_sms_sandbox_phone_number(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteSMSSandboxPhoneNumber">>, Input, Options).
 
 %% @doc Deletes a topic and all its subscriptions.
 %%
@@ -276,6 +325,24 @@ get_sms_attributes(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetSMSAttributes">>, Input, Options).
 
+%% @doc Retrieves the SMS sandbox status for the calling account in the
+%% target Region.
+%%
+%% When you start using Amazon SNS to send SMS messages, your account is in
+%% the SMS sandbox. The SMS sandbox provides a safe environment for you to
+%% try Amazon SNS features without risking your reputation as an SMS sender.
+%% While your account is in the SMS sandbox, you can use all of the features
+%% of Amazon SNS. However, you can send SMS messages only to verified
+%% destination phone numbers. For more information, including how to move out
+%% of the sandbox to send messages without restrictions, see SMS sandbox in
+%% the Amazon SNS Developer Guide.
+get_sms_sandbox_account_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_sms_sandbox_account_status(Client, Input, []).
+get_sms_sandbox_account_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetSMSSandboxAccountStatus">>, Input, Options).
+
 %% @doc Returns all of the properties of a subscription.
 get_subscription_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -316,6 +383,18 @@ list_endpoints_by_platform_application(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListEndpointsByPlatformApplication">>, Input, Options).
 
+%% @doc Lists the calling account's dedicated origination numbers and their
+%% metadata.
+%%
+%% For more information about origination numbers, see Origination numbers in
+%% the Amazon SNS Developer Guide.
+list_origination_numbers(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_origination_numbers(Client, Input, []).
+list_origination_numbers(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListOriginationNumbers">>, Input, Options).
+
 %% @doc Returns a list of phone numbers that are opted out, meaning you
 %% cannot send SMS messages to them.
 %%
@@ -350,6 +429,24 @@ list_platform_applications(Client, Input)
 list_platform_applications(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListPlatformApplications">>, Input, Options).
+
+%% @doc Lists the calling account's current verified and pending destination
+%% phone numbers in the SMS sandbox.
+%%
+%% When you start using Amazon SNS to send SMS messages, your account is in
+%% the SMS sandbox. The SMS sandbox provides a safe environment for you to
+%% try Amazon SNS features without risking your reputation as an SMS sender.
+%% While your account is in the SMS sandbox, you can use all of the features
+%% of Amazon SNS. However, you can send SMS messages only to verified
+%% destination phone numbers. For more information, including how to move out
+%% of the sandbox to send messages without restrictions, see SMS sandbox in
+%% the Amazon SNS Developer Guide.
+list_sms_sandbox_phone_numbers(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_sms_sandbox_phone_numbers(Client, Input, []).
+list_sms_sandbox_phone_numbers(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListSMSSandboxPhoneNumbers">>, Input, Options).
 
 %% @doc Returns a list of the requester's subscriptions.
 %%
@@ -434,8 +531,7 @@ opt_in_phone_number(Client, Input, Options)
 %% For more information about formatting messages, see Send Custom
 %% Platform-Specific Payloads in Messages to Mobile Devices.
 %%
-%% You can publish messages only to topics and endpoints in the same AWS
-%% Region.
+%% You can publish messages only to topics and endpoints in the same Region.
 publish(Client, Input)
   when is_map(Client), is_map(Input) ->
     publish(Client, Input, []).
@@ -514,7 +610,7 @@ set_topic_attributes(Client, Input, Options)
 %% @doc Subscribes an endpoint to an Amazon SNS topic.
 %%
 %% If the endpoint type is HTTP/S or email, or if the endpoint and the topic
-%% are not in the same AWS account, the endpoint owner must run the
+%% are not in the same account, the endpoint owner must run the
 %% `ConfirmSubscription' action to confirm the subscription.
 %%
 %% You call the `ConfirmSubscription' action with the token from the
@@ -544,9 +640,9 @@ subscribe(Client, Input, Options)
 %% </li> <li> A new tag with a key identical to that of an existing tag
 %% overwrites the existing tag.
 %%
-%% </li> <li> Tagging actions are limited to 10 TPS per AWS account, per AWS
-%% region. If your application requires a higher throughput, file a technical
-%% support request.
+%% </li> <li> Tagging actions are limited to 10 TPS per account, per Region.
+%% If your application requires a higher throughput, file a technical support
+%% request.
 %%
 %% </li> </ul>
 tag_resource(Client, Input)
@@ -559,12 +655,12 @@ tag_resource(Client, Input, Options)
 %% @doc Deletes a subscription.
 %%
 %% If the subscription requires authentication for deletion, only the owner
-%% of the subscription or the topic's owner can unsubscribe, and an AWS
-%% signature is required. If the `Unsubscribe' call does not require
-%% authentication and the requester is not the subscription owner, a final
-%% cancellation message is delivered to the endpoint, so that the endpoint
-%% owner can easily resubscribe to the topic if the `Unsubscribe' request was
-%% unintended.
+%% of the subscription or the topic's owner can unsubscribe, and an Amazon
+%% Web Services signature is required. If the `Unsubscribe' call does not
+%% require authentication and the requester is not the subscription owner, a
+%% final cancellation message is delivered to the endpoint, so that the
+%% endpoint owner can easily resubscribe to the topic if the `Unsubscribe'
+%% request was unintended.
 %%
 %% This action is throttled at 100 transactions per second (TPS).
 unsubscribe(Client, Input)
@@ -583,6 +679,24 @@ untag_resource(Client, Input)
 untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Verifies a destination phone number with a one-time password (OTP)
+%% for the calling account.
+%%
+%% When you start using Amazon SNS to send SMS messages, your account is in
+%% the SMS sandbox. The SMS sandbox provides a safe environment for you to
+%% try Amazon SNS features without risking your reputation as an SMS sender.
+%% While your account is in the SMS sandbox, you can use all of the features
+%% of Amazon SNS. However, you can send SMS messages only to verified
+%% destination phone numbers. For more information, including how to move out
+%% of the sandbox to send messages without restrictions, see SMS sandbox in
+%% the Amazon SNS Developer Guide.
+verify_sms_sandbox_phone_number(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    verify_sms_sandbox_phone_number(Client, Input, []).
+verify_sms_sandbox_phone_number(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"VerifySMSSandboxPhoneNumber">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_sqs.erl
+++ b/src/aws_sqs.erl
@@ -1,18 +1,19 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc Welcome to the Amazon Simple Queue Service API Reference.
+%% @doc Welcome to the Amazon SQS API Reference.
 %%
-%% Amazon Simple Queue Service (Amazon SQS) is a reliable, highly-scalable
-%% hosted queue for storing messages as they travel between applications or
-%% microservices. Amazon SQS moves data between distributed application
-%% components and helps you decouple these components.
+%% Amazon SQS is a reliable, highly-scalable hosted queue for storing
+%% messages as they travel between applications or microservices. Amazon SQS
+%% moves data between distributed application components and helps you
+%% decouple these components.
 %%
 %% For information on the permissions you need to use this API, see Identity
-%% and access management in the Amazon Simple Queue Service Developer Guide.
+%% and access management in the Amazon SQS Developer Guide.
 %%
-%% You can use AWS SDKs to access Amazon SQS using your favorite programming
-%% language. The SDKs perform tasks such as the following automatically:
+%% You can use Amazon Web Services SDKs to access Amazon SQS using your
+%% favorite programming language. The SDKs perform tasks such as the
+%% following automatically:
 %%
 %% <ul> <li> Cryptographically sign your service requests
 %%
@@ -20,11 +21,11 @@
 %%
 %% </li> <li> Handle error responses
 %%
-%% </li> </ul> Additional Information
+%% </li> </ul> Additional information
 %%
 %% <ul> <li> Amazon SQS Product Page
 %%
-%% </li> <li> Amazon Simple Queue Service Developer Guide
+%% </li> <li> Amazon SQS Developer Guide
 %%
 %% <ul> <li> Making API Requests
 %%
@@ -32,7 +33,7 @@
 %%
 %% </li> <li> Amazon SQS Dead-Letter Queues
 %%
-%% </li> </ul> </li> <li> Amazon SQS in the AWS CLI Command Reference
+%% </li> </ul> </li> <li> Amazon SQS in the Command Line Interface
 %%
 %% </li> <li> Amazon Web Services General Reference
 %%
@@ -95,13 +96,13 @@
 %% When you create a queue, you have full control access rights for the
 %% queue. Only you, the owner of the queue, can grant or deny permissions to
 %% the queue. For more information about these permissions, see Allow
-%% Developers to Write Messages to a Shared Queue in the Amazon Simple Queue
-%% Service Developer Guide.
+%% Developers to Write Messages to a Shared Queue in the Amazon SQS Developer
+%% Guide.
 %%
 %% `AddPermission' generates a policy for you. You can use `
 %% `SetQueueAttributes' ' to upload your policy. For more information, see
 %% Using Custom Policies with the Amazon SQS Access Policy Language in the
-%% Amazon Simple Queue Service Developer Guide.
+%% Amazon SQS Developer Guide.
 %%
 %% An Amazon SQS policy can have a maximum of 7 actions.
 %%
@@ -119,7 +120,7 @@
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 add_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_permission(Client, Input, []).
@@ -132,7 +133,7 @@ add_permission(Client, Input, Options)
 %%
 %% The default visibility timeout for a message is 30 seconds. The minimum is
 %% 0 seconds. The maximum is 12 hours. For more information, see Visibility
-%% Timeout in the Amazon Simple Queue Service Developer Guide.
+%% Timeout in the Amazon SQS Developer Guide.
 %%
 %% For example, you have a message with a visibility timeout of 5 minutes.
 %% After 3 minutes, you call `ChangeMessageVisibility' with a timeout of 10
@@ -227,8 +228,7 @@ change_message_visibility_batch(Client, Input, Options)
 %% an existing standard queue into a FIFO queue. You must either create a new
 %% FIFO queue for your application or delete your existing standard queue and
 %% recreate it as a FIFO queue. For more information, see Moving From a
-%% Standard Queue to a FIFO Queue in the Amazon Simple Queue Service
-%% Developer Guide.
+%% Standard Queue to a FIFO Queue in the Amazon SQS Developer Guide.
 %%
 %% </li> <li> If you don't provide a value for an attribute, the queue is
 %% created with the default value for the attribute.
@@ -264,7 +264,7 @@ change_message_visibility_batch(Client, Input, Options)
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 create_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_queue(Client, Input, []).
@@ -341,7 +341,7 @@ delete_message_batch(Client, Input, Options)
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 delete_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_queue(Client, Input, []).
@@ -367,7 +367,7 @@ get_queue_attributes(Client, Input, Options)
 %% queue's owner. The queue's owner must grant you permission to access the
 %% queue. For more information about shared queue access, see `
 %% `AddPermission' ' or see Allow Developers to Write Messages to a Shared
-%% Queue in the Amazon Simple Queue Service Developer Guide.
+%% Queue in the Amazon SQS Developer Guide.
 get_queue_url(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_queue_url(Client, Input, []).
@@ -387,7 +387,7 @@ get_queue_url(Client, Input, Options)
 %% `ListDeadLetterSourceQueues' to receive the next page of results.
 %%
 %% For more information about using dead-letter queues, see Using Amazon SQS
-%% Dead-Letter Queues in the Amazon Simple Queue Service Developer Guide.
+%% Dead-Letter Queues in the Amazon SQS Developer Guide.
 list_dead_letter_source_queues(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_dead_letter_source_queues(Client, Input, []).
@@ -398,12 +398,12 @@ list_dead_letter_source_queues(Client, Input, Options)
 %% @doc List all cost allocation tags added to the specified Amazon SQS
 %% queue.
 %%
-%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon Simple
-%% Queue Service Developer Guide.
+%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon SQS
+%% Developer Guide.
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 list_queue_tags(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_queue_tags(Client, Input, []).
@@ -427,7 +427,7 @@ list_queue_tags(Client, Input, Options)
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 list_queues(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_queues(Client, Input, []).
@@ -459,8 +459,8 @@ purge_queue(Client, Input, Options)
 %% @doc Retrieves one or more messages (up to 10), from the specified queue.
 %%
 %% Using the `WaitTimeSeconds' parameter enables long-poll support. For more
-%% information, see Amazon SQS Long Polling in the Amazon Simple Queue
-%% Service Developer Guide.
+%% information, see Amazon SQS Long Polling in the Amazon SQS Developer
+%% Guide.
 %%
 %% Short poll is the default behavior where a weighted random set of machines
 %% is sampled on a `ReceiveMessage' call. Thus, only the messages on the
@@ -488,14 +488,13 @@ purge_queue(Client, Input, Options)
 %%
 %% </li> </ul> The receipt handle is the identifier you must provide when
 %% deleting the message. For more information, see Queue and Message
-%% Identifiers in the Amazon Simple Queue Service Developer Guide.
+%% Identifiers in the Amazon SQS Developer Guide.
 %%
 %% You can provide the `VisibilityTimeout' parameter in your request. The
 %% parameter is applied to the messages that Amazon SQS returns in the
 %% response. If you don't include the parameter, the overall visibility
 %% timeout for the queue is used for the returned messages. For more
-%% information, see Visibility Timeout in the Amazon Simple Queue Service
-%% Developer Guide.
+%% information, see Visibility Timeout in the Amazon SQS Developer Guide.
 %%
 %% A message that isn't deleted or a message whose visibility isn't extended
 %% before the visibility timeout expires counts as a failed receive.
@@ -519,7 +518,7 @@ receive_message(Client, Input, Options)
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 %%
 %% To remove the ability to change queue permissions, you must deny
 %% permission to the `AddPermission', `RemovePermission', and
@@ -601,7 +600,7 @@ send_message_batch(Client, Input, Options)
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 %%
 %% To remove the ability to change queue permissions, you must deny
 %% permission to the `AddPermission', `RemovePermission', and
@@ -615,8 +614,8 @@ set_queue_attributes(Client, Input, Options)
 
 %% @doc Add cost allocation tags to the specified Amazon SQS queue.
 %%
-%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon Simple
-%% Queue Service Developer Guide.
+%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon SQS
+%% Developer Guide.
 %%
 %% When you use queue tags, keep the following guidelines in mind:
 %%
@@ -630,12 +629,12 @@ set_queue_attributes(Client, Input, Options)
 %% </li> <li> A new tag with a key identical to that of an existing tag
 %% overwrites the existing tag.
 %%
-%% </li> </ul> For a full list of tag restrictions, see Limits Related to
-%% Queues in the Amazon Simple Queue Service Developer Guide.
+%% </li> </ul> For a full list of tag restrictions, see Quotas related to
+%% queues in the Amazon SQS Developer Guide.
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 tag_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_queue(Client, Input, []).
@@ -645,12 +644,12 @@ tag_queue(Client, Input, Options)
 
 %% @doc Remove cost allocation tags from the specified Amazon SQS queue.
 %%
-%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon Simple
-%% Queue Service Developer Guide.
+%% For an overview, see Tagging Your Amazon SQS Queues in the Amazon SQS
+%% Developer Guide.
 %%
 %% Cross-account permissions don't apply to this action. For more
 %% information, see Grant cross-account permissions to a role and a user name
-%% in the Amazon Simple Queue Service Developer Guide.
+%% in the Amazon SQS Developer Guide.
 untag_queue(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_queue(Client, Input, []).

--- a/src/aws_ssm.erl
+++ b/src/aws_ssm.erl
@@ -1,13 +1,11 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Systems Manager
-%%
-%% AWS Systems Manager is a collection of capabilities that helps you
-%% automate management tasks such as collecting system inventory, applying
-%% operating system (OS) patches, automating the creation of Amazon Machine
-%% Images (AMIs), and configuring operating systems (OSs) and applications at
-%% scale.
+%% @doc Amazon Web Services Systems Manager is a collection of capabilities
+%% that helps you automate management tasks such as collecting system
+%% inventory, applying operating system (OS) patches, automating the creation
+%% of Amazon Machine Images (AMIs), and configuring operating systems (OSs)
+%% and applications at scale.
 %%
 %% Systems Manager lets you remotely and securely manage the configuration of
 %% your managed instances. A managed instance is any Amazon Elastic Compute
@@ -15,20 +13,35 @@
 %% machine (VM) in your hybrid environment that has been configured for
 %% Systems Manager.
 %%
-%% This reference is intended to be used with the AWS Systems Manager User
-%% Guide.
-%%
-%% To get started, verify prerequisites and configure managed instances. For
-%% more information, see Setting up AWS Systems Manager in the AWS Systems
+%% This reference is intended to be used with the Amazon Web Services Systems
 %% Manager User Guide.
 %%
-%% For information about other API actions you can perform on EC2 instances,
-%% see the Amazon EC2 API Reference. For information about how to use a Query
-%% API, see Making API requests.
+%% To get started, verify prerequisites and configure managed instances. For
+%% more information, see Setting up Amazon Web Services Systems Manager in
+%% the Amazon Web Services Systems Manager User Guide.
+%%
+%% == Related resources ==
+%%
+%% <ul> <li> For information about how to use a Query API, see Making API
+%% requests.
+%%
+%% </li> <li> For information about other API operations you can perform on
+%% EC2 instances, see the Amazon EC2 API Reference.
+%%
+%% </li> <li> For information about AppConfig, a capability of Systems
+%% Manager, see the AppConfig User Guide and the AppConfig API Reference.
+%%
+%% </li> <li> For information about Incident Manager, a capability of Systems
+%% Manager, see the Incident Manager User Guide and the Incident Manager API
+%% Reference.
+%%
+%% </li> </ul>
 -module(aws_ssm).
 
 -export([add_tags_to_resource/2,
          add_tags_to_resource/3,
+         associate_ops_item_related_item/2,
+         associate_ops_item_related_item/3,
          cancel_command/2,
          cancel_command/3,
          cancel_maintenance_window_execution/2,
@@ -143,6 +156,8 @@
          describe_patch_properties/3,
          describe_sessions/2,
          describe_sessions/3,
+         disassociate_ops_item_related_item/2,
+         disassociate_ops_item_related_item/3,
          get_automation_execution/2,
          get_automation_execution/3,
          get_calendar_state/2,
@@ -215,6 +230,8 @@
          list_inventory_entries/3,
          list_ops_item_events/2,
          list_ops_item_events/3,
+         list_ops_item_related_items/2,
+         list_ops_item_related_items/3,
          list_ops_metadata/2,
          list_ops_metadata/3,
          list_resource_compliance_summaries/2,
@@ -261,6 +278,8 @@
          stop_automation_execution/3,
          terminate_session/2,
          terminate_session/3,
+         unlabel_parameter_version/2,
+         unlabel_parameter_version/3,
          update_association/2,
          update_association/3,
          update_association_status/2,
@@ -304,11 +323,21 @@
 %% for example, by purpose, owner, or environment. Each tag consists of a key
 %% and an optional value, both of which you define. For example, you could
 %% define a set of tags for your account's managed instances that helps you
-%% track each instance's owner and stack level. For example: Key=Owner and
-%% Value=DbAdmin, SysAdmin, or Dev. Or Key=Stack and Value=Production,
-%% Pre-Production, or Test.
+%% track each instance's owner and stack level. For example:
 %%
-%% Each resource can have a maximum of 50 tags.
+%% <ul> <li> `Key=Owner,Value=DbAdmin'
+%%
+%% </li> <li> `Key=Owner,Value=SysAdmin'
+%%
+%% </li> <li> `Key=Owner,Value=Dev'
+%%
+%% </li> <li> `Key=Stack,Value=Production'
+%%
+%% </li> <li> `Key=Stack,Value=Pre-Production'
+%%
+%% </li> <li> `Key=Stack,Value=Test'
+%%
+%% </li> </ul> Each resource can have a maximum of 50 tags.
 %%
 %% We recommend that you devise a set of tag keys that meets your needs for
 %% each resource type. Using a consistent set of tag keys makes it easier for
@@ -316,14 +345,27 @@
 %% based on the tags you add. Tags don't have any semantic meaning to and are
 %% interpreted strictly as a string of characters.
 %%
-%% For more information about using tags with EC2 instances, see Tagging your
-%% Amazon EC2 resources in the Amazon EC2 User Guide.
+%% For more information about using tags with Amazon Elastic Compute Cloud
+%% (Amazon EC2) instances, see Tagging your Amazon EC2 resources in the
+%% Amazon EC2 User Guide.
 add_tags_to_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     add_tags_to_resource(Client, Input, []).
 add_tags_to_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AddTagsToResource">>, Input, Options).
+
+%% @doc Associates a related item to a Systems Manager OpsCenter OpsItem.
+%%
+%% For example, you can associate an Incident Manager incident or analysis
+%% with an OpsItem. Incident Manager and OpsCenter are capabilities of Amazon
+%% Web Services Systems Manager.
+associate_ops_item_related_item(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    associate_ops_item_related_item(Client, Input, []).
+associate_ops_item_related_item(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AssociateOpsItemRelatedItem">>, Input, Options).
 
 %% @doc Attempts to cancel the command specified by the Command ID.
 %%
@@ -337,9 +379,9 @@ cancel_command(Client, Input, Options)
     request(Client, <<"CancelCommand">>, Input, Options).
 
 %% @doc Stops a maintenance window execution that is already in progress and
-%% cancels any tasks in the window that have not already starting running.
+%% cancels any tasks in the window that haven't already starting running.
 %%
-%% (Tasks already in progress will continue to completion.)
+%% Tasks already in progress will continue to completion.
 cancel_maintenance_window_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     cancel_maintenance_window_execution(Client, Input, []).
@@ -348,20 +390,20 @@ cancel_maintenance_window_execution(Client, Input, Options)
     request(Client, <<"CancelMaintenanceWindowExecution">>, Input, Options).
 
 %% @doc Generates an activation code and activation ID you can use to
-%% register your on-premises server or virtual machine (VM) with Systems
-%% Manager.
+%% register your on-premises server or virtual machine (VM) with Amazon Web
+%% Services Systems Manager.
 %%
 %% Registering these machines with Systems Manager makes it possible to
 %% manage them using Systems Manager capabilities. You use the activation
 %% code and ID when installing SSM Agent on machines in your hybrid
 %% environment. For more information about requirements for managing
-%% on-premises instances and VMs using Systems Manager, see Setting up AWS
-%% Systems Manager for hybrid environments in the AWS Systems Manager User
-%% Guide.
+%% on-premises instances and VMs using Systems Manager, see Setting up Amazon
+%% Web Services Systems Manager for hybrid environments in the Amazon Web
+%% Services Systems Manager User Guide.
 %%
 %% On-premises servers or VMs that are registered with Systems Manager and
-%% EC2 instances that you manage with Systems Manager are all called managed
-%% instances.
+%% Amazon Elastic Compute Cloud (Amazon EC2) instances that you manage with
+%% Systems Manager are all called managed instances.
 create_activation(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_activation(Client, Input, []).
@@ -375,14 +417,15 @@ create_activation(Client, Input, Options)
 %% For example, an association can specify that anti-virus software must be
 %% installed and running on your instances, or that certain ports must be
 %% closed. For static targets, the association specifies a schedule for when
-%% the configuration is reapplied. For dynamic targets, such as an AWS
-%% Resource Group or an AWS Autoscaling Group, State Manager applies the
+%% the configuration is reapplied. For dynamic targets, such as an Amazon Web
+%% Services resource group or an Amazon Web Services autoscaling group, State
+%% Manager, a capability of Amazon Web Services Systems Manager applies the
 %% configuration when new instances are added to the group. The association
 %% also specifies actions to take when applying the configuration. For
 %% example, an association for anti-virus software might run once a day. If
-%% the software is not installed, then State Manager installs it. If the
-%% software is installed, but the service is not running, then the
-%% association might instruct State Manager to start the service.
+%% the software isn't installed, then State Manager installs it. If the
+%% software is installed, but the service isn't running, then the association
+%% might instruct State Manager to start the service.
 create_association(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_association(Client, Input, []).
@@ -390,12 +433,13 @@ create_association(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateAssociation">>, Input, Options).
 
-%% @doc Associates the specified Systems Manager document with the specified
-%% instances or targets.
+%% @doc Associates the specified Amazon Web Services Systems Manager document
+%% (SSM document) with the specified instances or targets.
 %%
 %% When you associate a document with one or more instances using instance
-%% IDs or tags, SSM Agent running on the instance processes the document and
-%% configures the instance as specified.
+%% IDs or tags, Amazon Web Services Systems Manager Agent (SSM Agent) running
+%% on the instance processes the document and configures the instance as
+%% specified.
 %%
 %% If you associate a document with an instance that already has an
 %% associated document, the system returns the AssociationAlreadyExists
@@ -407,12 +451,13 @@ create_association_batch(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateAssociationBatch">>, Input, Options).
 
-%% @doc Creates a Systems Manager (SSM) document.
+%% @doc Creates a Amazon Web Services Systems Manager (SSM document).
 %%
 %% An SSM document defines the actions that Systems Manager performs on your
 %% managed instances. For more information about SSM documents, including
-%% information about supported schemas, features, and syntax, see AWS Systems
-%% Manager Documents in the AWS Systems Manager User Guide.
+%% information about supported schemas, features, and syntax, see Amazon Web
+%% Services Systems Manager Documents in the Amazon Web Services Systems
+%% Manager User Guide.
 create_document(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_document(Client, Input, []).
@@ -437,14 +482,15 @@ create_maintenance_window(Client, Input, Options)
 
 %% @doc Creates a new OpsItem.
 %%
-%% You must have permission in AWS Identity and Access Management (IAM) to
-%% create a new OpsItem. For more information, see Getting started with
-%% OpsCenter in the AWS Systems Manager User Guide.
+%% You must have permission in Identity and Access Management (IAM) to create
+%% a new OpsItem. For more information, see Getting started with OpsCenter in
+%% the Amazon Web Services Systems Manager User Guide.
 %%
-%% Operations engineers and IT professionals use OpsCenter to view,
-%% investigate, and remediate operational issues impacting the performance
-%% and health of their AWS resources. For more information, see AWS Systems
-%% Manager OpsCenter in the AWS Systems Manager User Guide.
+%% Operations engineers and IT professionals use Amazon Web Services Systems
+%% Manager OpsCenter to view, investigate, and remediate operational issues
+%% impacting the performance and health of their Amazon Web Services
+%% resources. For more information, see Amazon Web Services Systems Manager
+%% OpsCenter in the Amazon Web Services Systems Manager User Guide.
 create_ops_item(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_ops_item(Client, Input, []).
@@ -452,9 +498,9 @@ create_ops_item(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateOpsItem">>, Input, Options).
 
-%% @doc If you create a new application in Application Manager, Systems
-%% Manager calls this API action to specify information about the new
-%% application, including the application type.
+%% @doc If you create a new application in Application Manager, Amazon Web
+%% Services Systems Manager calls this API operation to specify information
+%% about the new application, including the application type.
 create_ops_metadata(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_ops_metadata(Client, Input, []).
@@ -464,8 +510,8 @@ create_ops_metadata(Client, Input, Options)
 
 %% @doc Creates a patch baseline.
 %%
-%% For information about valid key and value pairs in `PatchFilters' for each
-%% supported operating system type, see PatchFilter.
+%% For information about valid key-value pairs in `PatchFilters' for each
+%% supported operating system type, see `PatchFilter'.
 create_patch_baseline(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_patch_baseline(Client, Input, []).
@@ -476,28 +522,30 @@ create_patch_baseline(Client, Input, Options)
 %% @doc A resource data sync helps you view data from multiple sources in a
 %% single location.
 %%
-%% Systems Manager offers two types of resource data sync:
-%% `SyncToDestination' and `SyncFromSource'.
+%% Amazon Web Services Systems Manager offers two types of resource data
+%% sync: `SyncToDestination' and `SyncFromSource'.
 %%
 %% You can configure Systems Manager Inventory to use the `SyncToDestination'
-%% type to synchronize Inventory data from multiple AWS Regions to a single
-%% S3 bucket. For more information, see Configuring Resource Data Sync for
-%% Inventory in the AWS Systems Manager User Guide.
+%% type to synchronize Inventory data from multiple Amazon Web Services
+%% Regions to a single Amazon Simple Storage Service (Amazon S3) bucket. For
+%% more information, see Configuring resource data sync for Inventory in the
+%% Amazon Web Services Systems Manager User Guide.
 %%
 %% You can configure Systems Manager Explorer to use the `SyncFromSource'
 %% type to synchronize operational work items (OpsItems) and operational data
-%% (OpsData) from multiple AWS Regions to a single S3 bucket. This type can
-%% synchronize OpsItems and OpsData from multiple AWS accounts and Regions or
-%% `EntireOrganization' by using AWS Organizations. For more information, see
+%% (OpsData) from multiple Amazon Web Services Regions to a single Amazon S3
+%% bucket. This type can synchronize OpsItems and OpsData from multiple
+%% Amazon Web Services accounts and Amazon Web Services Regions or
+%% `EntireOrganization' by using Organizations. For more information, see
 %% Setting up Systems Manager Explorer to display data from multiple accounts
-%% and Regions in the AWS Systems Manager User Guide.
+%% and Regions in the Amazon Web Services Systems Manager User Guide.
 %%
 %% A resource data sync is an asynchronous operation that returns
 %% immediately. After a successful initial sync is completed, the system
 %% continuously syncs data. To check the status of a sync, use the
 %% `ListResourceDataSync'.
 %%
-%% By default, data is not encrypted in Amazon S3. We strongly recommend that
+%% By default, data isn't encrypted in Amazon S3. We strongly recommend that
 %% you enable encryption in Amazon S3 to ensure secure data storage. We also
 %% recommend that you secure access to the Amazon S3 bucket by creating a
 %% restrictive bucket policy.
@@ -510,9 +558,9 @@ create_resource_data_sync(Client, Input, Options)
 
 %% @doc Deletes an activation.
 %%
-%% You are not required to delete an activation. If you delete an activation,
+%% You aren't required to delete an activation. If you delete an activation,
 %% you can no longer use it to register additional managed instances.
-%% Deleting an activation does not de-register managed instances. You must
+%% Deleting an activation doesn't de-register managed instances. You must
 %% manually de-register managed instances.
 delete_activation(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -521,10 +569,13 @@ delete_activation(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteActivation">>, Input, Options).
 
-%% @doc Disassociates the specified Systems Manager document from the
-%% specified instance.
+%% @doc Disassociates the specified Amazon Web Services Systems Manager
+%% document (SSM document) from the specified instance.
 %%
-%% When you disassociate a document from an instance, it does not change the
+%% If you created the association by using the `Targets' parameter, then you
+%% must delete the association by using the association ID.
+%%
+%% When you disassociate a document from an instance, it doesn't change the
 %% configuration of the instance. To change the configuration state of an
 %% instance after you disassociate a document, you must create a new document
 %% with the desired configuration and associate it with the instance.
@@ -535,8 +586,8 @@ delete_association(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteAssociation">>, Input, Options).
 
-%% @doc Deletes the Systems Manager document and all instance associations to
-%% the document.
+%% @doc Deletes the Amazon Web Services Systems Manager document (SSM
+%% document) and all instance associations to the document.
 %%
 %% Before you delete the document, we recommend that you use
 %% `DeleteAssociation' to disassociate all instances that are associated with
@@ -577,6 +628,9 @@ delete_ops_metadata(Client, Input, Options)
     request(Client, <<"DeleteOpsMetadata">>, Input, Options).
 
 %% @doc Delete a parameter from the system.
+%%
+%% After deleting a parameter, wait for at least 30 seconds to create a
+%% parameter with the same name.
 delete_parameter(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_parameter(Client, Input, []).
@@ -585,6 +639,9 @@ delete_parameter(Client, Input, Options)
     request(Client, <<"DeleteParameter">>, Input, Options).
 
 %% @doc Delete a list of parameters.
+%%
+%% After deleting a parameter, wait for at least 30 seconds to create a
+%% parameter with the same name.
 delete_parameters(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_parameters(Client, Input, []).
@@ -600,11 +657,11 @@ delete_patch_baseline(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeletePatchBaseline">>, Input, Options).
 
-%% @doc Deletes a Resource Data Sync configuration.
+%% @doc Deletes a resource data sync configuration.
 %%
 %% After the configuration is deleted, changes to data on managed instances
 %% are no longer synced to or from the target. Deleting a sync configuration
-%% does not delete data.
+%% doesn't delete data.
 delete_resource_data_sync(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_resource_data_sync(Client, Input, []).
@@ -649,9 +706,9 @@ deregister_task_from_maintenance_window(Client, Input, Options)
     request(Client, <<"DeregisterTaskFromMaintenanceWindow">>, Input, Options).
 
 %% @doc Describes details about the activation, such as the date and time the
-%% activation was created, its expiration date, the IAM role assigned to the
-%% instances in the activation, and the number of instances registered by
-%% using this activation.
+%% activation was created, its expiration date, the Identity and Access
+%% Management (IAM) role assigned to the instances in the activation, and the
+%% number of instances registered by using this activation.
 describe_activations(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_activations(Client, Input, []).
@@ -662,10 +719,7 @@ describe_activations(Client, Input, Options)
 %% @doc Describes the association for the specified target or instance.
 %%
 %% If you created the association by using the `Targets' parameter, then you
-%% must retrieve the association by using the association ID. If you created
-%% the association by specifying an instance ID and a Systems Manager
-%% document, then you retrieve the association by specifying the document
-%% name and the instance ID.
+%% must retrieve the association by using the association ID.
 describe_association(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_association(Client, Input, []).
@@ -673,8 +727,8 @@ describe_association(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAssociation">>, Input, Options).
 
-%% @doc Use this API action to view information about a specific execution of
-%% a specific association.
+%% @doc Views information about a specific execution of a specific
+%% association.
 describe_association_execution_targets(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_association_execution_targets(Client, Input, []).
@@ -682,8 +736,7 @@ describe_association_execution_targets(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAssociationExecutionTargets">>, Input, Options).
 
-%% @doc Use this API action to view all executions for a specific association
-%% ID.
+%% @doc Views all executions for a specific association ID.
 describe_association_executions(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_association_executions(Client, Input, []).
@@ -717,7 +770,8 @@ describe_available_patches(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAvailablePatches">>, Input, Options).
 
-%% @doc Describes the specified Systems Manager document.
+%% @doc Describes the specified Amazon Web Services Systems Manager document
+%% (SSM document).
 describe_document(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_document(Client, Input, []).
@@ -725,11 +779,12 @@ describe_document(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDocument">>, Input, Options).
 
-%% @doc Describes the permissions for a Systems Manager document.
+%% @doc Describes the permissions for a Amazon Web Services Systems Manager
+%% document (SSM document).
 %%
 %% If you created the document, you are the owner. If a document is shared,
-%% it can either be shared privately (by specifying a user's AWS account ID)
-%% or publicly (All).
+%% it can either be shared privately (by specifying a user's Amazon Web
+%% Services account ID) or publicly (All).
 describe_document_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_document_permission(Client, Input, []).
@@ -748,7 +803,7 @@ describe_effective_instance_associations(Client, Input, Options)
 %% @doc Retrieves the current effective patches (the patch and the approval
 %% state) for the specified patch baseline.
 %%
-%% Note that this API applies only to Windows patch baselines.
+%% Applies to patch baselines for Windows only.
 describe_effective_patches_for_patch_baseline(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_effective_patches_for_patch_baseline(Client, Input, []).
@@ -769,13 +824,13 @@ describe_instance_associations_status(Client, Input, Options)
 %% instance, instance status, and so on.
 %%
 %% If you specify one or more instance IDs, it returns information for those
-%% instances. If you do not specify instance IDs, it returns information for
-%% all your instances. If you specify an instance ID that is not valid or an
-%% instance that you do not own, you receive an error.
+%% instances. If you don't specify instance IDs, it returns information for
+%% all your instances. If you specify an instance ID that isn't valid or an
+%% instance that you don't own, you receive an error.
 %%
-%% The IamRole field for this API action is the Amazon Identity and Access
-%% Management (IAM) role assigned to on-premises instances. This call does
-%% not return the IAM role for EC2 instances.
+%% The `IamRole' field for this API operation is the Identity and Access
+%% Management (IAM) role assigned to on-premises instances. This call doesn't
+%% return the IAM role for EC2 instances.
 describe_instance_information(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_instance_information(Client, Input, []).
@@ -866,10 +921,10 @@ describe_maintenance_window_targets(Client, Input, Options)
 
 %% @doc Lists the tasks in a maintenance window.
 %%
-%% For maintenance window tasks without a specified target, you cannot supply
+%% For maintenance window tasks without a specified target, you can't supply
 %% values for `--max-errors' and `--max-concurrency'. Instead, the system
 %% inserts a placeholder value of `1', which may be reported in the response
-%% to this command. These values do not affect the running of your task and
+%% to this command. These values don't affect the running of your task and
 %% can be ignored.
 describe_maintenance_window_tasks(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -878,7 +933,7 @@ describe_maintenance_window_tasks(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeMaintenanceWindowTasks">>, Input, Options).
 
-%% @doc Retrieves the maintenance windows in an AWS account.
+%% @doc Retrieves the maintenance windows in an Amazon Web Services account.
 describe_maintenance_windows(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_maintenance_windows(Client, Input, []).
@@ -897,14 +952,15 @@ describe_maintenance_windows_for_target(Client, Input, Options)
 
 %% @doc Query a set of OpsItems.
 %%
-%% You must have permission in AWS Identity and Access Management (IAM) to
-%% query a list of OpsItems. For more information, see Getting started with
-%% OpsCenter in the AWS Systems Manager User Guide.
+%% You must have permission in Identity and Access Management (IAM) to query
+%% a list of OpsItems. For more information, see Getting started with
+%% OpsCenter in the Amazon Web Services Systems Manager User Guide.
 %%
-%% Operations engineers and IT professionals use OpsCenter to view,
-%% investigate, and remediate operational issues impacting the performance
-%% and health of their AWS resources. For more information, see AWS Systems
-%% Manager OpsCenter in the AWS Systems Manager User Guide.
+%% Operations engineers and IT professionals use Amazon Web Services Systems
+%% Manager OpsCenter to view, investigate, and remediate operational issues
+%% impacting the performance and health of their Amazon Web Services
+%% resources. For more information, see OpsCenter in the Amazon Web Services
+%% Systems Manager User Guide.
 describe_ops_items(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_ops_items(Client, Input, []).
@@ -921,6 +977,11 @@ describe_ops_items(Client, Input, Options)
 %% limit while processing the results, it stops the operation and returns the
 %% matching values up to that point and a `NextToken'. You can specify the
 %% `NextToken' in a subsequent call to get the next set of results.
+%%
+%% If you change the KMS key alias for the KMS key used to encrypt a
+%% parameter, then you must also update the key alias the parameter uses to
+%% reference KMS. Otherwise, `DescribeParameters' retrieves whatever the
+%% original key alias was referencing.
 describe_parameters(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_parameters(Client, Input, []).
@@ -928,7 +989,7 @@ describe_parameters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeParameters">>, Input, Options).
 
-%% @doc Lists the patch baselines in your AWS account.
+%% @doc Lists the patch baselines in your Amazon Web Services account.
 describe_patch_baselines(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_patch_baselines(Client, Input, []).
@@ -936,8 +997,8 @@ describe_patch_baselines(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribePatchBaselines">>, Input, Options).
 
-%% @doc Returns high-level aggregated patch compliance state for a patch
-%% group.
+%% @doc Returns high-level aggregated patch compliance state information for
+%% a patch group.
 describe_patch_group_state(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_patch_group_state(Client, Input, []).
@@ -959,38 +1020,38 @@ describe_patch_groups(Client, Input, Options)
 %% available patches.
 %%
 %% You can use the reported properties in the filters you specify in requests
-%% for actions such as `CreatePatchBaseline', `UpdatePatchBaseline',
+%% for operations such as `CreatePatchBaseline', `UpdatePatchBaseline',
 %% `DescribeAvailablePatches', and `DescribePatchBaselines'.
 %%
 %% The following section lists the properties that can be used in filters for
 %% each major operating system type:
 %%
-%% <dl> <dt>AMAZON_LINUX</dt> <dd> Valid properties: PRODUCT, CLASSIFICATION,
-%% SEVERITY
+%% <dl> <dt>AMAZON_LINUX</dt> <dd> Valid properties: `PRODUCT' |
+%% `CLASSIFICATION' | `SEVERITY'
 %%
-%% </dd> <dt>AMAZON_LINUX_2</dt> <dd> Valid properties: PRODUCT,
-%% CLASSIFICATION, SEVERITY
+%% </dd> <dt>AMAZON_LINUX_2</dt> <dd> Valid properties: `PRODUCT' |
+%% `CLASSIFICATION' | `SEVERITY'
 %%
-%% </dd> <dt>CENTOS</dt> <dd> Valid properties: PRODUCT, CLASSIFICATION,
-%% SEVERITY
+%% </dd> <dt>CENTOS</dt> <dd> Valid properties: `PRODUCT' | `CLASSIFICATION'
+%% | `SEVERITY'
 %%
-%% </dd> <dt>DEBIAN</dt> <dd> Valid properties: PRODUCT, PRIORITY
+%% </dd> <dt>DEBIAN</dt> <dd> Valid properties: `PRODUCT' | `PRIORITY'
 %%
-%% </dd> <dt>MACOS</dt> <dd> Valid properties: PRODUCT, CLASSIFICATION
+%% </dd> <dt>MACOS</dt> <dd> Valid properties: `PRODUCT' | `CLASSIFICATION'
 %%
-%% </dd> <dt>ORACLE_LINUX</dt> <dd> Valid properties: PRODUCT,
-%% CLASSIFICATION, SEVERITY
+%% </dd> <dt>ORACLE_LINUX</dt> <dd> Valid properties: `PRODUCT' |
+%% `CLASSIFICATION' | `SEVERITY'
 %%
-%% </dd> <dt>REDHAT_ENTERPRISE_LINUX</dt> <dd> Valid properties: PRODUCT,
-%% CLASSIFICATION, SEVERITY
+%% </dd> <dt>REDHAT_ENTERPRISE_LINUX</dt> <dd> Valid properties: `PRODUCT' |
+%% `CLASSIFICATION' | `SEVERITY'
 %%
-%% </dd> <dt>SUSE</dt> <dd> Valid properties: PRODUCT, CLASSIFICATION,
-%% SEVERITY
+%% </dd> <dt>SUSE</dt> <dd> Valid properties: `PRODUCT' | `CLASSIFICATION' |
+%% `SEVERITY'
 %%
-%% </dd> <dt>UBUNTU</dt> <dd> Valid properties: PRODUCT, PRIORITY
+%% </dd> <dt>UBUNTU</dt> <dd> Valid properties: `PRODUCT' | `PRIORITY'
 %%
-%% </dd> <dt>WINDOWS</dt> <dd> Valid properties: PRODUCT, PRODUCT_FAMILY,
-%% CLASSIFICATION, MSRC_SEVERITY
+%% </dd> <dt>WINDOWS</dt> <dd> Valid properties: `PRODUCT' | `PRODUCT_FAMILY'
+%% | `CLASSIFICATION' | `MSRC_SEVERITY'
 %%
 %% </dd> </dl>
 describe_patch_properties(Client, Input)
@@ -1009,6 +1070,18 @@ describe_sessions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeSessions">>, Input, Options).
 
+%% @doc Deletes the association between an OpsItem and a related item.
+%%
+%% For example, this API operation can delete an Incident Manager incident
+%% from an OpsItem. Incident Manager is a capability of Amazon Web Services
+%% Systems Manager.
+disassociate_ops_item_related_item(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    disassociate_ops_item_related_item(Client, Input, []).
+disassociate_ops_item_related_item(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DisassociateOpsItemRelatedItem">>, Input, Options).
+
 %% @doc Get detailed information about a particular Automation execution.
 get_automation_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1017,22 +1090,23 @@ get_automation_execution(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetAutomationExecution">>, Input, Options).
 
-%% @doc Gets the state of the AWS Systems Manager Change Calendar at an
-%% optional, specified time.
+%% @doc Gets the state of a Amazon Web Services Systems Manager change
+%% calendar at the current time or a specified time.
 %%
 %% If you specify a time, `GetCalendarState' returns the state of the
-%% calendar at a specific time, and returns the next time that the Change
-%% Calendar state will transition. If you do not specify a time,
-%% `GetCalendarState' assumes the current time. Change Calendar entries have
-%% two possible states: `OPEN' or `CLOSED'.
+%% calendar at that specific time, and returns the next time that the change
+%% calendar state will transition. If you don't specify a time,
+%% `GetCalendarState' uses the current time. Change Calendar entries have two
+%% possible states: `OPEN' or `CLOSED'.
 %%
 %% If you specify more than one calendar in a request, the command returns
 %% the status of `OPEN' only if all calendars in the request are open. If one
 %% or more calendars in the request are closed, the status returned is
 %% `CLOSED'.
 %%
-%% For more information about Systems Manager Change Calendar, see AWS
-%% Systems Manager Change Calendar in the AWS Systems Manager User Guide.
+%% For more information about Change Calendar, a capability of Amazon Web
+%% Services Systems Manager, see Amazon Web Services Systems Manager Change
+%% Calendar in the Amazon Web Services Systems Manager User Guide.
 get_calendar_state(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_calendar_state(Client, Input, []).
@@ -1042,6 +1116,11 @@ get_calendar_state(Client, Input, Options)
 
 %% @doc Returns detailed information about command execution for an
 %% invocation or plugin.
+%%
+%% `GetCommandInvocation' only gives the execution status of a plugin in a
+%% document. To get the command execution status on a specific instance, use
+%% `ListCommandInvocations'. To get the command execution status across
+%% instances, use `ListCommands'.
 get_command_invocation(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_command_invocation(Client, Input, []).
@@ -1061,12 +1140,12 @@ get_connection_status(Client, Input, Options)
 
 %% @doc Retrieves the default patch baseline.
 %%
-%% Note that Systems Manager supports creating multiple default patch
-%% baselines. For example, you can create a default patch baseline for each
-%% operating system.
+%% Amazon Web Services Systems Manager supports creating multiple default
+%% patch baselines. For example, you can create a default patch baseline for
+%% each operating system.
 %%
-%% If you do not specify an operating system value, the default patch
-%% baseline for Windows is returned.
+%% If you don't specify an operating system value, the default patch baseline
+%% for Windows is returned.
 get_default_patch_baseline(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_default_patch_baseline(Client, Input, []).
@@ -1077,8 +1156,17 @@ get_default_patch_baseline(Client, Input, Options)
 %% @doc Retrieves the current snapshot for the patch baseline the instance
 %% uses.
 %%
-%% This API is primarily used by the AWS-RunPatchBaseline Systems Manager
-%% document.
+%% This API is primarily used by the `AWS-RunPatchBaseline' Systems Manager
+%% document (SSM document).
+%%
+%% If you run the command locally, such as with the Command Line Interface
+%% (CLI), the system attempts to use your local Amazon Web Services
+%% credentials and the operation fails. To avoid this, you can run the
+%% command in the Amazon Web Services Systems Manager console. Use Run
+%% Command, a capability of Amazon Web Services Systems Manager, with an SSM
+%% document that enables you to target an instance with a script or command.
+%% For example, run the command using the `AWS-RunShellScript' document or
+%% the `AWS-RunPowerShellScript' document.
 get_deployable_patch_snapshot_for_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_deployable_patch_snapshot_for_instance(Client, Input, []).
@@ -1086,7 +1174,8 @@ get_deployable_patch_snapshot_for_instance(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetDeployablePatchSnapshotForInstance">>, Input, Options).
 
-%% @doc Gets the contents of the specified Systems Manager document.
+%% @doc Gets the contents of the specified Amazon Web Services Systems
+%% Manager document (SSM document).
 get_document(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_document(Client, Input, []).
@@ -1095,6 +1184,8 @@ get_document(Client, Input, Options)
     request(Client, <<"GetDocument">>, Input, Options).
 
 %% @doc Query inventory information.
+%%
+%% This includes instance status, such as `Stopped' or `Terminated'.
 get_inventory(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_inventory(Client, Input, []).
@@ -1147,10 +1238,10 @@ get_maintenance_window_execution_task_invocation(Client, Input, Options)
 
 %% @doc Lists the tasks in a maintenance window.
 %%
-%% For maintenance window tasks without a specified target, you cannot supply
+%% For maintenance window tasks without a specified target, you can't supply
 %% values for `--max-errors' and `--max-concurrency'. Instead, the system
 %% inserts a placeholder value of `1', which may be reported in the response
-%% to this command. These values do not affect the running of your task and
+%% to this command. These values don't affect the running of your task and
 %% can be ignored.
 get_maintenance_window_task(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1161,14 +1252,15 @@ get_maintenance_window_task(Client, Input, Options)
 
 %% @doc Get information about an OpsItem by using the ID.
 %%
-%% You must have permission in AWS Identity and Access Management (IAM) to
-%% view information about an OpsItem. For more information, see Getting
-%% started with OpsCenter in the AWS Systems Manager User Guide.
+%% You must have permission in Identity and Access Management (IAM) to view
+%% information about an OpsItem. For more information, see Getting started
+%% with OpsCenter in the Amazon Web Services Systems Manager User Guide.
 %%
-%% Operations engineers and IT professionals use OpsCenter to view,
-%% investigate, and remediate operational issues impacting the performance
-%% and health of their AWS resources. For more information, see AWS Systems
-%% Manager OpsCenter in the AWS Systems Manager User Guide.
+%% Operations engineers and IT professionals use Amazon Web Services Systems
+%% Manager OpsCenter to view, investigate, and remediate operational issues
+%% impacting the performance and health of their Amazon Web Services
+%% resources. For more information, see OpsCenter in the Amazon Web Services
+%% Systems Manager User Guide.
 get_ops_item(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ops_item(Client, Input, []).
@@ -1185,8 +1277,13 @@ get_ops_metadata(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetOpsMetadata">>, Input, Options).
 
-%% @doc View a summary of OpsItems based on specified filters and
-%% aggregators.
+%% @doc View a summary of operations metadata (OpsData) based on specified
+%% filters and aggregators.
+%%
+%% OpsData can include information about Amazon Web Services Systems Manager
+%% OpsCenter operational workitems (OpsItems) as well as information about
+%% any Amazon Web Services resource or service configured to report OpsData
+%% to Amazon Web Services Systems Manager Explorer.
 get_ops_summary(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_ops_summary(Client, Input, []).
@@ -1194,9 +1291,11 @@ get_ops_summary(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetOpsSummary">>, Input, Options).
 
-%% @doc Get information about a parameter by using the parameter name.
+%% @doc Get information about a single parameter by specifying the parameter
+%% name.
 %%
-%% Don't confuse this API action with the `GetParameters' API action.
+%% To get information about more than one parameter at a time, use the
+%% `GetParameters' operation.
 get_parameter(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_parameter(Client, Input, []).
@@ -1205,6 +1304,11 @@ get_parameter(Client, Input, Options)
     request(Client, <<"GetParameter">>, Input, Options).
 
 %% @doc Retrieves the history of all changes to a parameter.
+%%
+%% If you change the KMS key alias for the KMS key used to encrypt a
+%% parameter, then you must also update the key alias the parameter uses to
+%% reference KMS. Otherwise, `GetParameterHistory' retrieves whatever the
+%% original key alias was referencing.
 get_parameter_history(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_parameter_history(Client, Input, []).
@@ -1212,9 +1316,11 @@ get_parameter_history(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetParameterHistory">>, Input, Options).
 
-%% @doc Get details of a parameter.
+%% @doc Get information about one or more parameters by specifying multiple
+%% parameter names.
 %%
-%% Don't confuse this API action with the `GetParameter' API action.
+%% To get information about a single parameter, you can use the
+%% `GetParameter' operation instead.
 get_parameters(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_parameters(Client, Input, []).
@@ -1256,24 +1362,25 @@ get_patch_baseline_for_patch_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetPatchBaselineForPatchGroup">>, Input, Options).
 
-%% @doc `ServiceSetting' is an account-level setting for an AWS service.
+%% @doc `ServiceSetting' is an account-level setting for an Amazon Web
+%% Services service.
 %%
 %% This setting defines how a user interacts with or uses a service or a
-%% feature of a service. For example, if an AWS service charges money to the
-%% account based on feature or service usage, then the AWS service team might
-%% create a default setting of "false". This means the user can't use this
-%% feature unless they change the setting to "true" and intentionally opt in
-%% for a paid feature.
+%% feature of a service. For example, if an Amazon Web Services service
+%% charges money to the account based on feature or service usage, then the
+%% Amazon Web Services service team might create a default setting of
+%% `false'. This means the user can't use this feature unless they change the
+%% setting to `true' and intentionally opt in for a paid feature.
 %%
-%% Services map a `SettingId' object to a setting value. AWS services teams
-%% define the default value for a `SettingId'. You can't create a new
-%% `SettingId', but you can overwrite the default value if you have the
-%% `ssm:UpdateServiceSetting' permission for the setting. Use the
-%% `UpdateServiceSetting' API action to change the default setting. Or use
+%% Services map a `SettingId' object to a setting value. Amazon Web Services
+%% services teams define the default value for a `SettingId'. You can't
+%% create a new `SettingId', but you can overwrite the default value if you
+%% have the `ssm:UpdateServiceSetting' permission for the setting. Use the
+%% `UpdateServiceSetting' API operation to change the default setting. Or use
 %% the `ResetServiceSetting' to change the value back to the original value
-%% defined by the AWS service team.
+%% defined by the Amazon Web Services service team.
 %%
-%% Query the current service setting for the account.
+%% Query the current service setting for the Amazon Web Services account.
 get_service_setting(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_service_setting(Client, Input, []).
@@ -1284,9 +1391,10 @@ get_service_setting(Client, Input, Options)
 %% @doc A parameter label is a user-defined alias to help you manage
 %% different versions of a parameter.
 %%
-%% When you modify a parameter, Systems Manager automatically saves a new
-%% version and increments the version number by one. A label can help you
-%% remember the purpose of a parameter when there are multiple versions.
+%% When you modify a parameter, Amazon Web Services Systems Manager
+%% automatically saves a new version and increments the version number by
+%% one. A label can help you remember the purpose of a parameter when there
+%% are multiple versions.
 %%
 %% Parameter labels have the following requirements and restrictions.
 %%
@@ -1302,19 +1410,18 @@ get_service_setting(Client, Input, Options)
 %% </li> <li> You can't create a label when you create a new parameter. You
 %% must attach a label to a specific version of a parameter.
 %%
-%% </li> <li> You can't delete a parameter label. If you no longer want to
-%% use a parameter label, then you must move it to a different version of a
-%% parameter.
+%% </li> <li> If you no longer want to use a parameter label, then you can
+%% either delete it or move it to a different version of a parameter.
 %%
 %% </li> <li> A label can have a maximum of 100 characters.
 %%
 %% </li> <li> Labels can contain letters (case sensitive), numbers, periods
 %% (.), hyphens (-), or underscores (_).
 %%
-%% </li> <li> Labels can't begin with a number, "aws," or "ssm" (not case
-%% sensitive). If a label fails to meet these requirements, then the label is
-%% not associated with a parameter and the system displays it in the list of
-%% InvalidLabels.
+%% </li> <li> Labels can't begin with a number, "`aws'" or "`ssm'" (not case
+%% sensitive). If a label fails to meet these requirements, then the label
+%% isn't associated with a parameter and the system displays it in the list
+%% of InvalidLabels.
 %%
 %% </li> </ul>
 label_parameter_version(Client, Input)
@@ -1333,11 +1440,12 @@ list_association_versions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAssociationVersions">>, Input, Options).
 
-%% @doc Returns all State Manager associations in the current AWS account and
-%% Region.
+%% @doc Returns all State Manager associations in the current Amazon Web
+%% Services account and Amazon Web Services Region.
 %%
 %% You can limit the results to a specific State Manager association document
-%% or instance by specifying a filter.
+%% or instance by specifying a filter. State Manager is a capability of
+%% Amazon Web Services Systems Manager.
 list_associations(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_associations(Client, Input, []).
@@ -1348,9 +1456,9 @@ list_associations(Client, Input, Options)
 %% @doc An invocation is copy of a command sent to a specific instance.
 %%
 %% A command can apply to one or more instances. A command invocation applies
-%% to one instance. For example, if a user runs SendCommand against three
+%% to one instance. For example, if a user runs `SendCommand' against three
 %% instances, then a command invocation is created for each requested
-%% instance ID. ListCommandInvocations provide status about command
+%% instance ID. `ListCommandInvocations' provide status about command
 %% execution.
 list_command_invocations(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1359,7 +1467,8 @@ list_command_invocations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListCommandInvocations">>, Input, Options).
 
-%% @doc Lists the commands requested by users of the AWS account.
+%% @doc Lists the commands requested by users of the Amazon Web Services
+%% account.
 list_commands(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_commands(Client, Input, []).
@@ -1367,7 +1476,7 @@ list_commands(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListCommands">>, Input, Options).
 
-%% @doc For a specified resource ID, this API action returns a list of
+%% @doc For a specified resource ID, this API operation returns a list of
 %% compliance statuses for different resource types.
 %%
 %% Currently, you can only specify one resource ID per call. List results
@@ -1391,7 +1500,8 @@ list_compliance_summaries(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListComplianceSummaries">>, Input, Options).
 
-%% @doc Information about approval reviews for a version of an SSM document.
+%% @doc Information about approval reviews for a version of a change template
+%% in Change Manager.
 list_document_metadata_history(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_document_metadata_history(Client, Input, []).
@@ -1407,8 +1517,8 @@ list_document_versions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListDocumentVersions">>, Input, Options).
 
-%% @doc Returns all Systems Manager (SSM) documents in the current AWS
-%% account and Region.
+%% @doc Returns all Systems Manager (SSM) documents in the current Amazon Web
+%% Services account and Amazon Web Services Region.
 %%
 %% You can limit the results of this request by using a filter.
 list_documents(Client, Input)
@@ -1426,8 +1536,8 @@ list_inventory_entries(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListInventoryEntries">>, Input, Options).
 
-%% @doc Returns a list of all OpsItem events in the current AWS account and
-%% Region.
+%% @doc Returns a list of all OpsItem events in the current Amazon Web
+%% Services Region and Amazon Web Services account.
 %%
 %% You can limit the results to events associated with specific OpsItems by
 %% specifying a filter.
@@ -1438,8 +1548,19 @@ list_ops_item_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListOpsItemEvents">>, Input, Options).
 
-%% @doc Systems Manager calls this API action when displaying all Application
-%% Manager OpsMetadata objects or blobs.
+%% @doc Lists all related-item resources associated with a Systems Manager
+%% OpsCenter OpsItem.
+%%
+%% OpsCenter is a capability of Amazon Web Services Systems Manager.
+list_ops_item_related_items(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_ops_item_related_items(Client, Input, []).
+list_ops_item_related_items(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListOpsItemRelatedItems">>, Input, Options).
+
+%% @doc Amazon Web Services Systems Manager calls this API operation when
+%% displaying all Application Manager OpsMetadata objects or blobs.
 list_ops_metadata(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_ops_metadata(Client, Input, []).
@@ -1479,6 +1600,9 @@ list_resource_data_sync(Client, Input, Options)
     request(Client, <<"ListResourceDataSync">>, Input, Options).
 
 %% @doc Returns a list of the tags assigned to the specified resource.
+%%
+%% For information about the ID format for each supported resource type, see
+%% `AddTagsToResource'.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -1486,11 +1610,12 @@ list_tags_for_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListTagsForResource">>, Input, Options).
 
-%% @doc Shares a Systems Manager document publicly or privately.
+%% @doc Shares a Amazon Web Services Systems Manager document (SSM
+%% document)publicly or privately.
 %%
-%% If you share a document privately, you must specify the AWS user account
-%% IDs for those people who can use the document. If you share a document
-%% publicly, you must specify All as the account ID.
+%% If you share a document privately, you must specify the Amazon Web
+%% Services user account IDs for those people who can use the document. If
+%% you share a document publicly, you must specify All as the account ID.
 modify_document_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     modify_document_permission(Client, Input, []).
@@ -1501,10 +1626,10 @@ modify_document_permission(Client, Input, Options)
 %% @doc Registers a compliance type and other compliance details on a
 %% designated resource.
 %%
-%% This action lets you register custom compliance details with a resource.
-%% This call overwrites existing compliance information on the resource, so
-%% you must provide a full list of compliance items each time that you send
-%% the request.
+%% This operation lets you register custom compliance details with a
+%% resource. This call overwrites existing compliance information on the
+%% resource, so you must provide a full list of compliance items each time
+%% that you send the request.
 %%
 %% ComplianceType can be one of the following:
 %%
@@ -1525,8 +1650,8 @@ modify_document_permission(Client, Input, Options)
 %%
 %% </li> <li> Severity: A patch severity. For example, `critical'.
 %%
-%% </li> <li> DocumentName: A SSM document name. For example,
-%% AWS-RunPatchBaseline.
+%% </li> <li> DocumentName: An SSM document name. For example,
+%% `AWS-RunPatchBaseline'.
 %%
 %% </li> <li> DocumentVersion: An SSM document version number. For example,
 %% 4.
@@ -1576,9 +1701,9 @@ put_parameter(Client, Input, Options)
 
 %% @doc Defines the default patch baseline for the relevant operating system.
 %%
-%% To reset the AWS predefined patch baseline as the default, specify the
-%% full patch baseline ARN as the baseline ID value. For example, for CentOS,
-%% specify
+%% To reset the Amazon Web Services-predefined patch baseline as the default,
+%% specify the full patch baseline Amazon Resource Name (ARN) as the baseline
+%% ID value. For example, for CentOS, specify
 %% `arn:aws:ssm:us-east-2:733109147000:patchbaseline/pb-0574b43a65ea646ed'
 %% instead of `pb-0574b43a65ea646ed'.
 register_default_patch_baseline(Client, Input)
@@ -1620,24 +1745,25 @@ remove_tags_from_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"RemoveTagsFromResource">>, Input, Options).
 
-%% @doc `ServiceSetting' is an account-level setting for an AWS service.
+%% @doc `ServiceSetting' is an account-level setting for an Amazon Web
+%% Services service.
 %%
 %% This setting defines how a user interacts with or uses a service or a
-%% feature of a service. For example, if an AWS service charges money to the
-%% account based on feature or service usage, then the AWS service team might
-%% create a default setting of "false". This means the user can't use this
-%% feature unless they change the setting to "true" and intentionally opt in
-%% for a paid feature.
+%% feature of a service. For example, if an Amazon Web Services service
+%% charges money to the account based on feature or service usage, then the
+%% Amazon Web Services service team might create a default setting of
+%% "false". This means the user can't use this feature unless they change the
+%% setting to "true" and intentionally opt in for a paid feature.
 %%
-%% Services map a `SettingId' object to a setting value. AWS services teams
-%% define the default value for a `SettingId'. You can't create a new
-%% `SettingId', but you can overwrite the default value if you have the
-%% `ssm:UpdateServiceSetting' permission for the setting. Use the
-%% `GetServiceSetting' API action to view the current value. Use the
-%% `UpdateServiceSetting' API action to change the default setting.
+%% Services map a `SettingId' object to a setting value. Amazon Web Services
+%% services teams define the default value for a `SettingId'. You can't
+%% create a new `SettingId', but you can overwrite the default value if you
+%% have the `ssm:UpdateServiceSetting' permission for the setting. Use the
+%% `GetServiceSetting' API operation to view the current value. Use the
+%% `UpdateServiceSetting' API operation to change the default setting.
 %%
 %% Reset the service setting for the account to the default value as
-%% provisioned by the AWS service team.
+%% provisioned by the Amazon Web Services service team.
 reset_service_setting(Client, Input)
   when is_map(Client), is_map(Input) ->
     reset_service_setting(Client, Input, []).
@@ -1651,7 +1777,7 @@ reset_service_setting(Client, Input, Options)
 %% sessions.
 %%
 %% This command is primarily for use by client machines to automatically
-%% reconnect during intermittent network issues. It is not intended for any
+%% reconnect during intermittent network issues. It isn't intended for any
 %% other use.
 resume_session(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1677,10 +1803,9 @@ send_command(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"SendCommand">>, Input, Options).
 
-%% @doc Use this API action to run an association immediately and only one
-%% time.
+%% @doc Runs an association immediately and only one time.
 %%
-%% This action can be helpful when troubleshooting associations.
+%% This operation can be helpful when troubleshooting associations.
 start_associations_once(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_associations_once(Client, Input, []).
@@ -1688,7 +1813,7 @@ start_associations_once(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartAssociationsOnce">>, Input, Options).
 
-%% @doc Initiates execution of an Automation document.
+%% @doc Initiates execution of an Automation runbook.
 start_automation_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_automation_execution(Client, Input, []).
@@ -1698,9 +1823,8 @@ start_automation_execution(Client, Input, Options)
 
 %% @doc Creates a change request for Change Manager.
 %%
-%% The runbooks (Automation documents) specified in the change request run
-%% only after all required approvals for the change request have been
-%% received.
+%% The Automation runbooks specified in the change request run only after all
+%% required approvals for the change request have been received.
 start_change_request_execution(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_change_request_execution(Client, Input, []).
@@ -1714,13 +1838,15 @@ start_change_request_execution(Client, Input, Options)
 %% Returns a URL and token that can be used to open a WebSocket connection
 %% for sending input and receiving outputs.
 %%
-%% AWS CLI usage: `start-session' is an interactive command that requires the
-%% Session Manager plugin to be installed on the client machine making the
-%% call. For information, see Install the Session Manager plugin for the AWS
-%% CLI in the AWS Systems Manager User Guide.
+%% Amazon Web Services CLI usage: `start-session' is an interactive command
+%% that requires the Session Manager plugin to be installed on the client
+%% machine making the call. For information, see Install the Session Manager
+%% plugin for the Amazon Web Services CLI in the Amazon Web Services Systems
+%% Manager User Guide.
 %%
-%% AWS Tools for PowerShell usage: Start-SSMSession is not currently
-%% supported by AWS Tools for PowerShell on Windows local machines.
+%% Amazon Web Services Tools for PowerShell usage: Start-SSMSession isn't
+%% currently supported by Amazon Web Services Tools for PowerShell on Windows
+%% local machines.
 start_session(Client, Input)
   when is_map(Client), is_map(Input) ->
     start_session(Client, Input, []).
@@ -1739,7 +1865,7 @@ stop_automation_execution(Client, Input, Options)
 %% @doc Permanently ends a session and closes the data connection between the
 %% Session Manager client and SSM Agent on the instance.
 %%
-%% A terminated session cannot be resumed.
+%% A terminated session isn't be resumed.
 terminate_session(Client, Input)
   when is_map(Client), is_map(Input) ->
     terminate_session(Client, Input, []).
@@ -1747,18 +1873,27 @@ terminate_session(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TerminateSession">>, Input, Options).
 
+%% @doc Remove a label or labels from a parameter.
+unlabel_parameter_version(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    unlabel_parameter_version(Client, Input, []).
+unlabel_parameter_version(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UnlabelParameterVersion">>, Input, Options).
+
 %% @doc Updates an association.
 %%
 %% You can update the association name and version, the document version,
-%% schedule, parameters, and Amazon S3 output.
+%% schedule, parameters, and Amazon Simple Storage Service (Amazon S3)
+%% output.
 %%
-%% In order to call this API action, your IAM user account, group, or role
-%% must be configured with permission to call the `DescribeAssociation' API
-%% action. If you don't have permission to call DescribeAssociation, then you
-%% receive the following error: `An error occurred (AccessDeniedException)
-%% when calling the UpdateAssociation operation: User: <user_arn> is not
-%% authorized to perform: ssm:DescribeAssociation on resource:
-%% <resource_arn>'
+%% In order to call this API operation, your Identity and Access Management
+%% (IAM) user account, group, or role must be configured with permission to
+%% call the `DescribeAssociation' API operation. If you don't have permission
+%% to call `DescribeAssociation', then you receive the following error: `An
+%% error occurred (AccessDeniedException) when calling the UpdateAssociation
+%% operation: User: <user_arn> isn't authorized to perform:
+%% ssm:DescribeAssociation on resource: <resource_arn>'
 %%
 %% When you update an association, the association immediately runs against
 %% the specified targets.
@@ -1769,8 +1904,13 @@ update_association(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateAssociation">>, Input, Options).
 
-%% @doc Updates the status of the Systems Manager document associated with
-%% the specified instance.
+%% @doc Updates the status of the Amazon Web Services Systems Manager
+%% document (SSM document) associated with the specified instance.
+%%
+%% `UpdateAssociationStatus' is primarily used by the Amazon Web Services
+%% Systems Manager Agent (SSM Agent) to report status updates about your
+%% associations and is only used for associations created with the
+%% `InstanceId' legacy parameter.
 update_association_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_association_status(Client, Input, []).
@@ -1795,7 +1935,7 @@ update_document_default_version(Client, Input, Options)
     request(Client, <<"UpdateDocumentDefaultVersion">>, Input, Options).
 
 %% @doc Updates information related to approval reviews for a specific
-%% version of a document.
+%% version of a change template in Change Manager.
 update_document_metadata(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_document_metadata(Client, Input, []).
@@ -1838,7 +1978,7 @@ update_maintenance_window(Client, Input, Options)
 %% types are ID target, Tag target, and resource group. For more information,
 %% see `Target'.
 %%
-%% </li> </ul> If a parameter is null, then the corresponding field is not
+%% </li> </ul> If a parameter is null, then the corresponding field isn't
 %% modified.
 update_maintenance_window_target(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -1851,36 +1991,36 @@ update_maintenance_window_target(Client, Input, Options)
 %%
 %% You can't change the task type, but you can change the following values:
 %%
-%% <ul> <li> TaskARN. For example, you can change a RUN_COMMAND task from
-%% AWS-RunPowerShellScript to AWS-RunShellScript.
+%% <ul> <li> `TaskARN'. For example, you can change a `RUN_COMMAND' task from
+%% `AWS-RunPowerShellScript' to `AWS-RunShellScript'.
 %%
-%% </li> <li> ServiceRoleArn
+%% </li> <li> `ServiceRoleArn'
 %%
-%% </li> <li> TaskInvocationParameters
+%% </li> <li> `TaskInvocationParameters'
 %%
-%% </li> <li> Priority
+%% </li> <li> `Priority'
 %%
-%% </li> <li> MaxConcurrency
+%% </li> <li> `MaxConcurrency'
 %%
-%% </li> <li> MaxErrors
+%% </li> <li> `MaxErrors'
 %%
 %% </li> </ul> One or more targets must be specified for maintenance window
 %% Run Command-type tasks. Depending on the task, targets are optional for
-%% other maintenance window task types (Automation, AWS Lambda, and AWS Step
-%% Functions). For more information about running tasks that do not specify
+%% other maintenance window task types (Automation, Lambda, and Step
+%% Functions). For more information about running tasks that don't specify
 %% targets, see Registering maintenance window tasks without targets in the
-%% AWS Systems Manager User Guide.
+%% Amazon Web Services Systems Manager User Guide.
 %%
 %% If the value for a parameter in `UpdateMaintenanceWindowTask' is null,
-%% then the corresponding field is not modified. If you set `Replace' to
-%% true, then all fields required by the `RegisterTaskWithMaintenanceWindow'
-%% action are required for this request. Optional fields that aren't
+%% then the corresponding field isn't modified. If you set `Replace' to true,
+%% then all fields required by the `RegisterTaskWithMaintenanceWindow'
+%% operation are required for this request. Optional fields that aren't
 %% specified are set to null.
 %%
 %% When you update a maintenance window task that has options specified in
 %% `TaskInvocationParameters', you must provide again all the
 %% `TaskInvocationParameters' values that you want to retain. The values you
-%% do not specify again are removed. For example, suppose that when you
+%% don't specify again are removed. For example, suppose that when you
 %% registered a Run Command task, you specified `TaskInvocationParameters'
 %% values for `Comment', `NotificationConfig', and `OutputS3BucketName'. If
 %% you update the maintenance window task and specify only a different
@@ -1893,7 +2033,7 @@ update_maintenance_window_task(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateMaintenanceWindowTask">>, Input, Options).
 
-%% @doc Changes the Amazon Identity and Access Management (IAM) role that is
+%% @doc Changes the Identity and Access Management (IAM) role that is
 %% assigned to the on-premises instance or virtual machines (VM).
 %%
 %% IAM roles are first assigned to these hybrid instances during the
@@ -1907,14 +2047,15 @@ update_managed_instance_role(Client, Input, Options)
 
 %% @doc Edit or change an OpsItem.
 %%
-%% You must have permission in AWS Identity and Access Management (IAM) to
-%% update an OpsItem. For more information, see Getting started with
-%% OpsCenter in the AWS Systems Manager User Guide.
+%% You must have permission in Identity and Access Management (IAM) to update
+%% an OpsItem. For more information, see Getting started with OpsCenter in
+%% the Amazon Web Services Systems Manager User Guide.
 %%
-%% Operations engineers and IT professionals use OpsCenter to view,
-%% investigate, and remediate operational issues impacting the performance
-%% and health of their AWS resources. For more information, see AWS Systems
-%% Manager OpsCenter in the AWS Systems Manager User Guide.
+%% Operations engineers and IT professionals use Amazon Web Services Systems
+%% Manager OpsCenter to view, investigate, and remediate operational issues
+%% impacting the performance and health of their Amazon Web Services
+%% resources. For more information, see OpsCenter in the Amazon Web Services
+%% Systems Manager User Guide.
 update_ops_item(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_ops_item(Client, Input, []).
@@ -1922,8 +2063,8 @@ update_ops_item(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateOpsItem">>, Input, Options).
 
-%% @doc Systems Manager calls this API action when you edit OpsMetadata in
-%% Application Manager.
+%% @doc Amazon Web Services Systems Manager calls this API operation when you
+%% edit OpsMetadata in Application Manager.
 update_ops_metadata(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_ops_metadata(Client, Input, []).
@@ -1935,8 +2076,8 @@ update_ops_metadata(Client, Input, Options)
 %%
 %% Fields not specified in the request are left unchanged.
 %%
-%% For information about valid key and value pairs in `PatchFilters' for each
-%% supported operating system type, see PatchFilter.
+%% For information about valid key-value pairs in `PatchFilters' for each
+%% supported operating system type, see `PatchFilter'.
 update_patch_baseline(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_patch_baseline(Client, Input, []).
@@ -1948,13 +2089,13 @@ update_patch_baseline(Client, Input, Options)
 %%
 %% After you create a resource data sync for a Region, you can't change the
 %% account options for that sync. For example, if you create a sync in the
-%% us-east-2 (Ohio) Region and you choose the Include only the current
-%% account option, you can't edit that sync later and choose the Include all
-%% accounts from my AWS Organizations configuration option. Instead, you must
-%% delete the first resource data sync, and create a new one.
+%% us-east-2 (Ohio) Region and you choose the `Include only the current
+%% account' option, you can't edit that sync later and choose the `Include
+%% all accounts from my Organizations configuration' option. Instead, you
+%% must delete the first resource data sync, and create a new one.
 %%
-%% This API action only supports a resource data sync that was created with a
-%% SyncFromSource `SyncType'.
+%% This API operation only supports a resource data sync that was created
+%% with a SyncFromSource `SyncType'.
 update_resource_data_sync(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_resource_data_sync(Client, Input, []).
@@ -1962,22 +2103,23 @@ update_resource_data_sync(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateResourceDataSync">>, Input, Options).
 
-%% @doc `ServiceSetting' is an account-level setting for an AWS service.
+%% @doc `ServiceSetting' is an account-level setting for an Amazon Web
+%% Services service.
 %%
 %% This setting defines how a user interacts with or uses a service or a
-%% feature of a service. For example, if an AWS service charges money to the
-%% account based on feature or service usage, then the AWS service team might
-%% create a default setting of "false". This means the user can't use this
-%% feature unless they change the setting to "true" and intentionally opt in
-%% for a paid feature.
+%% feature of a service. For example, if an Amazon Web Services service
+%% charges money to the account based on feature or service usage, then the
+%% Amazon Web Services service team might create a default setting of
+%% "false". This means the user can't use this feature unless they change the
+%% setting to "true" and intentionally opt in for a paid feature.
 %%
-%% Services map a `SettingId' object to a setting value. AWS services teams
-%% define the default value for a `SettingId'. You can't create a new
-%% `SettingId', but you can overwrite the default value if you have the
-%% `ssm:UpdateServiceSetting' permission for the setting. Use the
-%% `GetServiceSetting' API action to view the current value. Or, use the
+%% Services map a `SettingId' object to a setting value. Amazon Web Services
+%% services teams define the default value for a `SettingId'. You can't
+%% create a new `SettingId', but you can overwrite the default value if you
+%% have the `ssm:UpdateServiceSetting' permission for the setting. Use the
+%% `GetServiceSetting' API operation to view the current value. Or, use the
 %% `ResetServiceSetting' to change the value back to the original value
-%% defined by the AWS service team.
+%% defined by the Amazon Web Services service team.
 %%
 %% Update the service setting for the account.
 update_service_setting(Client, Input)

--- a/src/aws_ssm_contacts.erl
+++ b/src/aws_ssm_contacts.erl
@@ -1,0 +1,386 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Systems Manager Incident Manager is an incident management console
+%% designed to help users mitigate and recover from incidents affecting their
+%% Amazon Web Services-hosted applications.
+%%
+%% An incident is any unplanned interruption or reduction in quality of
+%% services.
+%%
+%% Incident Manager increases incident resolution by notifying responders of
+%% impact, highlighting relevant troubleshooting data, and providing
+%% collaboration tools to get services back up and running. To achieve the
+%% primary goal of reducing the time-to-resolution of critical incidents,
+%% Incident Manager automates response plans and enables responder team
+%% escalation.
+-module(aws_ssm_contacts).
+
+-export([accept_page/2,
+         accept_page/3,
+         activate_contact_channel/2,
+         activate_contact_channel/3,
+         create_contact/2,
+         create_contact/3,
+         create_contact_channel/2,
+         create_contact_channel/3,
+         deactivate_contact_channel/2,
+         deactivate_contact_channel/3,
+         delete_contact/2,
+         delete_contact/3,
+         delete_contact_channel/2,
+         delete_contact_channel/3,
+         describe_engagement/2,
+         describe_engagement/3,
+         describe_page/2,
+         describe_page/3,
+         get_contact/2,
+         get_contact/3,
+         get_contact_channel/2,
+         get_contact_channel/3,
+         get_contact_policy/2,
+         get_contact_policy/3,
+         list_contact_channels/2,
+         list_contact_channels/3,
+         list_contacts/2,
+         list_contacts/3,
+         list_engagements/2,
+         list_engagements/3,
+         list_page_receipts/2,
+         list_page_receipts/3,
+         list_pages_by_contact/2,
+         list_pages_by_contact/3,
+         list_pages_by_engagement/2,
+         list_pages_by_engagement/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         put_contact_policy/2,
+         put_contact_policy/3,
+         send_activation_code/2,
+         send_activation_code/3,
+         start_engagement/2,
+         start_engagement/3,
+         stop_engagement/2,
+         stop_engagement/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_contact/2,
+         update_contact/3,
+         update_contact_channel/2,
+         update_contact_channel/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Used to acknowledge an engagement to a contact channel during an
+%% incident.
+accept_page(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    accept_page(Client, Input, []).
+accept_page(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AcceptPage">>, Input, Options).
+
+%% @doc Activates a contact's contact channel.
+%%
+%% Incident Manager can't engage a contact until the contact channel has been
+%% activated.
+activate_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    activate_contact_channel(Client, Input, []).
+activate_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ActivateContactChannel">>, Input, Options).
+
+%% @doc Contacts are either the contacts that Incident Manager engages during
+%% an incident or the escalation plans that Incident Manager uses to engage
+%% contacts in phases during an incident.
+create_contact(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_contact(Client, Input, []).
+create_contact(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateContact">>, Input, Options).
+
+%% @doc A contact channel is the method that Incident Manager uses to engage
+%% your contact.
+create_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_contact_channel(Client, Input, []).
+create_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateContactChannel">>, Input, Options).
+
+%% @doc To no longer receive Incident Manager engagements to a contact
+%% channel, you can deactivate the channel.
+deactivate_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    deactivate_contact_channel(Client, Input, []).
+deactivate_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeactivateContactChannel">>, Input, Options).
+
+%% @doc To remove a contact from Incident Manager, you can delete the
+%% contact.
+%%
+%% Deleting a contact removes them from all escalation plans and related
+%% response plans. Deleting an escalation plan removes it from all related
+%% response plans. You will have to recreate the contact and its contact
+%% channels before you can use it again.
+delete_contact(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_contact(Client, Input, []).
+delete_contact(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteContact">>, Input, Options).
+
+%% @doc To no longer receive engagements on a contact channel, you can delete
+%% the channel from a contact.
+%%
+%% Deleting the contact channel removes it from the contact's engagement
+%% plan. If you delete the only contact channel for a contact, you won't be
+%% able to engage that contact during an incident.
+delete_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_contact_channel(Client, Input, []).
+delete_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteContactChannel">>, Input, Options).
+
+%% @doc Incident Manager uses engagements to engage contacts and escalation
+%% plans during an incident.
+%%
+%% Use this command to describe the engagement that occurred during an
+%% incident.
+describe_engagement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_engagement(Client, Input, []).
+describe_engagement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeEngagement">>, Input, Options).
+
+%% @doc Lists details of the engagement to a contact channel.
+describe_page(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_page(Client, Input, []).
+describe_page(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribePage">>, Input, Options).
+
+%% @doc Retrieves information about the specified contact or escalation plan.
+get_contact(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_contact(Client, Input, []).
+get_contact(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetContact">>, Input, Options).
+
+%% @doc List details about a specific contact channel.
+get_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_contact_channel(Client, Input, []).
+get_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetContactChannel">>, Input, Options).
+
+%% @doc Retrieves the resource policies attached to the specified contact or
+%% escalation plan.
+get_contact_policy(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_contact_policy(Client, Input, []).
+get_contact_policy(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetContactPolicy">>, Input, Options).
+
+%% @doc Lists all contact channels for the specified contact.
+list_contact_channels(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_contact_channels(Client, Input, []).
+list_contact_channels(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListContactChannels">>, Input, Options).
+
+%% @doc Lists all contacts and escalation plans in Incident Manager.
+list_contacts(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_contacts(Client, Input, []).
+list_contacts(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListContacts">>, Input, Options).
+
+%% @doc Lists all engagements that have happened in an incident.
+list_engagements(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_engagements(Client, Input, []).
+list_engagements(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListEngagements">>, Input, Options).
+
+%% @doc Lists all of the engagements to contact channels that have been
+%% acknowledged.
+list_page_receipts(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_page_receipts(Client, Input, []).
+list_page_receipts(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListPageReceipts">>, Input, Options).
+
+%% @doc Lists the engagements to a contact's contact channels.
+list_pages_by_contact(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_pages_by_contact(Client, Input, []).
+list_pages_by_contact(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListPagesByContact">>, Input, Options).
+
+%% @doc Lists the engagements to contact channels that occurred by engaging a
+%% contact.
+list_pages_by_engagement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_pages_by_engagement(Client, Input, []).
+list_pages_by_engagement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListPagesByEngagement">>, Input, Options).
+
+%% @doc Lists the tags of an escalation plan or contact.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc Adds a resource to the specified contact or escalation plan.
+put_contact_policy(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_contact_policy(Client, Input, []).
+put_contact_policy(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutContactPolicy">>, Input, Options).
+
+%% @doc Sends an activation code to a contact channel.
+%%
+%% The contact can use this code to activate the contact channel in the
+%% console or with the `ActivateChannel' operation. Incident Manager can't
+%% engage a contact channel until it has been activated.
+send_activation_code(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_activation_code(Client, Input, []).
+send_activation_code(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendActivationCode">>, Input, Options).
+
+%% @doc Starts an engagement to a contact or escalation plan.
+%%
+%% The engagement engages each contact specified in the incident.
+start_engagement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_engagement(Client, Input, []).
+start_engagement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartEngagement">>, Input, Options).
+
+%% @doc Stops an engagement before it finishes the final stage of the
+%% escalation plan or engagement plan.
+%%
+%% Further contacts aren't engaged.
+stop_engagement(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    stop_engagement(Client, Input, []).
+stop_engagement(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StopEngagement">>, Input, Options).
+
+%% @doc Tags a contact or escalation plan.
+%%
+%% You can tag only contacts and escalation plans in the first region of your
+%% replication set.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes tags from the specified resource.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates the contact or escalation plan specified.
+update_contact(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_contact(Client, Input, []).
+update_contact(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateContact">>, Input, Options).
+
+%% @doc Updates a contact's contact channel.
+update_contact_channel(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_contact_channel(Client, Input, []).
+update_contact_channel(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateContactChannel">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"ssm-contacts">>},
+    Host = build_host(<<"ssm-contacts">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
+        {<<"X-Amz-Target">>, <<"SSMContacts.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_ssm_incidents.erl
+++ b/src/aws_ssm_incidents.erl
@@ -1,0 +1,888 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Systems Manager Incident Manager is an incident management console
+%% designed to help users mitigate and recover from incidents affecting their
+%% Amazon Web Services-hosted applications.
+%%
+%% An incident is any unplanned interruption or reduction in quality of
+%% services.
+%%
+%% Incident Manager increases incident resolution by notifying responders of
+%% impact, highlighting relevant troubleshooting data, and providing
+%% collaboration tools to get services back up and running. To achieve the
+%% primary goal of reducing the time-to-resolution of critical incidents,
+%% Incident Manager automates response plans and enables responder team
+%% escalation.
+-module(aws_ssm_incidents).
+
+-export([create_replication_set/2,
+         create_replication_set/3,
+         create_response_plan/2,
+         create_response_plan/3,
+         create_timeline_event/2,
+         create_timeline_event/3,
+         delete_incident_record/2,
+         delete_incident_record/3,
+         delete_replication_set/2,
+         delete_replication_set/3,
+         delete_resource_policy/2,
+         delete_resource_policy/3,
+         delete_response_plan/2,
+         delete_response_plan/3,
+         delete_timeline_event/2,
+         delete_timeline_event/3,
+         get_incident_record/2,
+         get_incident_record/4,
+         get_incident_record/5,
+         get_replication_set/2,
+         get_replication_set/4,
+         get_replication_set/5,
+         get_resource_policies/2,
+         get_resource_policies/3,
+         get_response_plan/2,
+         get_response_plan/4,
+         get_response_plan/5,
+         get_timeline_event/3,
+         get_timeline_event/5,
+         get_timeline_event/6,
+         list_incident_records/2,
+         list_incident_records/3,
+         list_related_items/2,
+         list_related_items/3,
+         list_replication_sets/2,
+         list_replication_sets/3,
+         list_response_plans/2,
+         list_response_plans/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         list_timeline_events/2,
+         list_timeline_events/3,
+         put_resource_policy/2,
+         put_resource_policy/3,
+         start_incident/2,
+         start_incident/3,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_deletion_protection/2,
+         update_deletion_protection/3,
+         update_incident_record/2,
+         update_incident_record/3,
+         update_related_items/2,
+         update_related_items/3,
+         update_replication_set/2,
+         update_replication_set/3,
+         update_response_plan/2,
+         update_response_plan/3,
+         update_timeline_event/2,
+         update_timeline_event/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc A replication set replicates and encrypts your data to the provided
+%% Regions with the provided KMS key.
+create_replication_set(Client, Input) ->
+    create_replication_set(Client, Input, []).
+create_replication_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/createReplicationSet"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a response plan that automates the initial response to
+%% incidents.
+%%
+%% A response plan engages contacts, starts chat channel collaboration, and
+%% initiates runbooks at the beginning of an incident.
+create_response_plan(Client, Input) ->
+    create_response_plan(Client, Input, []).
+create_response_plan(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/createResponsePlan"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a custom timeline event on the incident details page of an
+%% incident record.
+%%
+%% Timeline events are automatically created by Incident Manager, marking key
+%% moment during an incident. You can create custom timeline events to mark
+%% important events that are automatically detected by Incident Manager.
+create_timeline_event(Client, Input) ->
+    create_timeline_event(Client, Input, []).
+create_timeline_event(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/createTimelineEvent"],
+    SuccessStatusCode = 201,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Delete an incident record from Incident Manager.
+delete_incident_record(Client, Input) ->
+    delete_incident_record(Client, Input, []).
+delete_incident_record(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteIncidentRecord"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes all Regions in your replication set.
+%%
+%% Deleting the replication set deletes all Incident Manager data.
+delete_replication_set(Client, Input) ->
+    delete_replication_set(Client, Input, []).
+delete_replication_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteReplicationSet"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"arn">>, <<"arn">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the resource policy that Resource Access Manager uses to
+%% share your Incident Manager resource.
+delete_resource_policy(Client, Input) ->
+    delete_resource_policy(Client, Input, []).
+delete_resource_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteResourcePolicy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified response plan.
+%%
+%% Deleting a response plan stops all linked CloudWatch alarms and
+%% EventBridge events from creating an incident with this response plan.
+delete_response_plan(Client, Input) ->
+    delete_response_plan(Client, Input, []).
+delete_response_plan(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteResponsePlan"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a timeline event from an incident.
+delete_timeline_event(Client, Input) ->
+    delete_timeline_event(Client, Input, []).
+delete_timeline_event(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/deleteTimelineEvent"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns the details for the specified incident record.
+get_incident_record(Client, Arn)
+  when is_map(Client) ->
+    get_incident_record(Client, Arn, #{}, #{}).
+
+get_incident_record(Client, Arn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_incident_record(Client, Arn, QueryMap, HeadersMap, []).
+
+get_incident_record(Client, Arn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/getIncidentRecord"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, Arn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieve your Incident Manager replication set.
+get_replication_set(Client, Arn)
+  when is_map(Client) ->
+    get_replication_set(Client, Arn, #{}, #{}).
+
+get_replication_set(Client, Arn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_replication_set(Client, Arn, QueryMap, HeadersMap, []).
+
+get_replication_set(Client, Arn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/getReplicationSet"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, Arn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves the resource policies attached to the specified response
+%% plan.
+get_resource_policies(Client, Input) ->
+    get_resource_policies(Client, Input, []).
+get_resource_policies(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/getResourcePolicies"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"resourceArn">>, <<"resourceArn">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves the details of the specified response plan.
+get_response_plan(Client, Arn)
+  when is_map(Client) ->
+    get_response_plan(Client, Arn, #{}, #{}).
+
+get_response_plan(Client, Arn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_response_plan(Client, Arn, QueryMap, HeadersMap, []).
+
+get_response_plan(Client, Arn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/getResponsePlan"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"arn">>, Arn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves a timeline event based on its ID and incident record.
+get_timeline_event(Client, EventId, IncidentRecordArn)
+  when is_map(Client) ->
+    get_timeline_event(Client, EventId, IncidentRecordArn, #{}, #{}).
+
+get_timeline_event(Client, EventId, IncidentRecordArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_timeline_event(Client, EventId, IncidentRecordArn, QueryMap, HeadersMap, []).
+
+get_timeline_event(Client, EventId, IncidentRecordArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/getTimelineEvent"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"eventId">>, EventId},
+        {<<"incidentRecordArn">>, IncidentRecordArn}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists all incident records in your account.
+%%
+%% Use this command to retrieve the Amazon Resource Name (ARN) of the
+%% incident record you want to update.
+list_incident_records(Client, Input) ->
+    list_incident_records(Client, Input, []).
+list_incident_records(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/listIncidentRecords"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc List all related items for an incident record.
+list_related_items(Client, Input) ->
+    list_related_items(Client, Input, []).
+list_related_items(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/listRelatedItems"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists details about the replication set configured in your account.
+list_replication_sets(Client, Input) ->
+    list_replication_sets(Client, Input, []).
+list_replication_sets(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/listReplicationSets"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all response plans in your account.
+list_response_plans(Client, Input) ->
+    list_response_plans(Client, Input, []).
+list_response_plans(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/listResponsePlans"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the tags that are attached to the specified response plan.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists timeline events for the specified incident record.
+list_timeline_events(Client, Input) ->
+    list_timeline_events(Client, Input, []).
+list_timeline_events(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/listTimelineEvents"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds a resource policy to the specified response plan.
+put_resource_policy(Client, Input) ->
+    put_resource_policy(Client, Input, []).
+put_resource_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/putResourcePolicy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Used to start an incident from CloudWatch alarms, EventBridge events,
+%% or manually.
+start_incident(Client, Input) ->
+    start_incident(Client, Input, []).
+start_incident(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/startIncident"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds a tag to a response plan.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a tag from a resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update deletion protection to either allow or deny deletion of the
+%% final Region in a replication set.
+update_deletion_protection(Client, Input) ->
+    update_deletion_protection(Client, Input, []).
+update_deletion_protection(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateDeletionProtection"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Update the details of an incident record.
+%%
+%% You can use this operation to update an incident record from the defined
+%% chat channel. For more information about using actions in chat channels,
+%% see Interacting through chat.
+update_incident_record(Client, Input) ->
+    update_incident_record(Client, Input, []).
+update_incident_record(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateIncidentRecord"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Add or remove related items from the related items tab of an incident
+%% record.
+update_related_items(Client, Input) ->
+    update_related_items(Client, Input, []).
+update_related_items(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateRelatedItems"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Add or delete Regions from your replication set.
+update_replication_set(Client, Input) ->
+    update_replication_set(Client, Input, []).
+update_replication_set(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateReplicationSet"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the specified response plan.
+update_response_plan(Client, Input) ->
+    update_response_plan(Client, Input, []).
+update_response_plan(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateResponsePlan"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a timeline event.
+%%
+%% You can update events of type `Custom Event'.
+update_timeline_event(Client, Input) ->
+    update_timeline_event(Client, Input, []).
+update_timeline_event(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/updateTimelineEvent"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"ssm-incidents">>},
+    Host = build_host(<<"ssm-incidents">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -204,6 +204,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_sso_admin.erl
+++ b/src/aws_sso_admin.erl
@@ -1,7 +1,19 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-
+%% @doc Amazon Web Services Single Sign On (SSO) is a cloud SSO service that
+%% makes it easy to centrally manage SSO access to multiple Amazon Web
+%% Services accounts and business applications.
+%%
+%% This guide provides information on SSO operations which could be used for
+%% access management of Amazon Web Services accounts. For information about
+%% Amazon Web Services SSO features, see the Amazon Web Services Single
+%% Sign-On User Guide.
+%%
+%% Many operations in the SSO APIs rely on identifiers for users and groups,
+%% known as principals. For more information about how to work with
+%% principals and principal IDs in Amazon Web Services SSO, see the Amazon
+%% Web Services SSO Identity Store API Reference.
 -module(aws_sso_admin).
 
 -export([attach_managed_policy_to_permission_set/2,
@@ -77,8 +89,8 @@
 %%
 %% If the permission set is already referenced by one or more account
 %% assignments, you will need to call ` `ProvisionPermissionSet' ' after this
-%% action to apply the corresponding IAM policy updates to all assigned
-%% accounts.
+%% operation. Calling `ProvisionPermissionSet' applies the corresponding IAM
+%% policy updates to all assigned accounts.
 attach_managed_policy_to_permission_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     attach_managed_policy_to_permission_set(Client, Input, []).
@@ -86,19 +98,19 @@ attach_managed_policy_to_permission_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AttachManagedPolicyToPermissionSet">>, Input, Options).
 
-%% @doc Assigns access to a principal for a specified AWS account using a
-%% specified permission set.
+%% @doc Assigns access to a principal for a specified Amazon Web Services
+%% account using a specified permission set.
 %%
-%% The term principal here refers to a user or group that is defined in AWS
-%% SSO.
+%% The term principal here refers to a user or group that is defined in
+%% Amazon Web Services SSO.
 %%
 %% As part of a successful `CreateAccountAssignment' call, the specified
 %% permission set will automatically be provisioned to the account in the
-%% form of an IAM policy attached to the SSO-created IAM role. If the
-%% permission set is subsequently updated, the corresponding IAM policies
-%% attached to roles in your accounts will not be updated automatically. In
-%% this case, you will need to call ` `ProvisionPermissionSet' ' to make
-%% these updates.
+%% form of an IAM policy. That policy is attached to the SSO-created IAM
+%% role. If the permission set is subsequently updated, the corresponding IAM
+%% policies attached to roles in your accounts will not be updated
+%% automatically. In this case, you must call ` `ProvisionPermissionSet' ' to
+%% make these updates.
 create_account_assignment(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_account_assignment(Client, Input, []).
@@ -107,11 +119,11 @@ create_account_assignment(Client, Input, Options)
     request(Client, <<"CreateAccountAssignment">>, Input, Options).
 
 %% @doc Enables the attributes-based access control (ABAC) feature for the
-%% specified AWS SSO instance.
+%% specified Amazon Web Services SSO instance.
 %%
 %% You can also specify new attributes to add to your ABAC configuration
 %% during the enabling process. For more information about ABAC, see
-%% Attribute-Based Access Control in the AWS SSO User Guide.
+%% Attribute-Based Access Control in the Amazon Web Services SSO User Guide.
 create_instance_access_control_attribute_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_instance_access_control_attribute_configuration(Client, Input, []).
@@ -121,8 +133,8 @@ create_instance_access_control_attribute_configuration(Client, Input, Options)
 
 %% @doc Creates a permission set within a specified SSO instance.
 %%
-%% To grant users and groups access to AWS account resources, use `
-%% `CreateAccountAssignment' '.
+%% To grant users and groups access to Amazon Web Services account resources,
+%% use ` `CreateAccountAssignment' '.
 create_permission_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_permission_set(Client, Input, []).
@@ -130,8 +142,8 @@ create_permission_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreatePermissionSet">>, Input, Options).
 
-%% @doc Deletes a principal's access from a specified AWS account using a
-%% specified permission set.
+%% @doc Deletes a principal's access from a specified Amazon Web Services
+%% account using a specified permission set.
 delete_account_assignment(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_account_assignment(Client, Input, []).
@@ -148,13 +160,13 @@ delete_inline_policy_from_permission_set(Client, Input, Options)
     request(Client, <<"DeleteInlinePolicyFromPermissionSet">>, Input, Options).
 
 %% @doc Disables the attributes-based access control (ABAC) feature for the
-%% specified AWS SSO instance and deletes all of the attribute mappings that
-%% have been configured.
+%% specified Amazon Web Services SSO instance and deletes all of the
+%% attribute mappings that have been configured.
 %%
 %% Once deleted, any attributes that are received from an identity source and
 %% any custom attributes you have previously configured will not be passed.
 %% For more information about ABAC, see Attribute-Based Access Control in the
-%% AWS SSO User Guide.
+%% Amazon Web Services SSO User Guide.
 delete_instance_access_control_attribute_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_instance_access_control_attribute_configuration(Client, Input, []).
@@ -186,13 +198,13 @@ describe_account_assignment_deletion_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeAccountAssignmentDeletionStatus">>, Input, Options).
 
-%% @doc Returns the list of AWS SSO identity store attributes that have been
-%% configured to work with attributes-based access control (ABAC) for the
-%% specified AWS SSO instance.
+%% @doc Returns the list of Amazon Web Services SSO identity store attributes
+%% that have been configured to work with attributes-based access control
+%% (ABAC) for the specified Amazon Web Services SSO instance.
 %%
 %% This will not return attributes configured and sent by an external
 %% identity provider. For more information about ABAC, see Attribute-Based
-%% Access Control in the AWS SSO User Guide.
+%% Access Control in the Amazon Web Services SSO User Guide.
 describe_instance_access_control_attribute_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_instance_access_control_attribute_configuration(Client, Input, []).
@@ -234,8 +246,8 @@ get_inline_policy_for_permission_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetInlinePolicyForPermissionSet">>, Input, Options).
 
-%% @doc Lists the status of the AWS account assignment creation requests for
-%% a specified SSO instance.
+%% @doc Lists the status of the Amazon Web Services account assignment
+%% creation requests for a specified SSO instance.
 list_account_assignment_creation_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_account_assignment_creation_status(Client, Input, []).
@@ -243,8 +255,8 @@ list_account_assignment_creation_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAccountAssignmentCreationStatus">>, Input, Options).
 
-%% @doc Lists the status of the AWS account assignment deletion requests for
-%% a specified SSO instance.
+%% @doc Lists the status of the Amazon Web Services account assignment
+%% deletion requests for a specified SSO instance.
 list_account_assignment_deletion_status(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_account_assignment_deletion_status(Client, Input, []).
@@ -252,8 +264,8 @@ list_account_assignment_deletion_status(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAccountAssignmentDeletionStatus">>, Input, Options).
 
-%% @doc Lists the assignee of the specified AWS account with the specified
-%% permission set.
+%% @doc Lists the assignee of the specified Amazon Web Services account with
+%% the specified permission set.
 list_account_assignments(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_account_assignments(Client, Input, []).
@@ -261,8 +273,8 @@ list_account_assignments(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAccountAssignments">>, Input, Options).
 
-%% @doc Lists all the AWS accounts where the specified permission set is
-%% provisioned.
+%% @doc Lists all the Amazon Web Services accounts where the specified
+%% permission set is provisioned.
 list_accounts_for_provisioned_permission_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_accounts_for_provisioned_permission_set(Client, Input, []).
@@ -304,8 +316,8 @@ list_permission_sets(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListPermissionSets">>, Input, Options).
 
-%% @doc Lists all the permission sets that are provisioned to a specified AWS
-%% account.
+%% @doc Lists all the permission sets that are provisioned to a specified
+%% Amazon Web Services account.
 list_permission_sets_provisioned_to_account(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_permission_sets_provisioned_to_account(Client, Input, []).
@@ -359,16 +371,17 @@ untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
 
-%% @doc Updates the AWS SSO identity store attributes to use with the AWS SSO
-%% instance for attributes-based access control (ABAC).
+%% @doc Updates the Amazon Web Services SSO identity store attributes that
+%% you can use with the Amazon Web Services SSO instance for attributes-based
+%% access control (ABAC).
 %%
 %% When using an external identity provider as an identity source, you can
 %% pass attributes through the SAML assertion as an alternative to
-%% configuring attributes from the AWS SSO identity store. If a SAML
-%% assertion passes any of these attributes, AWS SSO will replace the
-%% attribute value with the value from the AWS SSO identity store. For more
-%% information about ABAC, see Attribute-Based Access Control in the AWS SSO
-%% User Guide.
+%% configuring attributes from the Amazon Web Services SSO identity store. If
+%% a SAML assertion passes any of these attributes, Amazon Web Services SSO
+%% replaces the attribute value with the value from the Amazon Web Services
+%% SSO identity store. For more information about ABAC, see Attribute-Based
+%% Access Control in the Amazon Web Services SSO User Guide.
 update_instance_access_control_attribute_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_instance_access_control_attribute_configuration(Client, Input, []).

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -149,6 +149,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_storage_gateway.erl
+++ b/src/aws_storage_gateway.erl
@@ -1,42 +1,40 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Storage Gateway Service
+%% @doc Storage Gateway Service
 %%
-%% AWS Storage Gateway is the service that connects an on-premises software
+%% Storage Gateway is the service that connects an on-premises software
 %% appliance with cloud-based storage to provide seamless and secure
 %% integration between an organization's on-premises IT environment and the
-%% AWS storage infrastructure.
+%% Amazon Web Services storage infrastructure.
 %%
-%% The service enables you to securely upload data to the AWS Cloud for cost
-%% effective backup and rapid disaster recovery.
+%% The service enables you to securely upload data to the Amazon Web Services
+%% Cloud for cost effective backup and rapid disaster recovery.
 %%
-%% Use the following links to get started using the AWS Storage Gateway
-%% Service API Reference:
+%% Use the following links to get started using the Storage Gateway Service
+%% API Reference:
 %%
-%% <ul> <li> AWS Storage Gateway required request headers: Describes the
-%% required headers that you must send with every POST request to AWS Storage
-%% Gateway.
+%% <ul> <li> Storage Gateway required request headers: Describes the required
+%% headers that you must send with every POST request to Storage Gateway.
 %%
-%% </li> <li> Signing requests: AWS Storage Gateway requires that you
+%% </li> <li> Signing requests: Storage Gateway requires that you
 %% authenticate every request you send; this topic describes how sign such a
 %% request.
 %%
-%% </li> <li> Error responses: Provides reference information about AWS
-%% Storage Gateway errors.
+%% </li> <li> Error responses: Provides reference information about Storage
+%% Gateway errors.
 %%
-%% </li> <li> Operations in AWS Storage Gateway: Contains detailed
-%% descriptions of all AWS Storage Gateway operations, their request
-%% parameters, response elements, possible errors, and examples of requests
-%% and responses.
+%% </li> <li> Operations in Storage Gateway: Contains detailed descriptions
+%% of all Storage Gateway operations, their request parameters, response
+%% elements, possible errors, and examples of requests and responses.
 %%
-%% </li> <li> AWS Storage Gateway endpoints and quotas: Provides a list of
-%% each AWS Region and the endpoints available for use with AWS Storage
-%% Gateway.
+%% </li> <li> Storage Gateway endpoints and quotas: Provides a list of each
+%% Amazon Web Services Region and the endpoints available for use with
+%% Storage Gateway.
 %%
-%% </li> </ul> AWS Storage Gateway resource IDs are in uppercase. When you
-%% use these resource IDs with the Amazon EC2 API, EC2 expects resource IDs
-%% in lowercase. You must change your resource ID to lowercase to use it with
+%% </li> </ul> Storage Gateway resource IDs are in uppercase. When you use
+%% these resource IDs with the Amazon EC2 API, EC2 expects resource IDs in
+%% lowercase. You must change your resource ID to lowercase to use it with
 %% the EC2 API. For example, in Storage Gateway the ID for a volume might be
 %% `vol-AA22BB012345DAF670'. When you use this ID with the EC2 API, you must
 %% change it to `vol-aa22bb012345daf670'. Otherwise, the EC2 API might not
@@ -57,8 +55,8 @@
 %% A snapshot ID with the longer ID format looks like the following:
 %% `snap-78e226633445566ee'.
 %%
-%% For more information, see Announcement: Heads-up – Longer AWS Storage
-%% Gateway volume and snapshot IDs coming in 2016.
+%% For more information, see Announcement: Heads-up – Longer Storage Gateway
+%% volume and snapshot IDs coming in 2016.
 -module(aws_storage_gateway).
 
 -export([activate_gateway/2,
@@ -73,6 +71,8 @@
          add_working_storage/3,
          assign_tape_pool/2,
          assign_tape_pool/3,
+         associate_file_system/2,
+         associate_file_system/3,
          attach_volume/2,
          attach_volume/3,
          cancel_archival/2,
@@ -129,6 +129,8 @@
          describe_cached_iscsi_volumes/3,
          describe_chap_credentials/2,
          describe_chap_credentials/3,
+         describe_file_system_associations/2,
+         describe_file_system_associations/3,
          describe_gateway_information/2,
          describe_gateway_information/3,
          describe_maintenance_start_time/2,
@@ -159,12 +161,16 @@
          detach_volume/3,
          disable_gateway/2,
          disable_gateway/3,
+         disassociate_file_system/2,
+         disassociate_file_system/3,
          join_domain/2,
          join_domain/3,
          list_automatic_tape_creation_policies/2,
          list_automatic_tape_creation_policies/3,
          list_file_shares/2,
          list_file_shares/3,
+         list_file_system_associations/2,
+         list_file_system_associations/3,
          list_gateways/2,
          list_gateways/3,
          list_local_disks/2,
@@ -211,6 +217,8 @@
          update_bandwidth_rate_limit_schedule/3,
          update_chap_credentials/2,
          update_chap_credentials/3,
+         update_file_system_association/2,
+         update_file_system_association/3,
          update_gateway_information/2,
          update_gateway_information/3,
          update_gateway_software_now/2,
@@ -223,6 +231,8 @@
          update_smb_file_share/3,
          update_smb_file_share_visibility/2,
          update_smb_file_share_visibility/3,
+         update_smb_local_groups/2,
+         update_smb_local_groups/3,
          update_smb_security_strategy/2,
          update_smb_security_strategy/3,
          update_snapshot_schedule/2,
@@ -238,11 +248,11 @@
 
 %% @doc Activates the gateway you previously deployed on your host.
 %%
-%% In the activation process, you specify information such as the AWS Region
-%% that you want to use for storing snapshots or tapes, the time zone for
-%% scheduled snapshots the gateway snapshot schedule window, an activation
-%% key, and a name for your gateway. The activation process also associates
-%% your gateway with your account. For more information, see
+%% In the activation process, you specify information such as the Amazon Web
+%% Services Region that you want to use for storing snapshots or tapes, the
+%% time zone for scheduled snapshots the gateway snapshot schedule window, an
+%% activation key, and a name for your gateway. The activation process also
+%% associates your gateway with your account. For more information, see
 %% `UpdateGatewayInformation'.
 %%
 %% You must turn on the gateway VM before you can activate your gateway.
@@ -256,7 +266,7 @@ activate_gateway(Client, Input, Options)
 %% @doc Configures one or more gateway local disks as cache for a gateway.
 %%
 %% This operation is only supported in the cached volume, tape, and file
-%% gateway type (see How AWS Storage Gateway works (architecture).
+%% gateway type (see How Storage Gateway works (architecture).
 %%
 %% In the request, you specify the gateway Amazon Resource Name (ARN) to
 %% which you want to add cache, and one or more disk IDs that you want to
@@ -273,8 +283,7 @@ add_cache(Client, Input, Options)
 %% You use tags to add metadata to resources, which you can use to categorize
 %% these resources. For example, you can categorize resources by purpose,
 %% owner, environment, or team. Each tag consists of a key and a value, which
-%% you define. You can add tags to the following AWS Storage Gateway
-%% resources:
+%% you define. You can add tags to the following Storage Gateway resources:
 %%
 %% <ul> <li> Storage gateways of all types
 %%
@@ -283,6 +292,8 @@ add_cache(Client, Input, Options)
 %% </li> <li> Virtual tapes
 %%
 %% </li> <li> NFS and SMB file shares
+%%
+%% </li> <li> File System associations
 %%
 %% </li> </ul> You can create a maximum of 50 tags for each resource. Virtual
 %% tapes and storage volumes that are recovered to a new gateway maintain
@@ -297,7 +308,7 @@ add_tags_to_resource(Client, Input, Options)
 %% @doc Configures one or more gateway local disks as upload buffer for a
 %% specified gateway.
 %%
-%% This operation is supported for the stored volume, cached volume and tape
+%% This operation is supported for the stored volume, cached volume, and tape
 %% gateway types.
 %%
 %% In the request, you specify the gateway Amazon Resource Name (ARN) to
@@ -345,6 +356,18 @@ assign_tape_pool(Client, Input)
 assign_tape_pool(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AssignTapePool">>, Input, Options).
+
+%% @doc Associate an Amazon FSx file system with the FSx File Gateway.
+%%
+%% After the association process is complete, the file shares on the Amazon
+%% FSx file system are available for access through the gateway. This
+%% operation only supports the FSx File Gateway type.
+associate_file_system(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    associate_file_system(Client, Input, []).
+associate_file_system(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AssociateFileSystem">>, Input, Options).
 
 %% @doc Connects a volume to an iSCSI connection and then attaches the volume
 %% to the specified gateway.
@@ -409,21 +432,23 @@ create_cached_iscsi_volume(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateCachediSCSIVolume">>, Input, Options).
 
-%% @doc Creates a Network File System (NFS) file share on an existing file
-%% gateway.
+%% @doc Creates a Network File System (NFS) file share on an existing S3 File
+%% Gateway.
 %%
 %% In Storage Gateway, a file share is a file system mount point backed by
 %% Amazon S3 cloud storage. Storage Gateway exposes file shares using an NFS
-%% interface. This operation is only supported for file gateways.
+%% interface. This operation is only supported for S3 File Gateways.
 %%
-%% File gateway requires AWS Security Token Service (AWS STS) to be activated
-%% to enable you to create a file share. Make sure AWS STS is activated in
-%% the AWS Region you are creating your file gateway in. If AWS STS is not
-%% activated in the AWS Region, activate it. For information about how to
-%% activate AWS STS, see Activating and deactivating AWS STS in an AWS Region
-%% in the AWS Identity and Access Management User Guide.
+%% S3 File gateway requires Security Token Service (Amazon Web Services STS)
+%% to be activated to enable you to create a file share. Make sure Amazon Web
+%% Services STS is activated in the Amazon Web Services Region you are
+%% creating your S3 File Gateway in. If Amazon Web Services STS is not
+%% activated in the Amazon Web Services Region, activate it. For information
+%% about how to activate Amazon Web Services STS, see Activating and
+%% deactivating Amazon Web Services STS in an Amazon Web Services Region in
+%% the Identity and Access Management User Guide.
 %%
-%% File gateway does not support creating hard or symbolic links on a file
+%% S3 File Gateways do not support creating hard or symbolic links on a file
 %% share.
 create_nfs_file_share(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -432,19 +457,21 @@ create_nfs_file_share(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateNFSFileShare">>, Input, Options).
 
-%% @doc Creates a Server Message Block (SMB) file share on an existing file
-%% gateway.
+%% @doc Creates a Server Message Block (SMB) file share on an existing S3
+%% File Gateway.
 %%
 %% In Storage Gateway, a file share is a file system mount point backed by
 %% Amazon S3 cloud storage. Storage Gateway exposes file shares using an SMB
-%% interface. This operation is only supported for file gateways.
+%% interface. This operation is only supported for S3 File Gateways.
 %%
-%% File gateways require AWS Security Token Service (AWS STS) to be activated
-%% to enable you to create a file share. Make sure that AWS STS is activated
-%% in the AWS Region you are creating your file gateway in. If AWS STS is not
-%% activated in this AWS Region, activate it. For information about how to
-%% activate AWS STS, see Activating and deactivating AWS STS in an AWS Region
-%% in the AWS Identity and Access Management User Guide.
+%% S3 File Gateways require Security Token Service (Amazon Web Services STS)
+%% to be activated to enable you to create a file share. Make sure that
+%% Amazon Web Services STS is activated in the Amazon Web Services Region you
+%% are creating your S3 File Gateway in. If Amazon Web Services STS is not
+%% activated in this Amazon Web Services Region, activate it. For information
+%% about how to activate Amazon Web Services STS, see Activating and
+%% deactivating Amazon Web Services STS in an Amazon Web Services Region in
+%% the Identity and Access Management User Guide.
 %%
 %% File gateways don't support creating hard or symbolic links on a file
 %% share.
@@ -457,22 +484,22 @@ create_smb_file_share(Client, Input, Options)
 
 %% @doc Initiates a snapshot of a volume.
 %%
-%% AWS Storage Gateway provides the ability to back up point-in-time
-%% snapshots of your data to Amazon Simple Storage (Amazon S3) for durable
-%% off-site recovery, as well as import the data to an Amazon Elastic Block
-%% Store (EBS) volume in Amazon Elastic Compute Cloud (EC2). You can take
-%% snapshots of your gateway volume on a scheduled or ad hoc basis. This API
-%% enables you to take an ad hoc snapshot. For more information, see Editing
-%% a snapshot schedule.
+%% Storage Gateway provides the ability to back up point-in-time snapshots of
+%% your data to Amazon Simple Storage (Amazon S3) for durable off-site
+%% recovery, and also import the data to an Amazon Elastic Block Store (EBS)
+%% volume in Amazon Elastic Compute Cloud (EC2). You can take snapshots of
+%% your gateway volume on a scheduled or ad hoc basis. This API enables you
+%% to take an ad hoc snapshot. For more information, see Editing a snapshot
+%% schedule.
 %%
 %% In the `CreateSnapshot' request, you identify the volume by providing its
 %% Amazon Resource Name (ARN). You must also provide description for the
-%% snapshot. When AWS Storage Gateway takes the snapshot of specified volume,
-%% the snapshot and description appears in the AWS Storage Gateway console.
-%% In response, AWS Storage Gateway returns you a snapshot ID. You can use
-%% this snapshot ID to check the snapshot progress or later use it when you
-%% want to create a volume from a snapshot. This operation is only supported
-%% in stored and cached volume gateway type.
+%% snapshot. When Storage Gateway takes the snapshot of specified volume, the
+%% snapshot and description appears in the Storage Gateway console. In
+%% response, Storage Gateway returns you a snapshot ID. You can use this
+%% snapshot ID to check the snapshot progress or later use it when you want
+%% to create a volume from a snapshot. This operation is only supported in
+%% stored and cached volume gateway type.
 %%
 %% To list or delete a snapshot, you must use the Amazon EC2 API. For more
 %% information, see DescribeSnapshots or DeleteSnapshot in the Amazon Elastic
@@ -499,10 +526,10 @@ create_snapshot(Client, Input, Options)
 %% In the `CreateSnapshotFromVolumeRecoveryPoint' request, you identify the
 %% volume by providing its Amazon Resource Name (ARN). You must also provide
 %% a description for the snapshot. When the gateway takes a snapshot of the
-%% specified volume, the snapshot and its description appear in the AWS
-%% Storage Gateway console. In response, the gateway returns you a snapshot
-%% ID. You can use this snapshot ID to check the snapshot progress or later
-%% use it when you want to create a volume from a snapshot.
+%% specified volume, the snapshot and its description appear in the Storage
+%% Gateway console. In response, the gateway returns you a snapshot ID. You
+%% can use this snapshot ID to check the snapshot progress or later use it
+%% when you want to create a volume from a snapshot.
 %%
 %% To list or delete a snapshot, you must use the Amazon EC2 API. For more
 %% information, see DescribeSnapshots or DeleteSnapshot in the Amazon Elastic
@@ -615,9 +642,9 @@ delete_chap_credentials(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteChapCredentials">>, Input, Options).
 
-%% @doc Deletes a file share from a file gateway.
+%% @doc Deletes a file share from an S3 File Gateway.
 %%
-%% This operation is only supported for file gateways.
+%% This operation is only supported for S3 File Gateways.
 delete_file_share(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_file_share(Client, Input, []).
@@ -642,7 +669,7 @@ delete_file_share(Client, Input, Options)
 %% billed for these snapshots. You can choose to remove all remaining Amazon
 %% EBS snapshots by canceling your Amazon EC2 subscription.  If you prefer
 %% not to cancel your Amazon EC2 subscription, you can delete your snapshots
-%% using the Amazon EC2 console. For more information, see the AWS Storage
+%% using the Amazon EC2 console. For more information, see the Storage
 %% Gateway detail page.
 delete_gateway(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -726,7 +753,7 @@ delete_volume(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteVolume">>, Input, Options).
 
-%% @doc Returns information about the most recent High Availability
+%% @doc Returns information about the most recent high availability
 %% monitoring test that was performed on the host in a cluster.
 %%
 %% If a test isn't performed, the status and start time in the response would
@@ -804,8 +831,8 @@ describe_cache(Client, Input, Options)
 %% This operation is only supported in the cached volume gateway types.
 %%
 %% The list of gateway volumes in the request must be from one gateway. In
-%% the response, AWS Storage Gateway returns volume information sorted by
-%% volume Amazon Resource Name (ARN).
+%% the response, Storage Gateway returns volume information sorted by volume
+%% Amazon Resource Name (ARN).
 describe_cached_iscsi_volumes(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_cached_iscsi_volumes(Client, Input, []).
@@ -824,6 +851,16 @@ describe_chap_credentials(Client, Input)
 describe_chap_credentials(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeChapCredentials">>, Input, Options).
+
+%% @doc Gets the file system association information.
+%%
+%% This operation is only supported for FSx File Gateways.
+describe_file_system_associations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_file_system_associations(Client, Input, []).
+describe_file_system_associations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFileSystemAssociations">>, Input, Options).
 
 %% @doc Returns metadata about a gateway such as its name, network
 %% interfaces, configured time zone, and the state (whether the gateway is
@@ -850,9 +887,9 @@ describe_maintenance_start_time(Client, Input, Options)
     request(Client, <<"DescribeMaintenanceStartTime">>, Input, Options).
 
 %% @doc Gets a description for one or more Network File System (NFS) file
-%% shares from a file gateway.
+%% shares from an S3 File Gateway.
 %%
-%% This operation is only supported for file gateways.
+%% This operation is only supported for S3 File Gateways.
 describe_nfs_file_shares(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_nfs_file_shares(Client, Input, []).
@@ -861,9 +898,9 @@ describe_nfs_file_shares(Client, Input, Options)
     request(Client, <<"DescribeNFSFileShares">>, Input, Options).
 
 %% @doc Gets a description for one or more Server Message Block (SMB) file
-%% shares from a file gateway.
+%% shares from a S3 File Gateway.
 %%
-%% This operation is only supported for file gateways.
+%% This operation is only supported for S3 File Gateways.
 describe_smb_file_shares(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_smb_file_shares(Client, Input, []).
@@ -898,9 +935,8 @@ describe_snapshot_schedule(Client, Input, Options)
 %% request.
 %%
 %% The list of gateway volumes in the request must be from one gateway. In
-%% the response, AWS Storage Gateway returns volume information sorted by
-%% volume ARNs. This operation is only supported in stored volume gateway
-%% type.
+%% the response, Storage Gateway returns volume information sorted by volume
+%% ARNs. This operation is only supported in stored volume gateway type.
 describe_stored_iscsi_volumes(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_stored_iscsi_volumes(Client, Input, []).
@@ -913,7 +949,7 @@ describe_stored_iscsi_volumes(Client, Input, Options)
 %%
 %% This operation is only supported in the tape gateway type.
 %%
-%% If a specific `TapeARN' is not specified, AWS Storage Gateway returns a
+%% If a specific `TapeARN' is not specified, Storage Gateway returns a
 %% description of all virtual tapes found in the VTS associated with your
 %% account.
 describe_tape_archives(Client, Input)
@@ -967,7 +1003,7 @@ describe_upload_buffer(Client, Input, Options)
 %% @doc Returns a description of virtual tape library (VTL) devices for the
 %% specified tape gateway.
 %%
-%% In the response, AWS Storage Gateway returns VTL device information.
+%% In the response, Storage Gateway returns VTL device information.
 %%
 %% This operation is only supported in the tape gateway type.
 describe_vtl_devices(Client, Input)
@@ -1027,6 +1063,18 @@ disable_gateway(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableGateway">>, Input, Options).
 
+%% @doc Disassociates an Amazon FSx file system from the specified gateway.
+%%
+%% After the disassociation process finishes, the gateway can no longer
+%% access the Amazon FSx file system. This operation is only supported in the
+%% FSx File Gateway type.
+disassociate_file_system(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    disassociate_file_system(Client, Input, []).
+disassociate_file_system(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DisassociateFileSystem">>, Input, Options).
+
 %% @doc Adds a file gateway to an Active Directory domain.
 %%
 %% This operation is only supported for file gateways that support the SMB
@@ -1051,10 +1099,10 @@ list_automatic_tape_creation_policies(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListAutomaticTapeCreationPolicies">>, Input, Options).
 
-%% @doc Gets a list of the file shares for a specific file gateway, or the
+%% @doc Gets a list of the file shares for a specific S3 File Gateway, or the
 %% list of file shares that belong to the calling user account.
 %%
-%% This operation is only supported for file gateways.
+%% This operation is only supported for S3 File Gateways.
 list_file_shares(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_file_shares(Client, Input, []).
@@ -1062,8 +1110,19 @@ list_file_shares(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListFileShares">>, Input, Options).
 
-%% @doc Lists gateways owned by an AWS account in an AWS Region specified in
-%% the request.
+%% @doc Gets a list of `FileSystemAssociationSummary' objects.
+%%
+%% Each object contains a summary of a file system association. This
+%% operation is only supported for FSx File Gateways.
+list_file_system_associations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_file_system_associations(Client, Input, []).
+list_file_system_associations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListFileSystemAssociations">>, Input, Options).
+
+%% @doc Lists gateways owned by an Amazon Web Services account in an Amazon
+%% Web Services Region specified in the request.
 %%
 %% The returned list is ordered by gateway Amazon Resource Name (ARN).
 %%
@@ -1200,17 +1259,17 @@ list_volumes(Client, Input, Options)
 %% @doc Sends you notification through CloudWatch Events when all files
 %% written to your file share have been uploaded to Amazon S3.
 %%
-%% AWS Storage Gateway can send a notification through Amazon CloudWatch
-%% Events when all files written to your file share up to that point in time
-%% have been uploaded to Amazon S3. These files include files written to the
-%% file share up to the time that you make a request for notification. When
-%% the upload is done, Storage Gateway sends you notification through an
-%% Amazon CloudWatch Event. You can configure CloudWatch Events to send the
-%% notification through event targets such as Amazon SNS or AWS Lambda
-%% function. This operation is only supported for file gateways.
+%% Storage Gateway can send a notification through Amazon CloudWatch Events
+%% when all files written to your file share up to that point in time have
+%% been uploaded to Amazon S3. These files include files written to the file
+%% share up to the time that you make a request for notification. When the
+%% upload is done, Storage Gateway sends you notification through an Amazon
+%% CloudWatch Event. You can configure CloudWatch Events to send the
+%% notification through event targets such as Amazon SNS or Lambda function.
+%% This operation is only supported for S3 File Gateways.
 %%
-%% For more information, see Getting file upload notification in the AWS
-%% Storage Gateway User Guide.
+%% For more information, see Getting file upload notification in the Storage
+%% Gateway User Guide.
 notify_when_uploaded(Client, Input)
   when is_map(Client), is_map(Input) ->
     notify_when_uploaded(Client, Input, []).
@@ -1218,36 +1277,41 @@ notify_when_uploaded(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"NotifyWhenUploaded">>, Input, Options).
 
-%% @doc Refreshes the cache for the specified file share.
+%% @doc Refreshes the cached inventory of objects for the specified file
+%% share.
 %%
 %% This operation finds objects in the Amazon S3 bucket that were added,
 %% removed, or replaced since the gateway last listed the bucket's contents
-%% and cached the results. This operation is only supported in the file
-%% gateway type. You can subscribe to be notified through an Amazon
-%% CloudWatch event when your RefreshCache operation completes. For more
-%% information, see Getting notified about file operations in the AWS Storage
-%% Gateway User Guide.
+%% and cached the results. This operation does not import files into the S3
+%% File Gateway cache storage. It only updates the cached inventory to
+%% reflect changes in the inventory of the objects in the S3 bucket. This
+%% operation is only supported in the S3 File Gateway types.
+%%
+%% You can subscribe to be notified through an Amazon CloudWatch event when
+%% your `RefreshCache' operation completes. For more information, see Getting
+%% notified about file operations in the Storage Gateway User Guide. This
+%% operation is Only supported for S3 File Gateways.
 %%
 %% When this API is called, it only initiates the refresh operation. When the
 %% API call completes and returns a success code, it doesn't necessarily mean
 %% that the file refresh has completed. You should use the refresh-complete
 %% notification to determine that the operation has completed before you
 %% check for new files on the gateway file share. You can subscribe to be
-%% notified through an CloudWatch event when your `RefreshCache' operation
+%% notified through a CloudWatch event when your `RefreshCache' operation
 %% completes.
 %%
-%% Throttle limit: This API is asynchronous so the gateway will accept no
+%% Throttle limit: This API is asynchronous, so the gateway will accept no
 %% more than two refreshes at any time. We recommend using the
 %% refresh-complete CloudWatch event notification before issuing additional
 %% requests. For more information, see Getting notified about file operations
-%% in the AWS Storage Gateway User Guide.
+%% in the Storage Gateway User Guide.
 %%
 %% If you invoke the RefreshCache API when two requests are already being
 %% processed, any new request will cause an `InvalidGatewayRequestException'
 %% error because too many requests were sent to the server.
 %%
 %% For more information, see Getting notified about file operations in the
-%% AWS Storage Gateway User Guide.
+%% Storage Gateway User Guide.
 refresh_cache(Client, Input)
   when is_map(Client), is_map(Input) ->
     refresh_cache(Client, Input, []).
@@ -1339,7 +1403,8 @@ set_local_console_password(Client, Input, Options)
 %% @doc Sets the password for the guest user `smbguest'.
 %%
 %% The `smbguest' user is the user when the authentication method for the
-%% file share is set to `GuestAccess'.
+%% file share is set to `GuestAccess'. This operation only supported for S3
+%% File Gateways
 set_smb_guest_password(Client, Input)
   when is_map(Client), is_map(Input) ->
     set_smb_guest_password(Client, Input, []).
@@ -1481,6 +1546,16 @@ update_chap_credentials(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateChapCredentials">>, Input, Options).
 
+%% @doc Updates a file system association.
+%%
+%% This operation is only supported in the FSx File Gateways.
+update_file_system_association(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_file_system_association(Client, Input, []).
+update_file_system_association(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateFileSystemAssociation">>, Input, Options).
+
 %% @doc Updates a gateway's metadata, which includes the gateway's name and
 %% time zone.
 %%
@@ -1532,7 +1607,7 @@ update_maintenance_start_time(Client, Input, Options)
 
 %% @doc Updates a Network File System (NFS) file share.
 %%
-%% This operation is only supported in the file gateway type.
+%% This operation is only supported in S3 File Gateways.
 %%
 %% To leave a file share field unchanged, set the corresponding input field
 %% to null.
@@ -1559,17 +1634,19 @@ update_nfs_file_share(Client, Input, Options)
 
 %% @doc Updates a Server Message Block (SMB) file share.
 %%
-%% This operation is only supported for file gateways.
+%% This operation is only supported for S3 File Gateways.
 %%
 %% To leave a file share field unchanged, set the corresponding input field
 %% to null.
 %%
-%% File gateways require AWS Security Token Service (AWS STS) to be activated
-%% to enable you to create a file share. Make sure that AWS STS is activated
-%% in the AWS Region you are creating your file gateway in. If AWS STS is not
-%% activated in this AWS Region, activate it. For information about how to
-%% activate AWS STS, see Activating and deactivating AWS STS in an AWS Region
-%% in the AWS Identity and Access Management User Guide.
+%% File gateways require Security Token Service (Amazon Web Services STS) to
+%% be activated to enable you to create a file share. Make sure that Amazon
+%% Web Services STS is activated in the Amazon Web Services Region you are
+%% creating your file gateway in. If Amazon Web Services STS is not activated
+%% in this Amazon Web Services Region, activate it. For information about how
+%% to activate Amazon Web Services STS, see Activating and deactivating
+%% Amazon Web Services STS in an Amazon Web Services Region in the Identity
+%% and Access Management User Guide.
 %%
 %% File gateways don't support creating hard or symbolic links on a file
 %% share.
@@ -1580,14 +1657,25 @@ update_smb_file_share(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateSMBFileShare">>, Input, Options).
 
-%% @doc Controls whether the shares on a gateway are visible in a net view or
-%% browse list.
+%% @doc Controls whether the shares on an S3 File Gateway are visible in a
+%% net view or browse list.
+%%
+%% The operation is only supported for S3 File Gateways.
 update_smb_file_share_visibility(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_smb_file_share_visibility(Client, Input, []).
 update_smb_file_share_visibility(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateSMBFileShareVisibility">>, Input, Options).
+
+%% @doc Updates the list of Active Directory users and groups that have
+%% special permissions for SMB file shares on the gateway.
+update_smb_local_groups(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_smb_local_groups(Client, Input, []).
+update_smb_local_groups(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateSMBLocalGroups">>, Input, Options).
 
 %% @doc Updates the SMB security strategy on a file gateway.
 %%

--- a/src/aws_sts.erl
+++ b/src/aws_sts.erl
@@ -1,10 +1,10 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Security Token Service
+%% @doc Security Token Service
 %%
-%% AWS Security Token Service (STS) enables you to request temporary,
-%% limited-privilege credentials for AWS Identity and Access Management (IAM)
+%% Security Token Service (STS) enables you to request temporary,
+%% limited-privilege credentials for Identity and Access Management (IAM)
 %% users or for users that you authenticate (federated users).
 %%
 %% This guide provides descriptions of the STS API. For more information
@@ -35,65 +35,41 @@
 %%====================================================================
 
 %% @doc Returns a set of temporary security credentials that you can use to
-%% access AWS resources that you might not normally have access to.
+%% access Amazon Web Services resources that you might not normally have
+%% access to.
 %%
 %% These temporary credentials consist of an access key ID, a secret access
 %% key, and a security token. Typically, you use `AssumeRole' within your
 %% account or for cross-account access. For a comparison of `AssumeRole' with
 %% other API operations that produce temporary credentials, see Requesting
-%% Temporary Security Credentials and Comparing the AWS STS API operations in
-%% the IAM User Guide.
-%%
-%% You cannot use AWS account root user credentials to call `AssumeRole'. You
-%% must use credentials for an IAM user or an IAM role to call `AssumeRole'.
-%%
-%% For cross-account access, imagine that you own multiple accounts and need
-%% to access resources in each account. You could create long-term
-%% credentials in each account to access those resources. However, managing
-%% all those credentials and remembering which one can access which account
-%% can be time consuming. Instead, you can create one set of long-term
-%% credentials in one account. Then use temporary security credentials to
-%% access all the other accounts by assuming roles in those accounts. For
-%% more information about roles, see IAM Roles in the IAM User Guide.
-%%
-%% Session Duration
-%%
-%% By default, the temporary security credentials created by `AssumeRole'
-%% last for one hour. However, you can use the optional `DurationSeconds'
-%% parameter to specify the duration of your session. You can provide a value
-%% from 900 seconds (15 minutes) up to the maximum session duration setting
-%% for the role. This setting can have a value from 1 hour to 12 hours. To
-%% learn how to view the maximum value for your role, see View the Maximum
-%% Session Duration Setting for a Role in the IAM User Guide. The maximum
-%% session duration limit applies when you use the `AssumeRole*' API
-%% operations or the `assume-role*' CLI commands. However the limit does not
-%% apply when you use those operations to create a console URL. For more
-%% information, see Using IAM Roles in the IAM User Guide.
+%% Temporary Security Credentials and Comparing the STS API operations in the
+%% IAM User Guide.
 %%
 %% Permissions
 %%
 %% The temporary security credentials created by `AssumeRole' can be used to
-%% make API calls to any AWS service with the following exception: You cannot
-%% call the AWS STS `GetFederationToken' or `GetSessionToken' API operations.
+%% make API calls to any Amazon Web Services service with the following
+%% exception: You cannot call the STS `GetFederationToken' or
+%% `GetSessionToken' API operations.
 %%
 %% (Optional) You can pass inline or managed session policies to this
 %% operation. You can pass a single JSON policy document to use as an inline
 %% session policy. You can also specify up to 10 managed policies to use as
-%% managed session policies. The plain text that you use for both inline and
+%% managed session policies. The plaintext that you use for both inline and
 %% managed session policies can't exceed 2,048 characters. Passing policies
 %% to this operation returns new temporary credentials. The resulting
 %% session's permissions are the intersection of the role's identity-based
 %% policy and the session policies. You can use the role's temporary
-%% credentials in subsequent AWS API calls to access resources in the account
-%% that owns the role. You cannot use session policies to grant more
-%% permissions than those allowed by the identity-based policy of the role
-%% that is being assumed. For more information, see Session Policies in the
-%% IAM User Guide.
+%% credentials in subsequent Amazon Web Services API calls to access
+%% resources in the account that owns the role. You cannot use session
+%% policies to grant more permissions than those allowed by the
+%% identity-based policy of the role that is being assumed. For more
+%% information, see Session Policies in the IAM User Guide.
 %%
-%% To assume a role from a different account, your AWS account must be
-%% trusted by the role. The trust relationship is defined in the role's trust
-%% policy when the role is created. That trust policy states which accounts
-%% are allowed to delegate that access to users in the account.
+%% To assume a role from a different account, your account must be trusted by
+%% the role. The trust relationship is defined in the role's trust policy
+%% when the role is created. That trust policy states which accounts are
+%% allowed to delegate that access to users in the account.
 %%
 %% A user who wants to access a role in a different account must also have
 %% permissions that are delegated from the user account administrator. The
@@ -132,11 +108,11 @@
 %% (Optional) You can include multi-factor authentication (MFA) information
 %% when you call `AssumeRole'. This is useful for cross-account scenarios to
 %% ensure that the user that assumes the role has been authenticated with an
-%% AWS MFA device. In that scenario, the trust policy of the role being
-%% assumed includes a condition that tests for MFA authentication. If the
-%% caller does not include valid MFA information, the request to assume the
-%% role is denied. The condition in a trust policy that tests for MFA
-%% authentication might look like the following example.
+%% Amazon Web Services MFA device. In that scenario, the trust policy of the
+%% role being assumed includes a condition that tests for MFA authentication.
+%% If the caller does not include valid MFA information, the request to
+%% assume the role is denied. The condition in a trust policy that tests for
+%% MFA authentication might look like the following example.
 %%
 %% `"Condition": {"Bool": {"aws:MultiFactorAuthPresent": true}}'
 %%
@@ -158,16 +134,16 @@ assume_role(Client, Input, Options)
 %% been authenticated via a SAML authentication response.
 %%
 %% This operation provides a mechanism for tying an enterprise identity store
-%% or directory to role-based AWS access without user-specific credentials or
-%% configuration. For a comparison of `AssumeRoleWithSAML' with the other API
-%% operations that produce temporary credentials, see Requesting Temporary
-%% Security Credentials and Comparing the AWS STS API operations in the IAM
-%% User Guide.
+%% or directory to role-based Amazon Web Services access without
+%% user-specific credentials or configuration. For a comparison of
+%% `AssumeRoleWithSAML' with the other API operations that produce temporary
+%% credentials, see Requesting Temporary Security Credentials and Comparing
+%% the STS API operations in the IAM User Guide.
 %%
 %% The temporary security credentials returned by this operation consist of
 %% an access key ID, a secret access key, and a security token. Applications
-%% can use these temporary security credentials to sign calls to AWS
-%% services.
+%% can use these temporary security credentials to sign calls to Amazon Web
+%% Services services.
 %%
 %% Session Duration
 %%
@@ -186,33 +162,42 @@ assume_role(Client, Input, Options)
 %% apply when you use those operations to create a console URL. For more
 %% information, see Using IAM Roles in the IAM User Guide.
 %%
+%% Role chaining limits your CLI or Amazon Web Services API role session to a
+%% maximum of one hour. When you use the `AssumeRole' API operation to assume
+%% a role, you can specify the duration of your role session with the
+%% `DurationSeconds' parameter. You can specify a parameter value of up to
+%% 43200 seconds (12 hours), depending on the maximum session duration
+%% setting for your role. However, if you assume a role using role chaining
+%% and provide a `DurationSeconds' parameter value greater than one hour, the
+%% operation fails.
+%%
 %% Permissions
 %%
 %% The temporary security credentials created by `AssumeRoleWithSAML' can be
-%% used to make API calls to any AWS service with the following exception:
-%% you cannot call the STS `GetFederationToken' or `GetSessionToken' API
-%% operations.
+%% used to make API calls to any Amazon Web Services service with the
+%% following exception: you cannot call the STS `GetFederationToken' or
+%% `GetSessionToken' API operations.
 %%
 %% (Optional) You can pass inline or managed session policies to this
 %% operation. You can pass a single JSON policy document to use as an inline
 %% session policy. You can also specify up to 10 managed policies to use as
-%% managed session policies. The plain text that you use for both inline and
+%% managed session policies. The plaintext that you use for both inline and
 %% managed session policies can't exceed 2,048 characters. Passing policies
 %% to this operation returns new temporary credentials. The resulting
 %% session's permissions are the intersection of the role's identity-based
 %% policy and the session policies. You can use the role's temporary
-%% credentials in subsequent AWS API calls to access resources in the account
-%% that owns the role. You cannot use session policies to grant more
-%% permissions than those allowed by the identity-based policy of the role
-%% that is being assumed. For more information, see Session Policies in the
-%% IAM User Guide.
+%% credentials in subsequent Amazon Web Services API calls to access
+%% resources in the account that owns the role. You cannot use session
+%% policies to grant more permissions than those allowed by the
+%% identity-based policy of the role that is being assumed. For more
+%% information, see Session Policies in the IAM User Guide.
 %%
-%% Calling `AssumeRoleWithSAML' does not require the use of AWS security
-%% credentials. The identity of the caller is validated by using keys in the
-%% metadata document that is uploaded for the SAML provider entity for your
-%% identity provider.
+%% Calling `AssumeRoleWithSAML' does not require the use of Amazon Web
+%% Services security credentials. The identity of the caller is validated by
+%% using keys in the metadata document that is uploaded for the SAML provider
+%% entity for your identity provider.
 %%
-%% Calling `AssumeRoleWithSAML' can result in an entry in your AWS CloudTrail
+%% Calling `AssumeRoleWithSAML' can result in an entry in your CloudTrail
 %% logs. The entry includes the value in the `NameID' element of the SAML
 %% assertion. We recommend that you use a `NameIDType' that is not associated
 %% with any personally identifiable information (PII). For example, you could
@@ -226,16 +211,17 @@ assume_role(Client, Input, Options)
 %% associated value. For more information about session tags, see Passing
 %% Session Tags in STS in the IAM User Guide.
 %%
-%% You can pass up to 50 session tags. The plain text session tag keys can’t
+%% You can pass up to 50 session tags. The plaintext session tag keys can’t
 %% exceed 128 characters and the values can’t exceed 256 characters. For
 %% these and additional limits, see IAM and STS Character Limits in the IAM
 %% User Guide.
 %%
-%% An AWS conversion compresses the passed session policies and session tags
-%% into a packed binary format that has a separate limit. Your request can
-%% fail for this limit even if your plain text meets the other requirements.
-%% The `PackedPolicySize' response element indicates by percentage how close
-%% the policies and tags for your request are to the upper size limit.
+%% An Amazon Web Services conversion compresses the passed session policies
+%% and session tags into a packed binary format that has a separate limit.
+%% Your request can fail for this limit even if your plaintext meets the
+%% other requirements. The `PackedPolicySize' response element indicates by
+%% percentage how close the policies and tags for your request are to the
+%% upper size limit.
 %%
 %% You can pass a session tag with the same key as a tag that is attached to
 %% the role. When you do, session tags override the role's tags with the same
@@ -253,11 +239,11 @@ assume_role(Client, Input, Options)
 %% SAML Configuration
 %%
 %% Before your application can call `AssumeRoleWithSAML', you must configure
-%% your SAML identity provider (IdP) to issue the claims required by AWS.
-%% Additionally, you must use AWS Identity and Access Management (IAM) to
-%% create a SAML provider entity in your AWS account that represents your
-%% identity provider. You must also create an IAM role that specifies this
-%% SAML provider in its trust policy.
+%% your SAML identity provider (IdP) to issue the claims required by Amazon
+%% Web Services. Additionally, you must use Identity and Access Management
+%% (IAM) to create a SAML provider entity in your Amazon Web Services account
+%% that represents your identity provider. You must also create an IAM role
+%% that specifies this SAML provider in its trust policy.
 %%
 %% For more information, see the following resources:
 %%
@@ -285,30 +271,31 @@ assume_role_with_saml(Client, Input, Options)
 %% Google, or any OpenID Connect-compatible identity provider.
 %%
 %% For mobile applications, we recommend that you use Amazon Cognito. You can
-%% use Amazon Cognito with the AWS SDK for iOS Developer Guide and the AWS
-%% SDK for Android Developer Guide to uniquely identify a user. You can also
-%% supply the user with a consistent identity throughout the lifetime of an
-%% application.
+%% use Amazon Cognito with the Amazon Web Services SDK for iOS Developer
+%% Guide and the Amazon Web Services SDK for Android Developer Guide to
+%% uniquely identify a user. You can also supply the user with a consistent
+%% identity throughout the lifetime of an application.
 %%
-%% To learn more about Amazon Cognito, see Amazon Cognito Overview in AWS SDK
-%% for Android Developer Guide and Amazon Cognito Overview in the AWS SDK for
-%% iOS Developer Guide.
+%% To learn more about Amazon Cognito, see Amazon Cognito Overview in Amazon
+%% Web Services SDK for Android Developer Guide and Amazon Cognito Overview
+%% in the Amazon Web Services SDK for iOS Developer Guide.
 %%
-%% Calling `AssumeRoleWithWebIdentity' does not require the use of AWS
-%% security credentials. Therefore, you can distribute an application (for
-%% example, on mobile devices) that requests temporary security credentials
-%% without including long-term AWS credentials in the application. You also
-%% don't need to deploy server-based proxy services that use long-term AWS
-%% credentials. Instead, the identity of the caller is validated by using a
-%% token from the web identity provider. For a comparison of
-%% `AssumeRoleWithWebIdentity' with the other API operations that produce
-%% temporary credentials, see Requesting Temporary Security Credentials and
-%% Comparing the AWS STS API operations in the IAM User Guide.
+%% Calling `AssumeRoleWithWebIdentity' does not require the use of Amazon Web
+%% Services security credentials. Therefore, you can distribute an
+%% application (for example, on mobile devices) that requests temporary
+%% security credentials without including long-term Amazon Web Services
+%% credentials in the application. You also don't need to deploy server-based
+%% proxy services that use long-term Amazon Web Services credentials.
+%% Instead, the identity of the caller is validated by using a token from the
+%% web identity provider. For a comparison of `AssumeRoleWithWebIdentity'
+%% with the other API operations that produce temporary credentials, see
+%% Requesting Temporary Security Credentials and Comparing the STS API
+%% operations in the IAM User Guide.
 %%
 %% The temporary security credentials returned by this API consist of an
 %% access key ID, a secret access key, and a security token. Applications can
-%% use these temporary security credentials to sign calls to AWS service API
-%% operations.
+%% use these temporary security credentials to sign calls to Amazon Web
+%% Services service API operations.
 %%
 %% Session Duration
 %%
@@ -328,23 +315,23 @@ assume_role_with_saml(Client, Input, Options)
 %% Permissions
 %%
 %% The temporary security credentials created by `AssumeRoleWithWebIdentity'
-%% can be used to make API calls to any AWS service with the following
-%% exception: you cannot call the STS `GetFederationToken' or
+%% can be used to make API calls to any Amazon Web Services service with the
+%% following exception: you cannot call the STS `GetFederationToken' or
 %% `GetSessionToken' API operations.
 %%
 %% (Optional) You can pass inline or managed session policies to this
 %% operation. You can pass a single JSON policy document to use as an inline
 %% session policy. You can also specify up to 10 managed policies to use as
-%% managed session policies. The plain text that you use for both inline and
+%% managed session policies. The plaintext that you use for both inline and
 %% managed session policies can't exceed 2,048 characters. Passing policies
 %% to this operation returns new temporary credentials. The resulting
 %% session's permissions are the intersection of the role's identity-based
 %% policy and the session policies. You can use the role's temporary
-%% credentials in subsequent AWS API calls to access resources in the account
-%% that owns the role. You cannot use session policies to grant more
-%% permissions than those allowed by the identity-based policy of the role
-%% that is being assumed. For more information, see Session Policies in the
-%% IAM User Guide.
+%% credentials in subsequent Amazon Web Services API calls to access
+%% resources in the account that owns the role. You cannot use session
+%% policies to grant more permissions than those allowed by the
+%% identity-based policy of the role that is being assumed. For more
+%% information, see Session Policies in the IAM User Guide.
 %%
 %% Tags
 %%
@@ -353,16 +340,17 @@ assume_role_with_saml(Client, Input, Options)
 %% and an associated value. For more information about session tags, see
 %% Passing Session Tags in STS in the IAM User Guide.
 %%
-%% You can pass up to 50 session tags. The plain text session tag keys can’t
+%% You can pass up to 50 session tags. The plaintext session tag keys can’t
 %% exceed 128 characters and the values can’t exceed 256 characters. For
 %% these and additional limits, see IAM and STS Character Limits in the IAM
 %% User Guide.
 %%
-%% An AWS conversion compresses the passed session policies and session tags
-%% into a packed binary format that has a separate limit. Your request can
-%% fail for this limit even if your plain text meets the other requirements.
-%% The `PackedPolicySize' response element indicates by percentage how close
-%% the policies and tags for your request are to the upper size limit.
+%% An Amazon Web Services conversion compresses the passed session policies
+%% and session tags into a packed binary format that has a separate limit.
+%% Your request can fail for this limit even if your plaintext meets the
+%% other requirements. The `PackedPolicySize' response element indicates by
+%% percentage how close the policies and tags for your request are to the
+%% upper size limit.
 %%
 %% You can pass a session tag with the same key as a tag that is attached to
 %% the role. When you do, the session tag overrides the role tag with the
@@ -386,9 +374,9 @@ assume_role_with_saml(Client, Input, Options)
 %% identity token. In other words, the identity provider must be specified in
 %% the role's trust policy.
 %%
-%% Calling `AssumeRoleWithWebIdentity' can result in an entry in your AWS
-%% CloudTrail logs. The entry includes the Subject of the provided Web
-%% Identity Token. We recommend that you avoid using any personally
+%% Calling `AssumeRoleWithWebIdentity' can result in an entry in your
+%% CloudTrail logs. The entry includes the Subject of the provided web
+%% identity token. We recommend that you avoid using any personally
 %% identifiable information (PII) in this field. For example, you could
 %% instead use a GUID or a pairwise identifier, as suggested in the OIDC
 %% specification.
@@ -402,13 +390,13 @@ assume_role_with_saml(Client, Input, Options)
 %% </li> <li> Web Identity Federation Playground. Walk through the process of
 %% authenticating through Login with Amazon, Facebook, or Google, getting
 %% temporary security credentials, and then using those credentials to make a
-%% request to AWS.
+%% request to Amazon Web Services.
 %%
-%% </li> <li> AWS SDK for iOS Developer Guide and AWS SDK for Android
-%% Developer Guide. These toolkits contain sample apps that show how to
-%% invoke the identity providers. The toolkits then show how to use the
-%% information from these providers to get and use temporary security
-%% credentials.
+%% </li> <li> Amazon Web Services SDK for iOS Developer Guide and Amazon Web
+%% Services SDK for Android Developer Guide. These toolkits contain sample
+%% apps that show how to invoke the identity providers. The toolkits then
+%% show how to use the information from these providers to get and use
+%% temporary security credentials.
 %%
 %% </li> <li> Web Identity Federation with Mobile Applications. This article
 %% discusses web identity federation and shows an example of how to use web
@@ -423,17 +411,19 @@ assume_role_with_web_identity(Client, Input, Options)
     request(Client, <<"AssumeRoleWithWebIdentity">>, Input, Options).
 
 %% @doc Decodes additional information about the authorization status of a
-%% request from an encoded message returned in response to an AWS request.
+%% request from an encoded message returned in response to an Amazon Web
+%% Services request.
 %%
 %% For example, if a user is not authorized to perform an operation that he
 %% or she has requested, the request returns a `Client.UnauthorizedOperation'
-%% response (an HTTP 403 response). Some AWS operations additionally return
-%% an encoded message that can provide details about this authorization
-%% failure.
+%% response (an HTTP 403 response). Some Amazon Web Services operations
+%% additionally return an encoded message that can provide details about this
+%% authorization failure.
 %%
-%% Only certain AWS operations return an encoded authorization message. The
-%% documentation for an individual operation indicates whether that operation
-%% returns an encoded message in addition to returning an HTTP code.
+%% Only certain Amazon Web Services operations return an encoded
+%% authorization message. The documentation for an individual operation
+%% indicates whether that operation returns an encoded message in addition to
+%% returning an HTTP code.
 %%
 %% The message is encoded because the details of the authorization status can
 %% constitute privileged information that the user who requested the
@@ -472,15 +462,15 @@ decode_authorization_message(Client, Input, Options)
 %% access keys, see Managing Access Keys for IAM Users in the IAM User Guide.
 %%
 %% When you pass an access key ID to this operation, it returns the ID of the
-%% AWS account to which the keys belong. Access key IDs beginning with `AKIA'
-%% are long-term credentials for an IAM user or the AWS account root user.
-%% Access key IDs beginning with `ASIA' are temporary credentials that are
-%% created using STS operations. If the account in the response belongs to
-%% you, you can sign in as the root user and review your root user access
-%% keys. Then, you can pull a credentials report to learn which IAM user owns
-%% the keys. To learn who requested the temporary credentials for an `ASIA'
-%% access key, view the STS events in your CloudTrail logs in the IAM User
-%% Guide.
+%% Amazon Web Services account to which the keys belong. Access key IDs
+%% beginning with `AKIA' are long-term credentials for an IAM user or the
+%% Amazon Web Services account root user. Access key IDs beginning with
+%% `ASIA' are temporary credentials that are created using STS operations. If
+%% the account in the response belongs to you, you can sign in as the root
+%% user and review your root user access keys. Then, you can pull a
+%% credentials report to learn which IAM user owns the keys. To learn who
+%% requested the temporary credentials for an `ASIA' access key, view the STS
+%% events in your CloudTrail logs in the IAM User Guide.
 %%
 %% This operation does not indicate the state of the access key. The key
 %% might be active, inactive, or deleted. Active keys might not have
@@ -522,7 +512,7 @@ get_caller_identity(Client, Input, Options)
 %% usually in a server-based application. For a comparison of
 %% `GetFederationToken' with the other API operations that produce temporary
 %% credentials, see Requesting Temporary Security Credentials and Comparing
-%% the AWS STS API operations in the IAM User Guide.
+%% the STS API operations in the IAM User Guide.
 %%
 %% You can create a mobile-based or browser-based app that can authenticate
 %% users using a web identity provider like Login with Amazon, Facebook,
@@ -532,27 +522,90 @@ get_caller_identity(Client, Input, Options)
 %% in the IAM User Guide.
 %%
 %% You can also call `GetFederationToken' using the security credentials of
-%% an AWS account root user, but we do not recommend it. Instead, we
-%% recommend that you create an IAM user for the purpose of the proxy
-%% application. Then attach a policy to the IAM user that limits federated
-%% users to only the actions and resources that they need to access. For more
-%% information, see IAM Best Practices in the IAM User Guide.
+%% an Amazon Web Services account root user, but we do not recommend it.
+%% Instead, we recommend that you create an IAM user for the purpose of the
+%% proxy application. Then attach a policy to the IAM user that limits
+%% federated users to only the actions and resources that they need to
+%% access. For more information, see IAM Best Practices in the IAM User
+%% Guide.
 %%
 %% Session duration
 %%
 %% The temporary credentials are valid for the specified duration, from 900
 %% seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The
 %% default session duration is 43,200 seconds (12 hours). Temporary
-%% credentials that are obtained by using AWS account root user credentials
-%% have a maximum duration of 3,600 seconds (1 hour).
+%% credentials that are obtained by using Amazon Web Services account root
+%% user credentials have a maximum duration of 3,600 seconds (1 hour).
 %%
 %% Permissions
 %%
 %% You can use the temporary credentials created by `GetFederationToken' in
-%% any AWS service except the following:
+%% any Amazon Web Services service except the following:
 %%
-%% <ul> <li> You cannot call any IAM operations using the AWS CLI or the AWS
-%% API.
+%% <ul> <li> You cannot call any IAM operations using the CLI or the Amazon
+%% Web Services API.
+%%
+%% </li> <li> You cannot call any STS operations except `GetCallerIdentity'.
+%%
+%% </li> </ul> You must pass an inline or managed session policy to this
+%% operation. You can pass a single JSON policy document to use as an inline
+%% session policy. You can also specify up to 10 managed policies to use as
+%% managed session policies. The plaintext that you use for both inline and
+%% managed session policies can't exceed 2,048 characters.
+%%
+%% Though the session policy parameters are optional, if you do not pass a
+%% policy, then the resulting federated user session has no permissions. When
+%% you pass session policies, the session permissions are the intersection of
+%% the IAM user policies and the session policies that you pass. This gives
+%% you a way to further restrict the permissions for a federated user. You
+%% cannot use session policies to grant more permissions than those that are
+%% defined in the permissions policy of the IAM user. For more information,
+%% see Session Policies in the IAM User Guide. For information about using
+%% `GetFederationToken' to create temporary security credentials, see
+%% GetFederationToken—Federation Through a Custom Identity Broker.
+%%
+%% You can use the credentials to access a resource that has a resource-based
+%% policy. If that policy specifically references the federated user session
+%% in the `Principal' element of the policy, the session has the permissions
+%% allowed by the policy. These permissions are granted in addition to the
+%% permissions granted by the session policies.
+%%
+%% Tags
+%%
+%% (Optional) You can pass tag key-value pairs to your session. These are
+%% called session tags. For more information about session tags, see Passing
+%% Session Tags in STS in the IAM User Guide.
+%%
+%% You can create a mobile-based or browser-based app that can authenticate
+%% users using a web identity provider like Login with Amazon, Facebook,
+%% Google, or an OpenID Connect-compatible identity provider. In this case,
+%% we recommend that you use Amazon Cognito or `AssumeRoleWithWebIdentity'.
+%% For more information, see Federation Through a Web-based Identity Provider
+%% in the IAM User Guide.
+%%
+%% You can also call `GetFederationToken' using the security credentials of
+%% an Amazon Web Services account root user, but we do not recommend it.
+%% Instead, we recommend that you create an IAM user for the purpose of the
+%% proxy application. Then attach a policy to the IAM user that limits
+%% federated users to only the actions and resources that they need to
+%% access. For more information, see IAM Best Practices in the IAM User
+%% Guide.
+%%
+%% Session duration
+%%
+%% The temporary credentials are valid for the specified duration, from 900
+%% seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The
+%% default session duration is 43,200 seconds (12 hours). Temporary
+%% credentials that are obtained by using Amazon Web Services account root
+%% user credentials have a maximum duration of 3,600 seconds (1 hour).
+%%
+%% Permissions
+%%
+%% You can use the temporary credentials created by `GetFederationToken' in
+%% any Amazon Web Services service except the following:
+%%
+%% <ul> <li> You cannot call any IAM operations using the CLI or the Amazon
+%% Web Services API.
 %%
 %% </li> <li> You cannot call any STS operations except `GetCallerIdentity'.
 %%
@@ -604,37 +657,38 @@ get_federation_token(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetFederationToken">>, Input, Options).
 
-%% @doc Returns a set of temporary credentials for an AWS account or IAM
-%% user.
+%% @doc Returns a set of temporary credentials for an Amazon Web Services
+%% account or IAM user.
 %%
 %% The credentials consist of an access key ID, a secret access key, and a
 %% security token. Typically, you use `GetSessionToken' if you want to use
-%% MFA to protect programmatic calls to specific AWS API operations like
-%% Amazon EC2 `StopInstances'. MFA-enabled IAM users would need to call
-%% `GetSessionToken' and submit an MFA code that is associated with their MFA
-%% device. Using the temporary security credentials that are returned from
-%% the call, IAM users can then make programmatic calls to API operations
-%% that require MFA authentication. If you do not supply a correct MFA code,
-%% then the API returns an access denied error. For a comparison of
+%% MFA to protect programmatic calls to specific Amazon Web Services API
+%% operations like Amazon EC2 `StopInstances'. MFA-enabled IAM users would
+%% need to call `GetSessionToken' and submit an MFA code that is associated
+%% with their MFA device. Using the temporary security credentials that are
+%% returned from the call, IAM users can then make programmatic calls to API
+%% operations that require MFA authentication. If you do not supply a correct
+%% MFA code, then the API returns an access denied error. For a comparison of
 %% `GetSessionToken' with the other API operations that produce temporary
 %% credentials, see Requesting Temporary Security Credentials and Comparing
-%% the AWS STS API operations in the IAM User Guide.
+%% the STS API operations in the IAM User Guide.
 %%
 %% Session Duration
 %%
-%% The `GetSessionToken' operation must be called by using the long-term AWS
-%% security credentials of the AWS account root user or an IAM user.
-%% Credentials that are created by IAM users are valid for the duration that
-%% you specify. This duration can range from 900 seconds (15 minutes) up to a
-%% maximum of 129,600 seconds (36 hours), with a default of 43,200 seconds
-%% (12 hours). Credentials based on account credentials can range from 900
-%% seconds (15 minutes) up to 3,600 seconds (1 hour), with a default of 1
-%% hour.
+%% The `GetSessionToken' operation must be called by using the long-term
+%% Amazon Web Services security credentials of the Amazon Web Services
+%% account root user or an IAM user. Credentials that are created by IAM
+%% users are valid for the duration that you specify. This duration can range
+%% from 900 seconds (15 minutes) up to a maximum of 129,600 seconds (36
+%% hours), with a default of 43,200 seconds (12 hours). Credentials based on
+%% account credentials can range from 900 seconds (15 minutes) up to 3,600
+%% seconds (1 hour), with a default of 1 hour.
 %%
 %% Permissions
 %%
 %% The temporary security credentials created by `GetSessionToken' can be
-%% used to make API calls to any AWS service with the following exceptions:
+%% used to make API calls to any Amazon Web Services service with the
+%% following exceptions:
 %%
 %% <ul> <li> You cannot call any IAM API operations unless MFA authentication
 %% information is included in the request.
@@ -642,17 +696,19 @@ get_federation_token(Client, Input, Options)
 %% </li> <li> You cannot call any STS API except `AssumeRole' or
 %% `GetCallerIdentity'.
 %%
-%% </li> </ul> We recommend that you do not call `GetSessionToken' with AWS
-%% account root user credentials. Instead, follow our best practices by
-%% creating one or more IAM users, giving them the necessary permissions, and
-%% using IAM users for everyday interaction with AWS.
+%% </li> </ul> We recommend that you do not call `GetSessionToken' with
+%% Amazon Web Services account root user credentials. Instead, follow our
+%% best practices by creating one or more IAM users, giving them the
+%% necessary permissions, and using IAM users for everyday interaction with
+%% Amazon Web Services.
 %%
 %% The credentials that are returned by `GetSessionToken' are based on
 %% permissions associated with the user whose credentials were used to call
-%% the operation. If `GetSessionToken' is called using AWS account root user
-%% credentials, the temporary credentials have root user permissions.
-%% Similarly, if `GetSessionToken' is called using the credentials of an IAM
-%% user, the temporary credentials have the same permissions as the IAM user.
+%% the operation. If `GetSessionToken' is called using Amazon Web Services
+%% account root user credentials, the temporary credentials have root user
+%% permissions. Similarly, if `GetSessionToken' is called using the
+%% credentials of an IAM user, the temporary credentials have the same
+%% permissions as the IAM user.
 %%
 %% For more information about using `GetSessionToken' to create temporary
 %% credentials, go to Temporary Credentials for Users in Untrusted

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -3,17 +3,17 @@
 
 %% @doc AWS Support
 %%
-%% The AWS Support API reference is intended for programmers who need
+%% The AWS Support API Reference is intended for programmers who need
 %% detailed information about the AWS Support operations and data types.
 %%
-%% This service enables you to manage your AWS Support cases
-%% programmatically. It uses HTTP methods that return results in JSON format.
+%% You can use the API to manage your support cases programmatically. The AWS
+%% Support API uses HTTP methods that return results in JSON format.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 %%
@@ -24,17 +24,17 @@
 %%
 %% The following list describes the AWS Support case management operations:
 %%
-%% <ul> <li> Service names, issue categories, and available severity levels.
+%% <ul> <li> Service names, issue categories, and available severity levels -
 %% The `DescribeServices' and `DescribeSeverityLevels' operations return AWS
 %% service names, service codes, service categories, and problem severity
 %% levels. You use these values when you call the `CreateCase' operation.
 %%
-%% </li> <li> Case creation, case details, and case resolution. The
+%% </li> <li> Case creation, case details, and case resolution - The
 %% `CreateCase', `DescribeCases', `DescribeAttachment', and `ResolveCase'
 %% operations create AWS Support cases, retrieve information about cases, and
 %% resolve cases.
 %%
-%% </li> <li> Case communication. The `DescribeCommunications',
+%% </li> <li> Case communication - The `DescribeCommunications',
 %% `AddCommunicationToCase', and `AddAttachmentsToSet' operations retrieve
 %% and add communications and attachments to AWS Support cases.
 %%
@@ -109,11 +109,11 @@
 %% created. The `expiryTime' returned in the response is when the set
 %% expires.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 add_attachments_to_set(Client, Input)
@@ -130,11 +130,11 @@ add_attachments_to_set(Client, Input, Options)
 %% communication by using the `ccEmailAddresses' parameter. The
 %% `communicationBody' value contains the text of the communication.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 add_communication_to_case(Client, Input)
@@ -165,11 +165,11 @@ add_communication_to_case(Client, Input, Options)
 %% The `caseId' is separate from the `displayId' that appears in the AWS
 %% Support Center. Use the `DescribeCases' operation to get the `displayId'.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 create_case(Client, Input)
@@ -187,11 +187,11 @@ create_case(Client, Input, Options)
 %% Attachment IDs are returned in the `AttachmentDetails' objects that are
 %% returned by the `DescribeCommunications' operation.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_attachment(Client, Input)
@@ -219,11 +219,11 @@ describe_attachment(Client, Input, Options)
 %% </li> </ul> Case data is available for 12 months after creation. If a case
 %% was created more than 12 months ago, a request might return an error.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_cases(Client, Input)
@@ -246,11 +246,11 @@ describe_cases(Client, Input, Options)
 %% you want to display on each page, and use `nextToken' to specify the
 %% resumption of pagination.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_communications(Client, Input)
@@ -274,11 +274,11 @@ describe_communications(Client, Input, Options)
 %% returns, so that you have the most recent set of service and category
 %% codes.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_services(Client, Input)
@@ -288,17 +288,17 @@ describe_services(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeServices">>, Input, Options).
 
-%% @doc Returns the list of severity levels that you can assign to an AWS
-%% Support case.
+%% @doc Returns the list of severity levels that you can assign to a support
+%% case.
 %%
 %% The severity level for a case is also a field in the `CaseDetails' data
 %% type that you include for a `CreateCase' request.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_severity_levels(Client, Input)
@@ -319,11 +319,11 @@ describe_severity_levels(Client, Input, Options)
 %% operation. If you call this operation for these checks, you might see an
 %% `InvalidParameterValue' error.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_trusted_advisor_check_refresh_statuses(Client, Input)
@@ -350,18 +350,18 @@ describe_trusted_advisor_check_refresh_statuses(Client, Input, Options)
 %%
 %% </li> </ul> In addition, the response contains these fields:
 %%
-%% <ul> <li> status - The alert status of the check: "ok" (green), "warning"
-%% (yellow), "error" (red), or "not_available".
+%% <ul> <li> status - The alert status of the check can be `ok' (green),
+%% `warning' (yellow), `error' (red), or `not_available'.
 %%
 %% </li> <li> timestamp - The time of the last refresh of the check.
 %%
 %% </li> <li> checkId - The unique identifier for the check.
 %%
-%% </li> </ul> You must have a Business or Enterprise support plan to use the
+%% </li> </ul> You must have a Business or Enterprise Support plan to use the
 %% AWS Support API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_trusted_advisor_check_result(Client, Input)
@@ -379,11 +379,11 @@ describe_trusted_advisor_check_result(Client, Input, Options)
 %%
 %% The response contains an array of `TrustedAdvisorCheckSummary' objects.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 describe_trusted_advisor_check_summaries(Client, Input)
@@ -401,13 +401,17 @@ describe_trusted_advisor_check_summaries(Client, Input, Options)
 %% `TrustedAdvisorCheckDescription' object for each check. You must set the
 %% AWS Region to us-east-1.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
+%%
+%% The names and descriptions for Trusted Advisor checks are subject to
+%% change. We recommend that you specify the check ID in your code to
+%% uniquely identify a check.
 describe_trusted_advisor_checks(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_trusted_advisor_checks(Client, Input, []).
@@ -427,11 +431,11 @@ describe_trusted_advisor_checks(Client, Input, Options)
 %%
 %% The response contains a `TrustedAdvisorCheckRefreshStatus' object.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 refresh_trusted_advisor_check(Client, Input)
@@ -446,11 +450,11 @@ refresh_trusted_advisor_check(Client, Input, Options)
 %% This operation takes a `caseId' and returns the initial and final state of
 %% the case.
 %%
-%% You must have a Business or Enterprise support plan to use the AWS Support
+%% You must have a Business or Enterprise Support plan to use the AWS Support
 %% API.
 %%
 %% If you call the AWS Support API from an account that does not have a
-%% Business or Enterprise support plan, the `SubscriptionRequiredException'
+%% Business or Enterprise Support plan, the `SubscriptionRequiredException'
 %% error message appears. For information about changing your support plan,
 %% see AWS Support.
 resolve_case(Client, Input)

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -359,8 +359,8 @@ stop_canary(Client, Name, Input0, Options0) ->
 %% them to scope user permissions, by granting a user permission to access or
 %% change only resources with certain tag values.
 %%
-%% Tags don't have any semantic meaning to AWS and are interpreted strictly
-%% as strings of characters.
+%% Tags don't have any semantic meaning to Amazon Web Services and are
+%% interpreted strictly as strings of characters.
 %%
 %% You can use the `TagResource' action with a canary that already has tags.
 %% If you specify a new tag key for the alarm, this tag is appended to the
@@ -477,6 +477,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_textract.erl
+++ b/src/aws_textract.erl
@@ -9,16 +9,22 @@
 
 -export([analyze_document/2,
          analyze_document/3,
+         analyze_expense/2,
+         analyze_expense/3,
          detect_document_text/2,
          detect_document_text/3,
          get_document_analysis/2,
          get_document_analysis/3,
          get_document_text_detection/2,
          get_document_text_detection/3,
+         get_expense_analysis/2,
+         get_expense_analysis/3,
          start_document_analysis/2,
          start_document_analysis/3,
          start_document_text_detection/2,
-         start_document_text_detection/3]).
+         start_document_text_detection/3,
+         start_expense_analysis/2,
+         start_expense_analysis/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -64,6 +70,26 @@ analyze_document(Client, Input)
 analyze_document(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"AnalyzeDocument">>, Input, Options).
+
+%% @doc Analyzes an input document for financially related relationships
+%% between text.
+%%
+%% Information is returned as `ExpenseDocuments' and seperated as follows.
+%%
+%% <ul> <li> `LineItemGroups'- A data set containing `LineItems' which store
+%% information about the lines of text, such as an item purchased and its
+%% price on a receipt.
+%%
+%% </li> <li> `SummaryFields'- Contains all other information a receipt, such
+%% as header information or the vendors name.
+%%
+%% </li> </ul>
+analyze_expense(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    analyze_expense(Client, Input, []).
+analyze_expense(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"AnalyzeExpense">>, Input, Options).
 
 %% @doc Detects text in the input document.
 %%
@@ -182,14 +208,46 @@ get_document_text_detection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetDocumentTextDetection">>, Input, Options).
 
+%% @doc Gets the results for an Amazon Textract asynchronous operation that
+%% analyzes invoices and receipts.
+%%
+%% Amazon Textract finds contact information, items purchased, and vendor
+%% name, from input invoices and receipts.
+%%
+%% You start asynchronous invoice/receipt analysis by calling
+%% `StartExpenseAnalysis', which returns a job identifier (`JobId'). Upon
+%% completion of the invoice/receipt analysis, Amazon Textract publishes the
+%% completion status to the Amazon Simple Notification Service (Amazon SNS)
+%% topic. This topic must be registered in the initial call to
+%% `StartExpenseAnalysis'. To get the results of the invoice/receipt analysis
+%% operation, first ensure that the status value published to the Amazon SNS
+%% topic is `SUCCEEDED'. If so, call `GetExpenseAnalysis', and pass the job
+%% identifier (`JobId') from the initial call to `StartExpenseAnalysis'.
+%%
+%% Use the MaxResults parameter to limit the number of blocks that are
+%% returned. If there are more results than specified in `MaxResults', the
+%% value of `NextToken' in the operation response contains a pagination token
+%% for getting the next set of results. To get the next page of results, call
+%% `GetExpenseAnalysis', and populate the `NextToken' request parameter with
+%% the token value that's returned from the previous call to
+%% `GetExpenseAnalysis'.
+%%
+%% For more information, see Analyzing Invoices and Receipts.
+get_expense_analysis(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_expense_analysis(Client, Input, []).
+get_expense_analysis(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetExpenseAnalysis">>, Input, Options).
+
 %% @doc Starts the asynchronous analysis of an input document for
 %% relationships between detected items such as key-value pairs, tables, and
 %% selection elements.
 %%
 %% `StartDocumentAnalysis' can analyze text in documents that are in JPEG,
-%% PNG, and PDF format. The documents are stored in an Amazon S3 bucket. Use
-%% `DocumentLocation' to specify the bucket name and file name of the
-%% document.
+%% PNG, TIFF, and PDF format. The documents are stored in an Amazon S3
+%% bucket. Use `DocumentLocation' to specify the bucket name and file name of
+%% the document.
 %%
 %% `StartDocumentAnalysis' returns a job identifier (`JobId') that you use to
 %% get the results of the operation. When text analysis is finished, Amazon
@@ -214,7 +272,7 @@ start_document_analysis(Client, Input, Options)
 %% of text.
 %%
 %% `StartDocumentTextDetection' can analyze text in documents that are in
-%% JPEG, PNG, and PDF format. The documents are stored in an Amazon S3
+%% JPEG, PNG, TIFF, and PDF format. The documents are stored in an Amazon S3
 %% bucket. Use `DocumentLocation' to specify the bucket name and file name of
 %% the document.
 %%
@@ -234,6 +292,32 @@ start_document_text_detection(Client, Input)
 start_document_text_detection(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartDocumentTextDetection">>, Input, Options).
+
+%% @doc Starts the asynchronous analysis of invoices or receipts for data
+%% like contact information, items purchased, and vendor names.
+%%
+%% `StartExpenseAnalysis' can analyze text in documents that are in JPEG,
+%% PNG, and PDF format. The documents must be stored in an Amazon S3 bucket.
+%% Use the `DocumentLocation' parameter to specify the name of your S3 bucket
+%% and the name of the document in that bucket.
+%%
+%% `StartExpenseAnalysis' returns a job identifier (`JobId') that you will
+%% provide to `GetExpenseAnalysis' to retrieve the results of the operation.
+%% When the analysis of the input invoices/receipts is finished, Amazon
+%% Textract publishes a completion status to the Amazon Simple Notification
+%% Service (Amazon SNS) topic that you provide to the `NotificationChannel'.
+%% To obtain the results of the invoice and receipt analysis operation,
+%% ensure that the status value published to the Amazon SNS topic is
+%% `SUCCEEDED'. If so, call `GetExpenseAnalysis', and pass the job identifier
+%% (`JobId') that was returned by your call to `StartExpenseAnalysis'.
+%%
+%% For more information, see Analyzing Invoices and Receipts.
+start_expense_analysis(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_expense_analysis(Client, Input, []).
+start_expense_analysis(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartExpenseAnalysis">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_transcribe.erl
+++ b/src/aws_transcribe.erl
@@ -4,7 +4,9 @@
 %% @doc Operations and objects for transcribing speech to text.
 -module(aws_transcribe).
 
--export([create_language_model/2,
+-export([create_call_analytics_category/2,
+         create_call_analytics_category/3,
+         create_language_model/2,
          create_language_model/3,
          create_medical_vocabulary/2,
          create_medical_vocabulary/3,
@@ -12,6 +14,10 @@
          create_vocabulary/3,
          create_vocabulary_filter/2,
          create_vocabulary_filter/3,
+         delete_call_analytics_category/2,
+         delete_call_analytics_category/3,
+         delete_call_analytics_job/2,
+         delete_call_analytics_job/3,
          delete_language_model/2,
          delete_language_model/3,
          delete_medical_transcription_job/2,
@@ -26,6 +32,10 @@
          delete_vocabulary_filter/3,
          describe_language_model/2,
          describe_language_model/3,
+         get_call_analytics_category/2,
+         get_call_analytics_category/3,
+         get_call_analytics_job/2,
+         get_call_analytics_job/3,
          get_medical_transcription_job/2,
          get_medical_transcription_job/3,
          get_medical_vocabulary/2,
@@ -36,22 +46,36 @@
          get_vocabulary/3,
          get_vocabulary_filter/2,
          get_vocabulary_filter/3,
+         list_call_analytics_categories/2,
+         list_call_analytics_categories/3,
+         list_call_analytics_jobs/2,
+         list_call_analytics_jobs/3,
          list_language_models/2,
          list_language_models/3,
          list_medical_transcription_jobs/2,
          list_medical_transcription_jobs/3,
          list_medical_vocabularies/2,
          list_medical_vocabularies/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
          list_transcription_jobs/2,
          list_transcription_jobs/3,
          list_vocabularies/2,
          list_vocabularies/3,
          list_vocabulary_filters/2,
          list_vocabulary_filters/3,
+         start_call_analytics_job/2,
+         start_call_analytics_job/3,
          start_medical_transcription_job/2,
          start_medical_transcription_job/3,
          start_transcription_job/2,
          start_transcription_job/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_call_analytics_category/2,
+         update_call_analytics_category/3,
          update_medical_vocabulary/2,
          update_medical_vocabulary/3,
          update_vocabulary/2,
@@ -65,6 +89,21 @@
 %% API
 %%====================================================================
 
+%% @doc Creates an analytics category.
+%%
+%% Amazon Transcribe applies the conditions specified by your analytics
+%% categories to your call analytics jobs. For each analytics category, you
+%% specify one or more rules. For example, you can specify a rule that the
+%% customer sentiment was neutral or negative within that category. If you
+%% start a call analytics job, Amazon Transcribe applies the category to the
+%% analytics job that you've specified.
+create_call_analytics_category(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_call_analytics_category(Client, Input, []).
+create_call_analytics_category(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateCallAnalyticsCategory">>, Input, Options).
+
 %% @doc Creates a new custom language model.
 %%
 %% Use Amazon S3 prefixes to provide the location of your input files. The
@@ -77,7 +116,7 @@ create_language_model(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateLanguageModel">>, Input, Options).
 
-%% @doc Creates a new custom vocabulary that you can use to change how Amazon
+%% @doc Creates a new custom vocabulary that you can use to modify how Amazon
 %% Transcribe Medical transcribes your audio file.
 create_medical_vocabulary(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -103,6 +142,22 @@ create_vocabulary_filter(Client, Input)
 create_vocabulary_filter(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateVocabularyFilter">>, Input, Options).
+
+%% @doc Deletes a call analytics category using its name.
+delete_call_analytics_category(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_call_analytics_category(Client, Input, []).
+delete_call_analytics_category(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteCallAnalyticsCategory">>, Input, Options).
+
+%% @doc Deletes a call analytics job using its name.
+delete_call_analytics_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_call_analytics_job(Client, Input, []).
+delete_call_analytics_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteCallAnalyticsJob">>, Input, Options).
 
 %% @doc Deletes a custom language model using its name.
 delete_language_model(Client, Input)
@@ -156,18 +211,41 @@ delete_vocabulary_filter(Client, Input, Options)
 
 %% @doc Gets information about a single custom language model.
 %%
-%% Use this information to see details about the language model in your AWS
-%% account. You can also see whether the base language model used to create
-%% your custom language model has been updated. If Amazon Transcribe has
-%% updated the base model, you can create a new custom language model using
-%% the updated base model. If the language model wasn't created, you can use
-%% this operation to understand why Amazon Transcribe couldn't create it.
+%% Use this information to see details about the language model in your
+%% Amazon Web Services account. You can also see whether the base language
+%% model used to create your custom language model has been updated. If
+%% Amazon Transcribe has updated the base model, you can create a new custom
+%% language model using the updated base model. If the language model wasn't
+%% created, you can use this operation to understand why Amazon Transcribe
+%% couldn't create it.
 describe_language_model(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_language_model(Client, Input, []).
 describe_language_model(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeLanguageModel">>, Input, Options).
+
+%% @doc Retrieves information about a call analytics category.
+get_call_analytics_category(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_call_analytics_category(Client, Input, []).
+get_call_analytics_category(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetCallAnalyticsCategory">>, Input, Options).
+
+%% @doc Returns information about a call analytics job.
+%%
+%% To see the status of the job, check the `CallAnalyticsJobStatus' field. If
+%% the status is `COMPLETED', the job is finished and you can find the
+%% results at the location specified in the `TranscriptFileUri' field. If you
+%% enable personally identifiable information (PII) redaction, the redacted
+%% transcript appears in the `RedactedTranscriptFileUri' field.
+get_call_analytics_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_call_analytics_job(Client, Input, []).
+get_call_analytics_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetCallAnalyticsJob">>, Input, Options).
 
 %% @doc Returns information about a transcription job from Amazon Transcribe
 %% Medical.
@@ -220,6 +298,27 @@ get_vocabulary_filter(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetVocabularyFilter">>, Input, Options).
 
+%% @doc Provides more information about the call analytics categories that
+%% you've created.
+%%
+%% You can use the information in this list to find a specific category. You
+%% can then use the operation to get more information about it.
+list_call_analytics_categories(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_call_analytics_categories(Client, Input, []).
+list_call_analytics_categories(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListCallAnalyticsCategories">>, Input, Options).
+
+%% @doc List call analytics jobs with a specified status or substring that
+%% matches their names.
+list_call_analytics_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_call_analytics_jobs(Client, Input, []).
+list_call_analytics_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListCallAnalyticsJobs">>, Input, Options).
+
 %% @doc Provides more information about the custom language models you've
 %% created.
 %%
@@ -253,6 +352,15 @@ list_medical_vocabularies(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListMedicalVocabularies">>, Input, Options).
 
+%% @doc Lists all tags associated with a given transcription job, vocabulary,
+%% or resource.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
 %% @doc Lists transcription jobs with the specified status.
 list_transcription_jobs(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -279,6 +387,22 @@ list_vocabulary_filters(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListVocabularyFilters">>, Input, Options).
 
+%% @doc Starts an asynchronous analytics job that not only transcribes the
+%% audio recording of a caller and agent, but also returns additional
+%% insights.
+%%
+%% These insights include how quickly or loudly the caller or agent was
+%% speaking. To retrieve additional insights with your analytics jobs, create
+%% categories. A category is a way to classify analytics jobs based on
+%% attributes, such as a customer's sentiment or a particular phrase being
+%% used during the call. For more information, see the operation.
+start_call_analytics_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_call_analytics_job(Client, Input, []).
+start_call_analytics_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartCallAnalyticsJob">>, Input, Options).
+
 %% @doc Starts a batch job to transcribe medical speech to text.
 start_medical_transcription_job(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -294,6 +418,33 @@ start_transcription_job(Client, Input)
 start_transcription_job(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"StartTranscriptionJob">>, Input, Options).
+
+%% @doc Tags an Amazon Transcribe resource with the given list of tags.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes specified tags from a specified Amazon Transcribe resource.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates the call analytics category with new values.
+%%
+%% The `UpdateCallAnalyticsCategory' operation overwrites all of the existing
+%% information with the values that you provide in the request.
+update_call_analytics_category(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_call_analytics_category(Client, Input, []).
+update_call_analytics_category(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateCallAnalyticsCategory">>, Input, Options).
 
 %% @doc Updates a vocabulary with new values that you provide in a different
 %% text file from the one you used to create the vocabulary.

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -79,10 +79,11 @@ start_medical_stream_transcription(Client, Input0, Options0) ->
         Result
     end.
 
-%% @doc Starts a bidirectional HTTP2 stream where audio is streamed to Amazon
-%% Transcribe and the transcription results are streamed to your application.
+%% @doc Starts a bidirectional HTTP/2 stream where audio is streamed to
+%% Amazon Transcribe and the transcription results are streamed to your
+%% application.
 %%
-%% The following are encoded as HTTP2 headers:
+%% The following are encoded as HTTP/2 headers:
 %%
 %% <ul> <li> x-amzn-transcribe-language-code
 %%
@@ -92,7 +93,7 @@ start_medical_stream_transcription(Client, Input0, Options0) ->
 %%
 %% </li> <li> x-amzn-transcribe-session-id
 %%
-%% </li> </ul>
+%% </li> </ul> See the SDK for Go API Reference for more detail.
 start_stream_transcription(Client, Input) ->
     start_stream_transcription(Client, Input, []).
 start_stream_transcription(Client, Input0, Options0) ->
@@ -105,11 +106,17 @@ start_stream_transcription(Client, Input0, Options0) ->
 
 
     HeadersMapping = [
+                       {<<"x-amzn-transcribe-content-identification-type">>, <<"ContentIdentificationType">>},
+                       {<<"x-amzn-transcribe-content-redaction-type">>, <<"ContentRedactionType">>},
                        {<<"x-amzn-transcribe-enable-channel-identification">>, <<"EnableChannelIdentification">>},
+                       {<<"x-amzn-transcribe-enable-partial-results-stabilization">>, <<"EnablePartialResultsStabilization">>},
                        {<<"x-amzn-transcribe-language-code">>, <<"LanguageCode">>},
+                       {<<"x-amzn-transcribe-language-model-name">>, <<"LanguageModelName">>},
                        {<<"x-amzn-transcribe-media-encoding">>, <<"MediaEncoding">>},
                        {<<"x-amzn-transcribe-sample-rate">>, <<"MediaSampleRateHertz">>},
                        {<<"x-amzn-transcribe-number-of-channels">>, <<"NumberOfChannels">>},
+                       {<<"x-amzn-transcribe-partial-results-stability">>, <<"PartialResultsStability">>},
+                       {<<"x-amzn-transcribe-pii-entity-types">>, <<"PiiEntityTypes">>},
                        {<<"x-amzn-transcribe-session-id">>, <<"SessionId">>},
                        {<<"x-amzn-transcribe-show-speaker-label">>, <<"ShowSpeakerLabel">>},
                        {<<"x-amzn-transcribe-vocabulary-filter-method">>, <<"VocabularyFilterMethod">>},
@@ -128,11 +135,17 @@ start_stream_transcription(Client, Input0, Options0) ->
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [
+            {<<"x-amzn-transcribe-content-identification-type">>, <<"ContentIdentificationType">>},
+            {<<"x-amzn-transcribe-content-redaction-type">>, <<"ContentRedactionType">>},
             {<<"x-amzn-transcribe-enable-channel-identification">>, <<"EnableChannelIdentification">>},
+            {<<"x-amzn-transcribe-enable-partial-results-stabilization">>, <<"EnablePartialResultsStabilization">>},
             {<<"x-amzn-transcribe-language-code">>, <<"LanguageCode">>},
+            {<<"x-amzn-transcribe-language-model-name">>, <<"LanguageModelName">>},
             {<<"x-amzn-transcribe-media-encoding">>, <<"MediaEncoding">>},
             {<<"x-amzn-transcribe-sample-rate">>, <<"MediaSampleRateHertz">>},
             {<<"x-amzn-transcribe-number-of-channels">>, <<"NumberOfChannels">>},
+            {<<"x-amzn-transcribe-partial-results-stability">>, <<"PartialResultsStability">>},
+            {<<"x-amzn-transcribe-pii-entity-types">>, <<"PiiEntityTypes">>},
             {<<"x-amzn-request-id">>, <<"RequestId">>},
             {<<"x-amzn-transcribe-session-id">>, <<"SessionId">>},
             {<<"x-amzn-transcribe-show-speaker-label">>, <<"ShowSpeakerLabel">>},
@@ -187,6 +200,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_transfer.erl
+++ b/src/aws_transfer.erl
@@ -1,38 +1,58 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Transfer Family is a fully managed service that enables the
-%% transfer of files over the File Transfer Protocol (FTP), File Transfer
-%% Protocol over SSL (FTPS), or Secure Shell (SSH) File Transfer Protocol
-%% (SFTP) directly into and out of Amazon Simple Storage Service (Amazon S3).
+%% @doc Amazon Web Services Transfer Family is a fully managed service that
+%% enables the transfer of files over the File Transfer Protocol (FTP), File
+%% Transfer Protocol over SSL (FTPS), or Secure Shell (SSH) File Transfer
+%% Protocol (SFTP) directly into and out of Amazon Simple Storage Service
+%% (Amazon S3).
 %%
-%% AWS helps you seamlessly migrate your file transfer workflows to AWS
-%% Transfer Family by integrating with existing authentication systems, and
-%% providing DNS routing with Amazon Route 53 so nothing changes for your
-%% customers and partners, or their applications. With your data in Amazon
-%% S3, you can use it with AWS services for processing, analytics, machine
-%% learning, and archiving. Getting started with AWS Transfer Family is easy
-%% since there is no infrastructure to buy and set up.
+%% Amazon Web Services helps you seamlessly migrate your file transfer
+%% workflows to Amazon Web Services Transfer Family by integrating with
+%% existing authentication systems, and providing DNS routing with Amazon
+%% Route 53 so nothing changes for your customers and partners, or their
+%% applications. With your data in Amazon S3, you can use it with Amazon Web
+%% Services services for processing, analytics, machine learning, and
+%% archiving. Getting started with Amazon Web Services Transfer Family is
+%% easy since there is no infrastructure to buy and set up.
 -module(aws_transfer).
 
--export([create_server/2,
+-export([create_access/2,
+         create_access/3,
+         create_server/2,
          create_server/3,
          create_user/2,
          create_user/3,
+         create_workflow/2,
+         create_workflow/3,
+         delete_access/2,
+         delete_access/3,
          delete_server/2,
          delete_server/3,
          delete_ssh_public_key/2,
          delete_ssh_public_key/3,
          delete_user/2,
          delete_user/3,
+         delete_workflow/2,
+         delete_workflow/3,
+         describe_access/2,
+         describe_access/3,
+         describe_execution/2,
+         describe_execution/3,
          describe_security_policy/2,
          describe_security_policy/3,
          describe_server/2,
          describe_server/3,
          describe_user/2,
          describe_user/3,
+         describe_workflow/2,
+         describe_workflow/3,
          import_ssh_public_key/2,
          import_ssh_public_key/3,
+         list_accesses/2,
+         list_accesses/3,
+         list_executions/2,
+         list_executions/3,
          list_security_policies/2,
          list_security_policies/3,
          list_servers/2,
@@ -41,6 +61,10 @@
          list_tags_for_resource/3,
          list_users/2,
          list_users/3,
+         list_workflows/2,
+         list_workflows/3,
+         send_workflow_step_state/2,
+         send_workflow_step_state/3,
          start_server/2,
          start_server/3,
          stop_server/2,
@@ -51,6 +75,8 @@
          test_identity_provider/3,
          untag_resource/2,
          untag_resource/3,
+         update_access/2,
+         update_access/3,
          update_server/2,
          update_server/3,
          update_user/2,
@@ -62,8 +88,23 @@
 %% API
 %%====================================================================
 
-%% @doc Instantiates an autoscaling virtual server based on the selected file
-%% transfer protocol in AWS.
+%% @doc Used by administrators to choose which groups in the directory should
+%% have access to upload and download files over the enabled protocols using
+%% Amazon Web Services Transfer Family.
+%%
+%% For example, a Microsoft Active Directory might contain 50,000 users, but
+%% only a small fraction might need the ability to transfer files to the
+%% server. An administrator can use `CreateAccess' to limit the access to the
+%% correct set of users who need this ability.
+create_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_access(Client, Input, []).
+create_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateAccess">>, Input, Options).
+
+%% @doc Instantiates an auto-scaling virtual server based on the selected
+%% file transfer protocol in Amazon Web Services.
 %%
 %% When you make updates to your file transfer protocol-enabled server or
 %% when you work with users, use the service-generated `ServerId' property
@@ -81,16 +122,38 @@ create_server(Client, Input, Options)
 %% You can only create and associate users with servers that have the
 %% `IdentityProviderType' set to `SERVICE_MANAGED'. Using parameters for
 %% `CreateUser', you can specify the user name, set the home directory, store
-%% the user's public key, and assign the user's AWS Identity and Access
-%% Management (IAM) role. You can also optionally add a scope-down policy,
-%% and assign metadata with tags that can be used to group and search for
-%% users.
+%% the user's public key, and assign the user's Amazon Web Services Identity
+%% and Access Management (IAM) role. You can also optionally add a session
+%% policy, and assign metadata with tags that can be used to group and search
+%% for users.
 create_user(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_user(Client, Input, []).
 create_user(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateUser">>, Input, Options).
+
+%% @doc Allows you to create a workflow with specified steps and step details
+%% the workflow invokes after file transfer completes.
+%%
+%% After creating a workflow, you can associate the workflow created with any
+%% transfer servers by specifying the `workflow-details' field in
+%% `CreateServer' and `UpdateServer' operations.
+create_workflow(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_workflow(Client, Input, []).
+create_workflow(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateWorkflow">>, Input, Options).
+
+%% @doc Allows you to delete the access specified in the `ServerID' and
+%% `ExternalID' parameters.
+delete_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_access(Client, Input, []).
+delete_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteAccess">>, Input, Options).
 
 %% @doc Deletes the file transfer protocol-enabled server that you specify.
 %%
@@ -103,8 +166,6 @@ delete_server(Client, Input, Options)
     request(Client, <<"DeleteServer">>, Input, Options).
 
 %% @doc Deletes a user's Secure Shell (SSH) public key.
-%%
-%% No response is returned from this operation.
 delete_ssh_public_key(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_ssh_public_key(Client, Input, []).
@@ -124,6 +185,36 @@ delete_user(Client, Input)
 delete_user(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteUser">>, Input, Options).
+
+%% @doc Deletes the specified workflow.
+delete_workflow(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_workflow(Client, Input, []).
+delete_workflow(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteWorkflow">>, Input, Options).
+
+%% @doc Describes the access that is assigned to the specific file transfer
+%% protocol-enabled server, as identified by its `ServerId' property and its
+%% `ExternalID'.
+%%
+%% The response from this call returns the properties of the access that is
+%% associated with the `ServerId' value that was specified.
+describe_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_access(Client, Input, []).
+describe_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeAccess">>, Input, Options).
+
+%% @doc You can use `DescribeExecution' to check the details of the execution
+%% of the specified workflow.
+describe_execution(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_execution(Client, Input, []).
+describe_execution(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeExecution">>, Input, Options).
 
 %% @doc Describes the security policy that is attached to your file transfer
 %% protocol-enabled server.
@@ -162,6 +253,14 @@ describe_user(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeUser">>, Input, Options).
 
+%% @doc Describes the specified workflow.
+describe_workflow(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_workflow(Client, Input, []).
+describe_workflow(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeWorkflow">>, Input, Options).
+
 %% @doc Adds a Secure Shell (SSH) public key to a user account identified by
 %% a `UserName' value assigned to the specific file transfer protocol-enabled
 %% server, identified by `ServerId'.
@@ -175,6 +274,22 @@ import_ssh_public_key(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ImportSshPublicKey">>, Input, Options).
 
+%% @doc Lists the details for all the accesses you have on your server.
+list_accesses(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_accesses(Client, Input, []).
+list_accesses(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListAccesses">>, Input, Options).
+
+%% @doc Lists all executions for the specified workflow.
+list_executions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_executions(Client, Input, []).
+list_executions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListExecutions">>, Input, Options).
+
 %% @doc Lists the security policies that are attached to your file transfer
 %% protocol-enabled servers.
 list_security_policies(Client, Input)
@@ -185,7 +300,7 @@ list_security_policies(Client, Input, Options)
     request(Client, <<"ListSecurityPolicies">>, Input, Options).
 
 %% @doc Lists the file transfer protocol-enabled servers that are associated
-%% with your AWS account.
+%% with your Amazon Web Services account.
 list_servers(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_servers(Client, Input, []).
@@ -193,8 +308,8 @@ list_servers(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListServers">>, Input, Options).
 
-%% @doc Lists all of the tags associated with the Amazon Resource Number
-%% (ARN) you specify.
+%% @doc Lists all of the tags associated with the Amazon Resource Name (ARN)
+%% that you specify.
 %%
 %% The resource can be a user, server, or role.
 list_tags_for_resource(Client, Input)
@@ -212,6 +327,26 @@ list_users(Client, Input)
 list_users(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListUsers">>, Input, Options).
+
+%% @doc Lists all of your workflows.
+list_workflows(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_workflows(Client, Input, []).
+list_workflows(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListWorkflows">>, Input, Options).
+
+%% @doc Sends a callback for asynchronous custom steps.
+%%
+%% The `ExecutionId', `WorkflowId', and `Token' are passed to the target
+%% resource during execution of a custom step of a workflow. You must include
+%% those with their callback as well as providing a status.
+send_workflow_step_state(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    send_workflow_step_state(Client, Input, []).
+send_workflow_step_state(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"SendWorkflowStepState">>, Input, Options).
 
 %% @doc Changes the state of a file transfer protocol-enabled server from
 %% `OFFLINE' to `ONLINE'.
@@ -267,13 +402,38 @@ tag_resource(Client, Input, Options)
     request(Client, <<"TagResource">>, Input, Options).
 
 %% @doc If the `IdentityProviderType' of a file transfer protocol-enabled
-%% server is `API_Gateway', tests whether your API Gateway is set up
-%% successfully.
+%% server is `AWS_DIRECTORY_SERVICE' or `API_Gateway', tests whether your
+%% identity provider is set up successfully.
 %%
 %% We highly recommend that you call this operation to test your
 %% authentication method as soon as you create your server. By doing so, you
-%% can troubleshoot issues with the API Gateway integration to ensure that
-%% your users can successfully use the service.
+%% can troubleshoot issues with the identity provider integration to ensure
+%% that your users can successfully use the service.
+%%
+%% The `ServerId' and `UserName' parameters are required. The
+%% `ServerProtocol', `SourceIp', and `UserPassword' are all optional.
+%%
+%% You cannot use `TestIdentityProvider' if the `IdentityProviderType' of
+%% your server is `SERVICE_MANAGED'.
+%%
+%% <ul> <li> If you provide any incorrect values for any parameters, the
+%% `Response' field is empty.
+%%
+%% </li> <li> If you provide a server ID for a server that uses
+%% service-managed users, you get an error:
+%%
+%% ` An error occurred (InvalidRequestException) when calling the
+%% TestIdentityProvider operation: s-server-ID not configured for external
+%% auth '
+%%
+%% </li> <li> If you enter a Server ID for the `--server-id' parameter that
+%% does not identify an actual Transfer server, you receive the following
+%% error:
+%%
+%% `An error occurred (ResourceNotFoundException) when calling the
+%% TestIdentityProvider operation: Unknown server'
+%%
+%% </li> </ul>
 test_identity_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     test_identity_provider(Client, Input, []).
@@ -293,6 +453,15 @@ untag_resource(Client, Input)
 untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Allows you to update parameters for the access specified in the
+%% `ServerID' and `ExternalID' parameters.
+update_access(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_access(Client, Input, []).
+update_access(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateAccess">>, Input, Options).
 
 %% @doc Updates the file transfer protocol-enabled server's properties after
 %% that server has been created.

--- a/src/aws_translate.erl
+++ b/src/aws_translate.erl
@@ -43,9 +43,9 @@
 %% @doc Creates a parallel data resource in Amazon Translate by importing an
 %% input file from Amazon S3.
 %%
-%% Parallel data files contain examples of source phrases and their
-%% translations from your translation memory. By adding parallel data, you
-%% can influence the style, tone, and word choice in your translation output.
+%% Parallel data files contain examples that show how you want segments of
+%% text to be translated. By adding parallel data, you can influence the
+%% style, tone, and word choice in your translation output.
 create_parallel_data(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_parallel_data(Client, Input, []).
@@ -69,7 +69,7 @@ delete_terminology(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteTerminology">>, Input, Options).
 
-%% @doc Gets the properties associated with an asycnhronous batch translation
+%% @doc Gets the properties associated with an asynchronous batch translation
 %% job including name, ID, status, source and target languages, input/output
 %% S3 buckets, and so on.
 describe_text_translation_job(Client, Input)

--- a/src/aws_voice_id.erl
+++ b/src/aws_voice_id.erl
@@ -1,0 +1,304 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc Amazon Connect Voice ID provides real-time caller authentication and
+%% fraud screening.
+%%
+%% This guide describes the APIs used for this service.
+-module(aws_voice_id).
+
+-export([create_domain/2,
+         create_domain/3,
+         delete_domain/2,
+         delete_domain/3,
+         delete_fraudster/2,
+         delete_fraudster/3,
+         delete_speaker/2,
+         delete_speaker/3,
+         describe_domain/2,
+         describe_domain/3,
+         describe_fraudster/2,
+         describe_fraudster/3,
+         describe_fraudster_registration_job/2,
+         describe_fraudster_registration_job/3,
+         describe_speaker/2,
+         describe_speaker/3,
+         describe_speaker_enrollment_job/2,
+         describe_speaker_enrollment_job/3,
+         evaluate_session/2,
+         evaluate_session/3,
+         list_domains/2,
+         list_domains/3,
+         list_fraudster_registration_jobs/2,
+         list_fraudster_registration_jobs/3,
+         list_speaker_enrollment_jobs/2,
+         list_speaker_enrollment_jobs/3,
+         list_speakers/2,
+         list_speakers/3,
+         list_tags_for_resource/2,
+         list_tags_for_resource/3,
+         opt_out_speaker/2,
+         opt_out_speaker/3,
+         start_fraudster_registration_job/2,
+         start_fraudster_registration_job/3,
+         start_speaker_enrollment_job/2,
+         start_speaker_enrollment_job/3,
+         tag_resource/2,
+         tag_resource/3,
+         untag_resource/2,
+         untag_resource/3,
+         update_domain/2,
+         update_domain/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates a domain that contains all Amazon Connect Voice ID data, such
+%% as speakers, fraudsters, customer audio, and voiceprints.
+create_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_domain(Client, Input, []).
+create_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateDomain">>, Input, Options).
+
+%% @doc Deletes the specified domain from the Amazon Connect Voice ID system.
+delete_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_domain(Client, Input, []).
+delete_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteDomain">>, Input, Options).
+
+%% @doc Deletes the specified fraudster from the Amazon Connect Voice ID
+%% system.
+delete_fraudster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_fraudster(Client, Input, []).
+delete_fraudster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteFraudster">>, Input, Options).
+
+%% @doc Deletes the specified speaker from the Amazon Connect Voice ID
+%% system.
+delete_speaker(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_speaker(Client, Input, []).
+delete_speaker(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteSpeaker">>, Input, Options).
+
+%% @doc Describes the specified domain.
+describe_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_domain(Client, Input, []).
+describe_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeDomain">>, Input, Options).
+
+%% @doc Describes the specified fraudster.
+describe_fraudster(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_fraudster(Client, Input, []).
+describe_fraudster(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFraudster">>, Input, Options).
+
+%% @doc Describes the specified fraudster registration job.
+describe_fraudster_registration_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_fraudster_registration_job(Client, Input, []).
+describe_fraudster_registration_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeFraudsterRegistrationJob">>, Input, Options).
+
+%% @doc Describes the specified speaker.
+describe_speaker(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_speaker(Client, Input, []).
+describe_speaker(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeSpeaker">>, Input, Options).
+
+%% @doc Describes the specified speaker enrollment job.
+describe_speaker_enrollment_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_speaker_enrollment_job(Client, Input, []).
+describe_speaker_enrollment_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeSpeakerEnrollmentJob">>, Input, Options).
+
+%% @doc Evaluates a specified session based on audio data accumulated during
+%% a streaming Amazon Connect Voice ID call.
+evaluate_session(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    evaluate_session(Client, Input, []).
+evaluate_session(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"EvaluateSession">>, Input, Options).
+
+%% @doc Lists all the domains in the Amazon Web Services account.
+list_domains(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_domains(Client, Input, []).
+list_domains(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDomains">>, Input, Options).
+
+%% @doc Lists all the fraudster registration jobs in the domain with the
+%% given `JobStatus'.
+%%
+%% If `JobStatus' is not provided, this lists all fraudster registration jobs
+%% in the given domain.
+list_fraudster_registration_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_fraudster_registration_jobs(Client, Input, []).
+list_fraudster_registration_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListFraudsterRegistrationJobs">>, Input, Options).
+
+%% @doc Lists all the speaker enrollment jobs in the domain with the
+%% specified `JobStatus'.
+%%
+%% If `JobStatus' is not provided, this lists all jobs with all possible
+%% speaker enrollment job statuses.
+list_speaker_enrollment_jobs(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_speaker_enrollment_jobs(Client, Input, []).
+list_speaker_enrollment_jobs(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListSpeakerEnrollmentJobs">>, Input, Options).
+
+%% @doc Lists all speakers in a specified domain.
+list_speakers(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_speakers(Client, Input, []).
+list_speakers(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListSpeakers">>, Input, Options).
+
+%% @doc Lists all tags associated with a specified Voice ID resource.
+list_tags_for_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_tags_for_resource(Client, Input, []).
+list_tags_for_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListTagsForResource">>, Input, Options).
+
+%% @doc Opts out a speaker from Voice ID system.
+%%
+%% A speaker can be opted out regardless of whether or not they already exist
+%% in the system. If they don't yet exist, a new speaker is created in an
+%% opted out state. If they already exist, their existing status is
+%% overridden and they are opted out. Enrollment and evaluation
+%% authentication requests are rejected for opted out speakers, and opted out
+%% speakers have no voice embeddings stored in the system.
+opt_out_speaker(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    opt_out_speaker(Client, Input, []).
+opt_out_speaker(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"OptOutSpeaker">>, Input, Options).
+
+%% @doc Starts a new batch fraudster registration job using provided details.
+start_fraudster_registration_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_fraudster_registration_job(Client, Input, []).
+start_fraudster_registration_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartFraudsterRegistrationJob">>, Input, Options).
+
+%% @doc Starts a new batch speaker enrollment job using specified details.
+start_speaker_enrollment_job(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    start_speaker_enrollment_job(Client, Input, []).
+start_speaker_enrollment_job(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"StartSpeakerEnrollmentJob">>, Input, Options).
+
+%% @doc Tags an Amazon Connect Voice ID resource with the provided list of
+%% tags.
+tag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    tag_resource(Client, Input, []).
+tag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"TagResource">>, Input, Options).
+
+%% @doc Removes specified tags from a specified Amazon Connect Voice ID
+%% resource.
+untag_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    untag_resource(Client, Input, []).
+untag_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UntagResource">>, Input, Options).
+
+%% @doc Updates the specified domain.
+%%
+%% This API has clobber behavior, and clears and replaces all attributes. If
+%% an optional field, such as 'Description' is not provided, it is removed
+%% from the domain.
+update_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_domain(Client, Input, []).
+update_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateDomain">>, Input, Options).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), binary(), map(), list()) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: map().
+request(Client, Action, Input0, Options) ->
+    Client1 = Client#{service => <<"voiceid">>},
+    Host = build_host(<<"voiceid">>, Client1),
+    URL = build_url(Host, Client1),
+    Headers = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
+        {<<"X-Amz-Target">>, <<"VoiceID.", Action/binary>>}
+    ],
+
+    Input = Input0,
+
+    Payload = jsx:encode(Input),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
+    handle_response(Response).
+
+handle_response({ok, 200, ResponseHeaders, Client}) ->
+    case hackney:body(Client) of
+        {ok, <<>>} ->
+            {ok, undefined, {200, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body),
+            {ok, Result, {200, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}) ->
+    {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/src/aws_wafv2.erl
+++ b/src/aws_wafv2.erl
@@ -1,8 +1,9 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc This is the latest version of the AWS WAF API, released in November,
-%% 2019.
+%% @doc WAF
+%%
+%% This is the latest version of the WAF API, released in November, 2019.
 %%
 %% The names of the entities that you use to access this API, like endpoints
 %% and namespaces, all have the versioning information added, like "V2" or
@@ -10,47 +11,45 @@
 %% resources to this version, because it has a number of significant
 %% improvements.
 %%
-%% If you used AWS WAF prior to this release, you can't use this AWS WAFV2
-%% API to access any AWS WAF resources that you created before. You can
-%% access your old rules, web ACLs, and other AWS WAF resources only through
-%% the AWS WAF Classic APIs. The AWS WAF Classic APIs have retained the prior
-%% names, endpoints, and namespaces.
+%% If you used WAF prior to this release, you can't use this WAFV2 API to
+%% access any WAF resources that you created before. You can access your old
+%% rules, web ACLs, and other WAF resources only through the WAF Classic
+%% APIs. The WAF Classic APIs have retained the prior names, endpoints, and
+%% namespaces.
 %%
-%% For information, including how to migrate your AWS WAF resources to this
-%% version, see the AWS WAF Developer Guide.
+%% For information, including how to migrate your WAF resources to this
+%% version, see the WAF Developer Guide.
 %%
-%% AWS WAF is a web application firewall that lets you monitor the HTTP and
-%% HTTPS requests that are forwarded to Amazon CloudFront, an Amazon API
-%% Gateway REST API, an Application Load Balancer, or an AWS AppSync GraphQL
-%% API. AWS WAF also lets you control access to your content. Based on
-%% conditions that you specify, such as the IP addresses that requests
-%% originate from or the values of query strings, the API Gateway REST API,
-%% CloudFront distribution, the Application Load Balancer, or the AWS AppSync
-%% GraphQL API responds to requests either with the requested content or with
-%% an HTTP 403 status code (Forbidden). You also can configure CloudFront to
-%% return a custom error page when a request is blocked.
+%% WAF is a web application firewall that lets you monitor the HTTP and HTTPS
+%% requests that are forwarded to Amazon CloudFront, an Amazon API Gateway
+%% REST API, an Application Load Balancer, or an AppSync GraphQL API. WAF
+%% also lets you control access to your content. Based on conditions that you
+%% specify, such as the IP addresses that requests originate from or the
+%% values of query strings, the Amazon API Gateway REST API, CloudFront
+%% distribution, the Application Load Balancer, or the AppSync GraphQL API
+%% responds to requests either with the requested content or with an HTTP 403
+%% status code (Forbidden). You also can configure CloudFront to return a
+%% custom error page when a request is blocked.
 %%
-%% This API guide is for developers who need detailed information about AWS
-%% WAF API actions, data types, and errors. For detailed information about
-%% AWS WAF features and an overview of how to use AWS WAF, see the AWS WAF
-%% Developer Guide.
+%% This API guide is for developers who need detailed information about WAF
+%% API actions, data types, and errors. For detailed information about WAF
+%% features and an overview of how to use WAF, see the WAF Developer Guide.
 %%
-%% You can make calls using the endpoints listed in AWS Service Endpoints for
-%% AWS WAF.
+%% You can make calls using the endpoints listed in WAF endpoints and quotas.
 %%
 %% <ul> <li> For regional applications, you can use any of the endpoints in
 %% the list. A regional application can be an Application Load Balancer
-%% (ALB), an API Gateway REST API, or an AppSync GraphQL API.
+%% (ALB), an Amazon API Gateway REST API, or an AppSync GraphQL API.
 %%
-%% </li> <li> For AWS CloudFront applications, you must use the API endpoint
-%% listed for US East (N. Virginia): us-east-1.
+%% </li> <li> For Amazon CloudFront applications, you must use the API
+%% endpoint listed for US East (N. Virginia): us-east-1.
 %%
-%% </li> </ul> Alternatively, you can use one of the AWS SDKs to access an
-%% API that's tailored to the programming language or platform that you're
-%% using. For more information, see AWS SDKs.
+%% </li> </ul> Alternatively, you can use one of the Amazon Web Services SDKs
+%% to access an API that's tailored to the programming language or platform
+%% that you're using. For more information, see Amazon Web Services SDKs.
 %%
-%% We currently provide two versions of the AWS WAF API: this API and the
-%% prior versions, the classic AWS WAF APIs. This new API provides the same
+%% We currently provide two versions of the WAF API: this API and the prior
+%% versions, the classic WAF APIs. This new API provides the same
 %% functionality as the older versions, with the following major
 %% improvements:
 %%
@@ -58,14 +57,13 @@
 %% you need to distinguish the scope, you specify a `Scope' parameter and set
 %% it to `CLOUDFRONT' or `REGIONAL'.
 %%
-%% </li> <li> You can define a Web ACL or rule group with a single call, and
+%% </li> <li> You can define a web ACL or rule group with a single call, and
 %% update it with a single call. You define all rule specifications in JSON
-%% format, and pass them to your rule group or Web ACL calls.
+%% format, and pass them to your rule group or web ACL calls.
 %%
-%% </li> <li> The limits AWS WAF places on the use of rules more closely
-%% reflects the cost of running each type of rule. Rule groups include
-%% capacity settings, so you know the maximum cost of a rule group when you
-%% use it.
+%% </li> <li> The limits WAF places on the use of rules more closely reflects
+%% the cost of running each type of rule. Rule groups include capacity
+%% settings, so you know the maximum cost of a rule group when you use it.
 %%
 %% </li> </ul>
 -module(aws_wafv2).
@@ -104,6 +102,8 @@
          get_ip_set/3,
          get_logging_configuration/2,
          get_logging_configuration/3,
+         get_managed_rule_set/2,
+         get_managed_rule_set/3,
          get_permission_policy/2,
          get_permission_policy/3,
          get_rate_based_statement_managed_keys/2,
@@ -118,12 +118,16 @@
          get_web_acl/3,
          get_web_acl_for_resource/2,
          get_web_acl_for_resource/3,
+         list_available_managed_rule_group_versions/2,
+         list_available_managed_rule_group_versions/3,
          list_available_managed_rule_groups/2,
          list_available_managed_rule_groups/3,
          list_ip_sets/2,
          list_ip_sets/3,
          list_logging_configurations/2,
          list_logging_configurations/3,
+         list_managed_rule_sets/2,
+         list_managed_rule_sets/3,
          list_regex_pattern_sets/2,
          list_regex_pattern_sets/3,
          list_resources_for_web_acl/2,
@@ -136,6 +140,8 @@
          list_web_acls/3,
          put_logging_configuration/2,
          put_logging_configuration/3,
+         put_managed_rule_set_versions/2,
+         put_managed_rule_set_versions/3,
          put_permission_policy/2,
          put_permission_policy/3,
          tag_resource/2,
@@ -144,6 +150,8 @@
          untag_resource/3,
          update_ip_set/2,
          update_ip_set/3,
+         update_managed_rule_set_version_expiry_date/2,
+         update_managed_rule_set_version_expiry_date/3,
          update_regex_pattern_set/2,
          update_regex_pattern_set/3,
          update_rule_group/2,
@@ -157,16 +165,16 @@
 %% API
 %%====================================================================
 
-%% @doc Associates a Web ACL with a regional application resource, to protect
+%% @doc Associates a web ACL with a regional application resource, to protect
 %% the resource.
 %%
-%% A regional application can be an Application Load Balancer (ALB), an API
-%% Gateway REST API, or an AppSync GraphQL API.
+%% A regional application can be an Application Load Balancer (ALB), an
+%% Amazon API Gateway REST API, or an AppSync GraphQL API.
 %%
-%% For AWS CloudFront, don't use this call. Instead, use your CloudFront
-%% distribution configuration. To associate a Web ACL, in the CloudFront call
+%% For Amazon CloudFront, don't use this call. Instead, use your CloudFront
+%% distribution configuration. To associate a web ACL, in the CloudFront call
 %% `UpdateDistribution', set the web ACL ID to the Amazon Resource Name (ARN)
-%% of the Web ACL. For information, see UpdateDistribution.
+%% of the web ACL. For information, see UpdateDistribution.
 associate_web_acl(Client, Input)
   when is_map(Client), is_map(Input) ->
     associate_web_acl(Client, Input, []).
@@ -180,13 +188,13 @@ associate_web_acl(Client, Input, Options)
 %% You can use this to check the capacity requirements for the rules you want
 %% to use in a `RuleGroup' or `WebACL'.
 %%
-%% AWS WAF uses WCUs to calculate and control the operating resources that
-%% are used to run your rules, rule groups, and web ACLs. AWS WAF calculates
-%% capacity differently for each rule type, to reflect the relative cost of
-%% each rule. Simple rules that cost little to run use fewer WCUs than more
-%% complex rules that use more processing power. Rule group capacity is fixed
-%% at creation, which helps users plan their web ACL WCU usage when they use
-%% a rule group. The WCU limit for web ACLs is 1,500.
+%% WAF uses WCUs to calculate and control the operating resources that are
+%% used to run your rules, rule groups, and web ACLs. WAF calculates capacity
+%% differently for each rule type, to reflect the relative cost of each rule.
+%% Simple rules that cost little to run use fewer WCUs than more complex
+%% rules that use more processing power. Rule group capacity is fixed at
+%% creation, which helps users plan their web ACL WCU usage when they use a
+%% rule group. The WCU limit for web ACLs is 1,500.
 check_capacity(Client, Input)
   when is_map(Client), is_map(Input) ->
     check_capacity(Client, Input, []).
@@ -198,8 +206,8 @@ check_capacity(Client, Input, Options)
 %% originate from specific IP addresses or ranges of IP addresses.
 %%
 %% For example, if you're receiving a lot of requests from a ranges of IP
-%% addresses, you can configure AWS WAF to block them using an IPSet that
-%% lists those IP addresses.
+%% addresses, you can configure WAF to block them using an IPSet that lists
+%% those IP addresses.
 create_ip_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_ip_set(Client, Input, []).
@@ -208,7 +216,7 @@ create_ip_set(Client, Input, Options)
     request(Client, <<"CreateIPSet">>, Input, Options).
 
 %% @doc Creates a `RegexPatternSet', which you reference in a
-%% `RegexPatternSetReferenceStatement', to have AWS WAF inspect a web request
+%% `RegexPatternSetReferenceStatement', to have WAF inspect a web request
 %% component for the specified patterns.
 create_regex_pattern_set(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -233,15 +241,15 @@ create_rule_group(Client, Input, Options)
 
 %% @doc Creates a `WebACL' per the specifications provided.
 %%
-%% A Web ACL defines a collection of rules to use to inspect and control web
+%% A web ACL defines a collection of rules to use to inspect and control web
 %% requests. Each rule has an action defined (allow, block, or count) for
-%% requests that match the statement of the rule. In the Web ACL, you assign
+%% requests that match the statement of the rule. In the web ACL, you assign
 %% a default action to take (allow, block) for any request that does not
-%% match any of the rules. The rules in a Web ACL can be a combination of the
-%% types `Rule', `RuleGroup', and managed rule group. You can associate a Web
-%% ACL with one or more AWS resources to protect. The resources can be Amazon
-%% CloudFront, an Amazon API Gateway REST API, an Application Load Balancer,
-%% or an AWS AppSync GraphQL API.
+%% match any of the rules. The rules in a web ACL can be a combination of the
+%% types `Rule', `RuleGroup', and managed rule group. You can associate a web
+%% ACL with one or more Amazon Web Services resources to protect. The
+%% resources can be an Amazon CloudFront distribution, an Amazon API Gateway
+%% REST API, an Application Load Balancer, or an AppSync GraphQL API.
 create_web_acl(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_web_acl(Client, Input, []).
@@ -249,8 +257,8 @@ create_web_acl(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateWebACL">>, Input, Options).
 
-%% @doc Deletes all rule groups that are managed by AWS Firewall Manager for
-%% the specified web ACL.
+%% @doc Deletes all rule groups that are managed by Firewall Manager for the
+%% specified web ACL.
 %%
 %% You can only use this if `ManagedByFirewallManager' is false in the
 %% specified `WebACL'.
@@ -323,13 +331,13 @@ describe_managed_rule_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeManagedRuleGroup">>, Input, Options).
 
-%% @doc Disassociates a Web ACL from a regional application resource.
+%% @doc Disassociates a web ACL from a regional application resource.
 %%
-%% A regional application can be an Application Load Balancer (ALB), an API
-%% Gateway REST API, or an AppSync GraphQL API.
+%% A regional application can be an Application Load Balancer (ALB), an
+%% Amazon API Gateway REST API, or an AppSync GraphQL API.
 %%
-%% For AWS CloudFront, don't use this call. Instead, use your CloudFront
-%% distribution configuration. To disassociate a Web ACL, provide an empty
+%% For Amazon CloudFront, don't use this call. Instead, use your CloudFront
+%% distribution configuration. To disassociate a web ACL, provide an empty
 %% web ACL ID in the CloudFront call `UpdateDistribution'. For information,
 %% see UpdateDistribution.
 disassociate_web_acl(Client, Input)
@@ -355,6 +363,22 @@ get_logging_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetLoggingConfiguration">>, Input, Options).
 
+%% @doc Retrieves the specified managed rule set.
+%%
+%% This is intended for use only by vendors of managed rule sets. Vendors are
+%% Amazon Web Services and Amazon Web Services Marketplace sellers.
+%%
+%% Vendors, you can use the managed rule set APIs to provide controlled
+%% rollout of your versioned managed rule group offerings for your customers.
+%% The APIs are `ListManagedRuleSets', `GetManagedRuleSet',
+%% `PutManagedRuleSetVersions', and `UpdateManagedRuleSetVersionExpiryDate'.
+get_managed_rule_set(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_managed_rule_set(Client, Input, []).
+get_managed_rule_set(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetManagedRuleSet">>, Input, Options).
+
 %% @doc Returns the IAM policy that is attached to the specified rule group.
 %%
 %% You must be the owner of the rule group to perform this operation.
@@ -365,11 +389,25 @@ get_permission_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetPermissionPolicy">>, Input, Options).
 
-%% @doc Retrieves the keys that are currently blocked by a rate-based rule.
+%% @doc Retrieves the keys that are currently blocked by a rate-based rule
+%% instance.
 %%
 %% The maximum number of managed keys that can be blocked for a single
-%% rate-based rule is 10,000. If more than 10,000 addresses exceed the rate
-%% limit, those with the highest rates are blocked.
+%% rate-based rule instance is 10,000. If more than 10,000 addresses exceed
+%% the rate limit, those with the highest rates are blocked.
+%%
+%% For a rate-based rule that you've defined inside a rule group, provide the
+%% name of the rule group reference statement in your request, in addition to
+%% the rate-based rule name and the web ACL name.
+%%
+%% WAF monitors web requests and manages keys independently for each unique
+%% combination of web ACL, optional rule group, and rate-based rule. For
+%% example, if you define a rate-based rule inside a rule group, and then use
+%% the rule group in a web ACL, WAF monitors web requests and manages keys
+%% for that web ACL, rule group reference statement, and rate-based rule
+%% instance. If you use the same rule group in a second web ACL, WAF monitors
+%% web requests and manages keys for this second usage completely independent
+%% of your first.
 get_rate_based_statement_managed_keys(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_rate_based_statement_managed_keys(Client, Input, []).
@@ -394,8 +432,9 @@ get_rule_group(Client, Input, Options)
     request(Client, <<"GetRuleGroup">>, Input, Options).
 
 %% @doc Gets detailed information about a specified number of requests--a
-%% sample--that AWS WAF randomly selects from among the first 5,000 requests
-%% that your AWS resource received during a time range that you choose.
+%% sample--that WAF randomly selects from among the first 5,000 requests that
+%% your Amazon Web Services resource received during a time range that you
+%% choose.
 %%
 %% You can specify a sample size of up to 500 requests, and you can specify
 %% any time range in the previous three hours.
@@ -404,8 +443,8 @@ get_rule_group(Client, Input, Options)
 %% that you specified. However, if your resource (such as a CloudFront
 %% distribution) received 5,000 requests before the specified time range
 %% elapsed, `GetSampledRequests' returns an updated time range. This new time
-%% range indicates the actual period during which AWS WAF selected the
-%% requests in the sample.
+%% range indicates the actual period during which WAF selected the requests
+%% in the sample.
 get_sampled_requests(Client, Input)
   when is_map(Client), is_map(Input) ->
     get_sampled_requests(Client, Input, []).
@@ -429,11 +468,21 @@ get_web_acl_for_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetWebACLForResource">>, Input, Options).
 
+%% @doc Returns a list of the available versions for the specified managed
+%% rule group.
+list_available_managed_rule_group_versions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_available_managed_rule_group_versions(Client, Input, []).
+list_available_managed_rule_group_versions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListAvailableManagedRuleGroupVersions">>, Input, Options).
+
 %% @doc Retrieves an array of managed rule groups that are available for you
 %% to use.
 %%
-%% This list includes all AWS Managed Rules rule groups and the AWS
-%% Marketplace managed rule groups that you're subscribed to.
+%% This list includes all Amazon Web Services Managed Rules rule groups and
+%% all of the Amazon Web Services Marketplace managed rule groups that you're
+%% subscribed to.
 list_available_managed_rule_groups(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_available_managed_rule_groups(Client, Input, []).
@@ -458,6 +507,22 @@ list_logging_configurations(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListLoggingConfigurations">>, Input, Options).
 
+%% @doc Retrieves the managed rule sets that you own.
+%%
+%% This is intended for use only by vendors of managed rule sets. Vendors are
+%% Amazon Web Services and Amazon Web Services Marketplace sellers.
+%%
+%% Vendors, you can use the managed rule set APIs to provide controlled
+%% rollout of your versioned managed rule group offerings for your customers.
+%% The APIs are `ListManagedRuleSets', `GetManagedRuleSet',
+%% `PutManagedRuleSetVersions', and `UpdateManagedRuleSetVersionExpiryDate'.
+list_managed_rule_sets(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_managed_rule_sets(Client, Input, []).
+list_managed_rule_sets(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListManagedRuleSets">>, Input, Options).
+
 %% @doc Retrieves an array of `RegexPatternSetSummary' objects for the regex
 %% pattern sets that you manage.
 list_regex_pattern_sets(Client, Input)
@@ -470,7 +535,7 @@ list_regex_pattern_sets(Client, Input, Options)
 %% @doc Retrieves an array of the Amazon Resource Names (ARNs) for the
 %% regional resources that are associated with the specified web ACL.
 %%
-%% If you want the list of AWS CloudFront resources, use the AWS CloudFront
+%% If you want the list of Amazon CloudFront resources, use the CloudFront
 %% call `ListDistributionsByWebACLId'.
 list_resources_for_web_acl(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -493,12 +558,12 @@ list_rule_groups(Client, Input, Options)
 %% Tags are key:value pairs that you can use to categorize and manage your
 %% resources, for purposes like billing. For example, you might set the tag
 %% key to "customer" and the value to the customer name or ID. You can
-%% specify one or more tags to add to each AWS resource, up to 50 tags for a
-%% resource.
+%% specify one or more tags to add to each Amazon Web Services resource, up
+%% to 50 tags for a resource.
 %%
-%% You can tag the AWS resources that you manage through AWS WAF: web ACLs,
-%% rule groups, IP sets, and regex pattern sets. You can't manage or view
-%% tags through the AWS WAF console.
+%% You can tag the Amazon Web Services resources that you manage through WAF:
+%% web ACLs, rule groups, IP sets, and regex pattern sets. You can't manage
+%% or view tags through the WAF console.
 list_tags_for_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_tags_for_resource(Client, Input, []).
@@ -518,8 +583,8 @@ list_web_acls(Client, Input, Options)
 %% @doc Enables the specified `LoggingConfiguration', to start logging from a
 %% web ACL, according to the configuration provided.
 %%
-%% You can access information about all traffic that AWS WAF inspects using
-%% the following steps:
+%% You can access information about all traffic that WAF inspects using the
+%% following steps:
 %%
 %% <ol> <li> Create an Amazon Kinesis Data Firehose.
 %%
@@ -536,16 +601,52 @@ list_web_acls(Client, Input, Options)
 %% `PutLoggingConfiguration' request.
 %%
 %% </li> </ol> When you successfully enable logging using a
-%% `PutLoggingConfiguration' request, AWS WAF will create a service linked
-%% role with the necessary permissions to write logs to the Amazon Kinesis
-%% Data Firehose. For more information, see Logging Web ACL Traffic
-%% Information in the AWS WAF Developer Guide.
+%% `PutLoggingConfiguration' request, WAF will create a service linked role
+%% with the necessary permissions to write logs to the Amazon Kinesis Data
+%% Firehose. For more information, see Logging Web ACL Traffic Information in
+%% the WAF Developer Guide.
+%%
+%% This operation completely replaces the mutable specifications that you
+%% already have for the logging configuration with the ones that you provide
+%% to this call. To modify the logging configuration, retrieve it by calling
+%% `GetLoggingConfiguration', update the settings as needed, and then provide
+%% the complete logging configuration specification to this call.
 put_logging_configuration(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_logging_configuration(Client, Input, []).
 put_logging_configuration(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutLoggingConfiguration">>, Input, Options).
+
+%% @doc Defines the versions of your managed rule set that you are offering
+%% to the customers.
+%%
+%% Customers see your offerings as managed rule groups with versioning.
+%%
+%% This is intended for use only by vendors of managed rule sets. Vendors are
+%% Amazon Web Services and Amazon Web Services Marketplace sellers.
+%%
+%% Vendors, you can use the managed rule set APIs to provide controlled
+%% rollout of your versioned managed rule group offerings for your customers.
+%% The APIs are `ListManagedRuleSets', `GetManagedRuleSet',
+%% `PutManagedRuleSetVersions', and `UpdateManagedRuleSetVersionExpiryDate'.
+%%
+%% Customers retrieve their managed rule group list by calling
+%% `ListAvailableManagedRuleGroups'. The name that you provide here for your
+%% managed rule set is the name the customer sees for the corresponding
+%% managed rule group. Customers can retrieve the available versions for a
+%% managed rule group by calling `ListAvailableManagedRuleGroupVersions'. You
+%% provide a rule group specification for each version. For each managed rule
+%% set, you must specify a version that you recommend using.
+%%
+%% To initiate the expiration of a managed rule group version, use
+%% `UpdateManagedRuleSetVersionExpiryDate'.
+put_managed_rule_set_versions(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_managed_rule_set_versions(Client, Input, []).
+put_managed_rule_set_versions(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutManagedRuleSetVersions">>, Input, Options).
 
 %% @doc Attaches an IAM policy to the specified resource.
 %%
@@ -559,7 +660,7 @@ put_logging_configuration(Client, Input, Options)
 %% request.
 %%
 %% </li> <li> The ARN in the request must be a valid WAF `RuleGroup' ARN and
-%% the rule group must exist in the same region.
+%% the rule group must exist in the same Region.
 %%
 %% </li> <li> The user making the request must be the owner of the rule
 %% group.
@@ -572,17 +673,17 @@ put_permission_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutPermissionPolicy">>, Input, Options).
 
-%% @doc Associates tags with the specified AWS resource.
+%% @doc Associates tags with the specified Amazon Web Services resource.
 %%
 %% Tags are key:value pairs that you can use to categorize and manage your
 %% resources, for purposes like billing. For example, you might set the tag
 %% key to "customer" and the value to the customer name or ID. You can
-%% specify one or more tags to add to each AWS resource, up to 50 tags for a
-%% resource.
+%% specify one or more tags to add to each Amazon Web Services resource, up
+%% to 50 tags for a resource.
 %%
-%% You can tag the AWS resources that you manage through AWS WAF: web ACLs,
-%% rule groups, IP sets, and regex pattern sets. You can't manage or view
-%% tags through the AWS WAF console.
+%% You can tag the Amazon Web Services resources that you manage through WAF:
+%% web ACLs, rule groups, IP sets, and regex pattern sets. You can't manage
+%% or view tags through the WAF console.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     tag_resource(Client, Input, []).
@@ -590,12 +691,12 @@ tag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"TagResource">>, Input, Options).
 
-%% @doc Disassociates tags from an AWS resource.
+%% @doc Disassociates tags from an Amazon Web Services resource.
 %%
-%% Tags are key:value pairs that you can associate with AWS resources. For
-%% example, the tag key might be "customer" and the tag value might be
-%% "companyA." You can specify one or more tags to add to each container. You
-%% can add up to 50 tags to each AWS resource.
+%% Tags are key:value pairs that you can associate with Amazon Web Services
+%% resources. For example, the tag key might be "customer" and the tag value
+%% might be "companyA." You can specify one or more tags to add to each
+%% container. You can add up to 50 tags to each Amazon Web Services resource.
 untag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     untag_resource(Client, Input, []).
@@ -604,6 +705,12 @@ untag_resource(Client, Input, Options)
     request(Client, <<"UntagResource">>, Input, Options).
 
 %% @doc Updates the specified `IPSet'.
+%%
+%% This operation completely replaces the mutable specifications that you
+%% already have for the IP set with the ones that you provide to this call.
+%% To modify the IP set, retrieve it by calling `GetIPSet', update the
+%% settings as needed, and then provide the complete IP set specification to
+%% this call.
 update_ip_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_ip_set(Client, Input, []).
@@ -611,7 +718,33 @@ update_ip_set(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateIPSet">>, Input, Options).
 
+%% @doc Updates the expiration information for your managed rule set.
+%%
+%% Use this to initiate the expiration of a managed rule group version. After
+%% you initiate expiration for a version, WAF excludes it from the reponse to
+%% `ListAvailableManagedRuleGroupVersions' for the managed rule group.
+%%
+%% This is intended for use only by vendors of managed rule sets. Vendors are
+%% Amazon Web Services and Amazon Web Services Marketplace sellers.
+%%
+%% Vendors, you can use the managed rule set APIs to provide controlled
+%% rollout of your versioned managed rule group offerings for your customers.
+%% The APIs are `ListManagedRuleSets', `GetManagedRuleSet',
+%% `PutManagedRuleSetVersions', and `UpdateManagedRuleSetVersionExpiryDate'.
+update_managed_rule_set_version_expiry_date(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_managed_rule_set_version_expiry_date(Client, Input, []).
+update_managed_rule_set_version_expiry_date(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateManagedRuleSetVersionExpiryDate">>, Input, Options).
+
 %% @doc Updates the specified `RegexPatternSet'.
+%%
+%% This operation completely replaces the mutable specifications that you
+%% already have for the regex pattern set with the ones that you provide to
+%% this call. To modify the regex pattern set, retrieve it by calling
+%% `GetRegexPatternSet', update the settings as needed, and then provide the
+%% complete regex pattern set specification to this call.
 update_regex_pattern_set(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_regex_pattern_set(Client, Input, []).
@@ -620,6 +753,12 @@ update_regex_pattern_set(Client, Input, Options)
     request(Client, <<"UpdateRegexPatternSet">>, Input, Options).
 
 %% @doc Updates the specified `RuleGroup'.
+%%
+%% This operation completely replaces the mutable specifications that you
+%% already have for the rule group with the ones that you provide to this
+%% call. To modify the rule group, retrieve it by calling `GetRuleGroup',
+%% update the settings as needed, and then provide the complete rule group
+%% specification to this call.
 %%
 %% A rule group defines a collection of rules to inspect and control web
 %% requests that you can use in a `WebACL'. When you create a rule group, you
@@ -635,15 +774,21 @@ update_rule_group(Client, Input, Options)
 
 %% @doc Updates the specified `WebACL'.
 %%
-%% A Web ACL defines a collection of rules to use to inspect and control web
+%% This operation completely replaces the mutable specifications that you
+%% already have for the web ACL with the ones that you provide to this call.
+%% To modify the web ACL, retrieve it by calling `GetWebACL', update the
+%% settings as needed, and then provide the complete web ACL specification to
+%% this call.
+%%
+%% A web ACL defines a collection of rules to use to inspect and control web
 %% requests. Each rule has an action defined (allow, block, or count) for
-%% requests that match the statement of the rule. In the Web ACL, you assign
+%% requests that match the statement of the rule. In the web ACL, you assign
 %% a default action to take (allow, block) for any request that does not
-%% match any of the rules. The rules in a Web ACL can be a combination of the
-%% types `Rule', `RuleGroup', and managed rule group. You can associate a Web
-%% ACL with one or more AWS resources to protect. The resources can be Amazon
-%% CloudFront, an Amazon API Gateway REST API, an Application Load Balancer,
-%% or an AWS AppSync GraphQL API.
+%% match any of the rules. The rules in a web ACL can be a combination of the
+%% types `Rule', `RuleGroup', and managed rule group. You can associate a web
+%% ACL with one or more Amazon Web Services resources to protect. The
+%% resources can be an Amazon CloudFront distribution, an Amazon API Gateway
+%% REST API, an Application Load Balancer, or an AppSync GraphQL API.
 update_web_acl(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_web_acl(Client, Input, []).

--- a/src/aws_wellarchitected.erl
+++ b/src/aws_wellarchitected.erl
@@ -273,7 +273,7 @@ disassociate_lenses(Client, WorkloadId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Get lens review.
+%% @doc Get the answer to a specific question in a workload review.
 get_answer(Client, LensAlias, QuestionId, WorkloadId)
   when is_map(Client) ->
     get_answer(Client, LensAlias, QuestionId, WorkloadId, #{}, #{}).
@@ -720,6 +720,10 @@ tag_resource(Client, WorkloadArn, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Deletes specified tags from a resource.
+%%
+%% To specify multiple tags, use separate tagKeys parameters, for example:
+%%
+%% `DELETE /tags/WorkloadArn?tagKeys=key1&tagKeys=key2'
 untag_resource(Client, WorkloadArn, Input) ->
     untag_resource(Client, WorkloadArn, Input, []).
 untag_resource(Client, WorkloadArn, Input0, Options0) ->
@@ -916,6 +920,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_wisdom.erl
+++ b/src/aws_wisdom.erl
@@ -1,0 +1,980 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc All Amazon Connect Wisdom functionality is accessible using the API.
+%%
+%% For example, you can create an assistant and a knowledge base.
+%%
+%% <p>Some more advanced features are only accessible using the Wisdom API.
+%% For example, you can manually manage content by uploading custom files and
+%% control their lifecycle. </p>
+-module(aws_wisdom).
+
+-export([create_assistant/2,
+         create_assistant/3,
+         create_assistant_association/3,
+         create_assistant_association/4,
+         create_content/3,
+         create_content/4,
+         create_knowledge_base/2,
+         create_knowledge_base/3,
+         create_session/3,
+         create_session/4,
+         delete_assistant/3,
+         delete_assistant/4,
+         delete_assistant_association/4,
+         delete_assistant_association/5,
+         delete_content/4,
+         delete_content/5,
+         delete_knowledge_base/3,
+         delete_knowledge_base/4,
+         get_assistant/2,
+         get_assistant/4,
+         get_assistant/5,
+         get_assistant_association/3,
+         get_assistant_association/5,
+         get_assistant_association/6,
+         get_content/3,
+         get_content/5,
+         get_content/6,
+         get_content_summary/3,
+         get_content_summary/5,
+         get_content_summary/6,
+         get_knowledge_base/2,
+         get_knowledge_base/4,
+         get_knowledge_base/5,
+         get_recommendations/3,
+         get_recommendations/5,
+         get_recommendations/6,
+         get_session/3,
+         get_session/5,
+         get_session/6,
+         list_assistant_associations/2,
+         list_assistant_associations/4,
+         list_assistant_associations/5,
+         list_assistants/1,
+         list_assistants/3,
+         list_assistants/4,
+         list_contents/2,
+         list_contents/4,
+         list_contents/5,
+         list_knowledge_bases/1,
+         list_knowledge_bases/3,
+         list_knowledge_bases/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         notify_recommendations_received/4,
+         notify_recommendations_received/5,
+         query_assistant/3,
+         query_assistant/4,
+         remove_knowledge_base_template_uri/3,
+         remove_knowledge_base_template_uri/4,
+         search_content/3,
+         search_content/4,
+         search_sessions/3,
+         search_sessions/4,
+         start_content_upload/3,
+         start_content_upload/4,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_content/4,
+         update_content/5,
+         update_knowledge_base_template_uri/3,
+         update_knowledge_base_template_uri/4]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Creates an Amazon Connect Wisdom assistant.
+create_assistant(Client, Input) ->
+    create_assistant(Client, Input, []).
+create_assistant(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates an association between an Amazon Connect Wisdom assistant and
+%% another resource.
+%%
+%% Currently, the only supported association is with a knowledge base. An
+%% assistant can have only a single association.
+create_assistant_association(Client, AssistantId, Input) ->
+    create_assistant_association(Client, AssistantId, Input, []).
+create_assistant_association(Client, AssistantId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/associations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates Wisdom content.
+%%
+%% Before to calling this API, use StartContentUpload to upload an asset.
+create_content(Client, KnowledgeBaseId, Input) ->
+    create_content(Client, KnowledgeBaseId, Input, []).
+create_content(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a knowledge base.
+%%
+%% When using this API, you cannot reuse Amazon AppIntegrations
+%% DataIntegrations with external knowledge bases such as Salesforce and
+%% ServiceNow. If you do, you'll get an `InvalidRequestException' error.
+%%
+%% <p>For example, you're programmatically managing your external knowledge
+%% base, and you want to add or remove one of the fields that is being
+%% ingested from Salesforce. Do the following:</p> <ol> <li> <p>Call <a
+%% href="https://docs.aws.amazon.com/wisdom/latest/APIReference/API_DeleteKnowledgeBase.html">DeleteKnowledgeBase</a>.</p>
+%% </li> <li> <p>Call <a
+%% href="https://docs.aws.amazon.com/appintegrations/latest/APIReference/API_DeleteDataIntegration.html">DeleteDataIntegration</a>.</p>
+%% </li> <li> <p>Call <a
+%% href="https://docs.aws.amazon.com/appintegrations/latest/APIReference/API_CreateDataIntegration.html">CreateDataIntegration</a>
+%% to recreate the DataIntegration or a create different one.</p> </li> <li>
+%% <p>Call CreateKnowledgeBase.</p> </li> </ol> </note>
+create_knowledge_base(Client, Input) ->
+    create_knowledge_base(Client, Input, []).
+create_knowledge_base(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a session.
+%%
+%% A session is a contextual container used for generating recommendations.
+%% Amazon Connect creates a new Wisdom session for each contact on which
+%% Wisdom is enabled.
+create_session(Client, AssistantId, Input) ->
+    create_session(Client, AssistantId, Input, []).
+create_session(Client, AssistantId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/sessions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an assistant.
+delete_assistant(Client, AssistantId, Input) ->
+    delete_assistant(Client, AssistantId, Input, []).
+delete_assistant(Client, AssistantId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an assistant association.
+delete_assistant_association(Client, AssistantAssociationId, AssistantId, Input) ->
+    delete_assistant_association(Client, AssistantAssociationId, AssistantId, Input, []).
+delete_assistant_association(Client, AssistantAssociationId, AssistantId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/associations/", aws_util:encode_uri(AssistantAssociationId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the content.
+delete_content(Client, ContentId, KnowledgeBaseId, Input) ->
+    delete_content(Client, ContentId, KnowledgeBaseId, Input, []).
+delete_content(Client, ContentId, KnowledgeBaseId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents/", aws_util:encode_uri(ContentId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the knowledge base.
+%%
+%% When you use this API to delete an external knowledge base such as
+%% Salesforce or ServiceNow, you must also delete the Amazon AppIntegrations
+%% DataIntegration. This is because you can't reuse the DataIntegration after
+%% it's been associated with an external knowledge base. However, you can
+%% delete and recreate it. See DeleteDataIntegration and
+%% CreateDataIntegration in the Amazon AppIntegrations API Reference.
+delete_knowledge_base(Client, KnowledgeBaseId, Input) ->
+    delete_knowledge_base(Client, KnowledgeBaseId, Input, []).
+delete_knowledge_base(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), ""],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about an assistant.
+get_assistant(Client, AssistantId)
+  when is_map(Client) ->
+    get_assistant(Client, AssistantId, #{}, #{}).
+
+get_assistant(Client, AssistantId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_assistant(Client, AssistantId, QueryMap, HeadersMap, []).
+
+get_assistant(Client, AssistantId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about an assistant association.
+get_assistant_association(Client, AssistantAssociationId, AssistantId)
+  when is_map(Client) ->
+    get_assistant_association(Client, AssistantAssociationId, AssistantId, #{}, #{}).
+
+get_assistant_association(Client, AssistantAssociationId, AssistantId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_assistant_association(Client, AssistantAssociationId, AssistantId, QueryMap, HeadersMap, []).
+
+get_assistant_association(Client, AssistantAssociationId, AssistantId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/associations/", aws_util:encode_uri(AssistantAssociationId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves content, including a pre-signed URL to download the
+%% content.
+get_content(Client, ContentId, KnowledgeBaseId)
+  when is_map(Client) ->
+    get_content(Client, ContentId, KnowledgeBaseId, #{}, #{}).
+
+get_content(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_content(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap, []).
+
+get_content(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents/", aws_util:encode_uri(ContentId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves summary information about the content.
+get_content_summary(Client, ContentId, KnowledgeBaseId)
+  when is_map(Client) ->
+    get_content_summary(Client, ContentId, KnowledgeBaseId, #{}, #{}).
+
+get_content_summary(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_content_summary(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap, []).
+
+get_content_summary(Client, ContentId, KnowledgeBaseId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents/", aws_util:encode_uri(ContentId), "/summary"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information about the knowledge base.
+get_knowledge_base(Client, KnowledgeBaseId)
+  when is_map(Client) ->
+    get_knowledge_base(Client, KnowledgeBaseId, #{}, #{}).
+
+get_knowledge_base(Client, KnowledgeBaseId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_knowledge_base(Client, KnowledgeBaseId, QueryMap, HeadersMap, []).
+
+get_knowledge_base(Client, KnowledgeBaseId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves recommendations for the specified session.
+%%
+%% To avoid retrieving the same recommendations in subsequent calls, use
+%% NotifyRecommendationsReceived. This API supports long-polling behavior
+%% with the `waitTimeSeconds' parameter. Short poll is the default behavior
+%% and only returns recommendations already available. To perform a manual
+%% query against an assistant, use QueryAssistant.
+get_recommendations(Client, AssistantId, SessionId)
+  when is_map(Client) ->
+    get_recommendations(Client, AssistantId, SessionId, #{}, #{}).
+
+get_recommendations(Client, AssistantId, SessionId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_recommendations(Client, AssistantId, SessionId, QueryMap, HeadersMap, []).
+
+get_recommendations(Client, AssistantId, SessionId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/sessions/", aws_util:encode_uri(SessionId), "/recommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"waitTimeSeconds">>, maps:get(<<"waitTimeSeconds">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Retrieves information for a specified session.
+get_session(Client, AssistantId, SessionId)
+  when is_map(Client) ->
+    get_session(Client, AssistantId, SessionId, #{}, #{}).
+
+get_session(Client, AssistantId, SessionId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    get_session(Client, AssistantId, SessionId, QueryMap, HeadersMap, []).
+
+get_session(Client, AssistantId, SessionId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/sessions/", aws_util:encode_uri(SessionId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists information about assistant associations.
+list_assistant_associations(Client, AssistantId)
+  when is_map(Client) ->
+    list_assistant_associations(Client, AssistantId, #{}, #{}).
+
+list_assistant_associations(Client, AssistantId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_assistant_associations(Client, AssistantId, QueryMap, HeadersMap, []).
+
+list_assistant_associations(Client, AssistantId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/associations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists information about assistants.
+list_assistants(Client)
+  when is_map(Client) ->
+    list_assistants(Client, #{}, #{}).
+
+list_assistants(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_assistants(Client, QueryMap, HeadersMap, []).
+
+list_assistants(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/assistants"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the content.
+list_contents(Client, KnowledgeBaseId)
+  when is_map(Client) ->
+    list_contents(Client, KnowledgeBaseId, #{}, #{}).
+
+list_contents(Client, KnowledgeBaseId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_contents(Client, KnowledgeBaseId, QueryMap, HeadersMap, []).
+
+list_contents(Client, KnowledgeBaseId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the knowledge bases.
+list_knowledge_bases(Client)
+  when is_map(Client) ->
+    list_knowledge_bases(Client, #{}, #{}).
+
+list_knowledge_bases(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_knowledge_bases(Client, QueryMap, HeadersMap, []).
+
+list_knowledge_bases(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/knowledgeBases"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags for the specified resource.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Removes the specified recommendations from the specified assistant's
+%% queue of newly available recommendations.
+%%
+%% You can use this API in conjunction with GetRecommendations and a
+%% `waitTimeSeconds' input for long-polling behavior and avoiding duplicate
+%% recommendations.
+notify_recommendations_received(Client, AssistantId, SessionId, Input) ->
+    notify_recommendations_received(Client, AssistantId, SessionId, Input, []).
+notify_recommendations_received(Client, AssistantId, SessionId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/sessions/", aws_util:encode_uri(SessionId), "/recommendations/notify"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Performs a manual search against the specified assistant.
+%%
+%% To retrieve recommendations for an assistant, use GetRecommendations.
+query_assistant(Client, AssistantId, Input) ->
+    query_assistant(Client, AssistantId, Input, []).
+query_assistant(Client, AssistantId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/query"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes a URI template from a knowledge base.
+remove_knowledge_base_template_uri(Client, KnowledgeBaseId, Input) ->
+    remove_knowledge_base_template_uri(Client, KnowledgeBaseId, Input, []).
+remove_knowledge_base_template_uri(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = delete,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/templateUri"],
+    SuccessStatusCode = 204,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Searches for content in a specified knowledge base.
+%%
+%% Can be used to get a specific content resource by its name.
+search_content(Client, KnowledgeBaseId, Input) ->
+    search_content(Client, KnowledgeBaseId, Input, []).
+search_content(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/search"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"maxResults">>, <<"maxResults">>},
+                     {<<"nextToken">>, <<"nextToken">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Searches for sessions.
+search_sessions(Client, AssistantId, Input) ->
+    search_sessions(Client, AssistantId, Input, []).
+search_sessions(Client, AssistantId, Input0, Options0) ->
+    Method = post,
+    Path = ["/assistants/", aws_util:encode_uri(AssistantId), "/searchSessions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"maxResults">>, <<"maxResults">>},
+                     {<<"nextToken">>, <<"nextToken">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Get a URL to upload content to a knowledge base.
+%%
+%% To upload content, first make a PUT request to the returned URL with your
+%% file, making sure to include the required headers. Then use CreateContent
+%% to finalize the content creation process or UpdateContent to modify an
+%% existing resource. You can only upload content to a knowledge base of type
+%% CUSTOM.
+start_content_upload(Client, KnowledgeBaseId, Input) ->
+    start_content_upload(Client, KnowledgeBaseId, Input, []).
+start_content_upload(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/upload"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds the specified tags to the specified resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes the specified tags from the specified resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates information about the content.
+update_content(Client, ContentId, KnowledgeBaseId, Input) ->
+    update_content(Client, ContentId, KnowledgeBaseId, Input, []).
+update_content(Client, ContentId, KnowledgeBaseId, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/contents/", aws_util:encode_uri(ContentId), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the template URI of a knowledge base.
+%%
+%% This is only supported for knowledge bases of type EXTERNAL. Include a
+%% single variable in `${variable}' format; this interpolated by Wisdom using
+%% ingested content. For example, if you ingest a Salesforce article, it has
+%% an `Id' value, and you can set the template URI to
+%% `https://myInstanceName.lightning.force.com/lightning/r/Knowledge__kav/*${Id}*/view'.
+update_knowledge_base_template_uri(Client, KnowledgeBaseId, Input) ->
+    update_knowledge_base_template_uri(Client, KnowledgeBaseId, Input, []).
+update_knowledge_base_template_uri(Client, KnowledgeBaseId, Input0, Options0) ->
+    Method = post,
+    Path = ["/knowledgeBases/", aws_util:encode_uri(KnowledgeBaseId), "/templateUri"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"wisdom">>},
+    Host = build_host(<<"wisdom">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -1425,6 +1425,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_worklink.erl
+++ b/src/aws_worklink.erl
@@ -910,6 +910,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_workmail.erl
+++ b/src/aws_workmail.erl
@@ -43,6 +43,8 @@
          create_alias/3,
          create_group/2,
          create_group/3,
+         create_mobile_device_access_rule/2,
+         create_mobile_device_access_rule/3,
          create_organization/2,
          create_organization/3,
          create_resource/2,
@@ -57,6 +59,10 @@
          delete_group/3,
          delete_mailbox_permissions/2,
          delete_mailbox_permissions/3,
+         delete_mobile_device_access_override/2,
+         delete_mobile_device_access_override/3,
+         delete_mobile_device_access_rule/2,
+         delete_mobile_device_access_rule/3,
          delete_organization/2,
          delete_organization/3,
          delete_resource/2,
@@ -67,8 +73,12 @@
          delete_user/3,
          deregister_from_work_mail/2,
          deregister_from_work_mail/3,
+         deregister_mail_domain/2,
+         deregister_mail_domain/3,
          describe_group/2,
          describe_group/3,
+         describe_inbound_dmarc_settings/2,
+         describe_inbound_dmarc_settings/3,
          describe_mailbox_export_job/2,
          describe_mailbox_export_job/3,
          describe_organization/2,
@@ -85,8 +95,14 @@
          get_access_control_effect/3,
          get_default_retention_policy/2,
          get_default_retention_policy/3,
+         get_mail_domain/2,
+         get_mail_domain/3,
          get_mailbox_details/2,
          get_mailbox_details/3,
+         get_mobile_device_access_effect/2,
+         get_mobile_device_access_effect/3,
+         get_mobile_device_access_override/2,
+         get_mobile_device_access_override/3,
          list_access_control_rules/2,
          list_access_control_rules/3,
          list_aliases/2,
@@ -95,10 +111,16 @@
          list_group_members/3,
          list_groups/2,
          list_groups/3,
+         list_mail_domains/2,
+         list_mail_domains/3,
          list_mailbox_export_jobs/2,
          list_mailbox_export_jobs/3,
          list_mailbox_permissions/2,
          list_mailbox_permissions/3,
+         list_mobile_device_access_overrides/2,
+         list_mobile_device_access_overrides/3,
+         list_mobile_device_access_rules/2,
+         list_mobile_device_access_rules/3,
          list_organizations/2,
          list_organizations/3,
          list_resource_delegates/2,
@@ -111,10 +133,16 @@
          list_users/3,
          put_access_control_rule/2,
          put_access_control_rule/3,
+         put_inbound_dmarc_settings/2,
+         put_inbound_dmarc_settings/3,
          put_mailbox_permissions/2,
          put_mailbox_permissions/3,
+         put_mobile_device_access_override/2,
+         put_mobile_device_access_override/3,
          put_retention_policy/2,
          put_retention_policy/3,
+         register_mail_domain/2,
+         register_mail_domain/3,
          register_to_work_mail/2,
          register_to_work_mail/3,
          reset_password/2,
@@ -125,8 +153,12 @@
          tag_resource/3,
          untag_resource/2,
          untag_resource/3,
+         update_default_mail_domain/2,
+         update_default_mail_domain/3,
          update_mailbox_quota/2,
          update_mailbox_quota/3,
+         update_mobile_device_access_rule/2,
+         update_mobile_device_access_rule/3,
          update_primary_email_address/2,
          update_primary_email_address/3,
          update_resource/2,
@@ -183,6 +215,15 @@ create_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateGroup">>, Input, Options).
 
+%% @doc Creates a new mobile device access rule for the specified Amazon
+%% WorkMail organization.
+create_mobile_device_access_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_mobile_device_access_rule(Client, Input, []).
+create_mobile_device_access_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateMobileDeviceAccessRule">>, Input, Options).
+
 %% @doc Creates a new Amazon WorkMail organization.
 %%
 %% Optionally, you can choose to associate an existing AWS Directory Service
@@ -229,6 +270,10 @@ create_user(Client, Input, Options)
 
 %% @doc Deletes an access control rule for the specified WorkMail
 %% organization.
+%%
+%% Deleting already deleted and non-existing rules does not produce an error.
+%% In those cases, the service sends back an HTTP 200 response with an empty
+%% HTTP body.
 delete_access_control_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_access_control_rule(Client, Input, []).
@@ -260,6 +305,32 @@ delete_mailbox_permissions(Client, Input)
 delete_mailbox_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteMailboxPermissions">>, Input, Options).
+
+%% @doc Deletes the mobile device access override for the given WorkMail
+%% organization, user, and device.
+%%
+%% Deleting already deleted and non-existing overrides does not produce an
+%% error. In those cases, the service sends back an HTTP 200 response with an
+%% empty HTTP body.
+delete_mobile_device_access_override(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_mobile_device_access_override(Client, Input, []).
+delete_mobile_device_access_override(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteMobileDeviceAccessOverride">>, Input, Options).
+
+%% @doc Deletes a mobile device access rule for the specified Amazon WorkMail
+%% organization.
+%%
+%% Deleting already deleted and non-existing rules does not produce an error.
+%% In those cases, the service sends back an HTTP 200 response with an empty
+%% HTTP body.
+delete_mobile_device_access_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_mobile_device_access_rule(Client, Input, []).
+delete_mobile_device_access_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteMobileDeviceAccessRule">>, Input, Options).
 
 %% @doc Deletes an Amazon WorkMail organization and all underlying AWS
 %% resources managed by Amazon WorkMail as part of the organization.
@@ -317,6 +388,19 @@ deregister_from_work_mail(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeregisterFromWorkMail">>, Input, Options).
 
+%% @doc Removes a domain from Amazon WorkMail, stops email routing to
+%% WorkMail, and removes the authorization allowing WorkMail use.
+%%
+%% SES keeps the domain because other applications may use it. You must first
+%% remove any email address used by WorkMail entities before you remove the
+%% domain.
+deregister_mail_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    deregister_mail_domain(Client, Input, []).
+deregister_mail_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeregisterMailDomain">>, Input, Options).
+
 %% @doc Returns the data available for the group.
 describe_group(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -324,6 +408,14 @@ describe_group(Client, Input)
 describe_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeGroup">>, Input, Options).
+
+%% @doc Lists the settings in a DMARC policy for a specified organization.
+describe_inbound_dmarc_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_inbound_dmarc_settings(Client, Input, []).
+describe_inbound_dmarc_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeInboundDmarcSettings">>, Input, Options).
 
 %% @doc Describes the current status of a mailbox export job.
 describe_mailbox_export_job(Client, Input)
@@ -392,6 +484,15 @@ get_default_retention_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetDefaultRetentionPolicy">>, Input, Options).
 
+%% @doc Gets details for a mail domain, including domain records required to
+%% configure your domain with recommended security.
+get_mail_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_mail_domain(Client, Input, []).
+get_mail_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetMailDomain">>, Input, Options).
+
 %% @doc Requests a user's mailbox details for a specified organization and
 %% user.
 get_mailbox_details(Client, Input)
@@ -400,6 +501,28 @@ get_mailbox_details(Client, Input)
 get_mailbox_details(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetMailboxDetails">>, Input, Options).
+
+%% @doc Simulates the effect of the mobile device access rules for the given
+%% attributes of a sample access event.
+%%
+%% Use this method to test the effects of the current set of mobile device
+%% access rules for the Amazon WorkMail organization for a particular user's
+%% attributes.
+get_mobile_device_access_effect(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_mobile_device_access_effect(Client, Input, []).
+get_mobile_device_access_effect(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetMobileDeviceAccessEffect">>, Input, Options).
+
+%% @doc Gets the mobile device access override for the given WorkMail
+%% organization, user, and device.
+get_mobile_device_access_override(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_mobile_device_access_override(Client, Input, []).
+get_mobile_device_access_override(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetMobileDeviceAccessOverride">>, Input, Options).
 
 %% @doc Lists the access control rules for the specified organization.
 list_access_control_rules(Client, Input)
@@ -436,6 +559,14 @@ list_groups(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListGroups">>, Input, Options).
 
+%% @doc Lists the mail domains in a given Amazon WorkMail organization.
+list_mail_domains(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_mail_domains(Client, Input, []).
+list_mail_domains(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListMailDomains">>, Input, Options).
+
 %% @doc Lists the mailbox export jobs started for the specified organization
 %% within the last seven days.
 list_mailbox_export_jobs(Client, Input)
@@ -453,6 +584,24 @@ list_mailbox_permissions(Client, Input)
 list_mailbox_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"ListMailboxPermissions">>, Input, Options).
+
+%% @doc Lists all the mobile device access overrides for any given
+%% combination of WorkMail organization, user, or device.
+list_mobile_device_access_overrides(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_mobile_device_access_overrides(Client, Input, []).
+list_mobile_device_access_overrides(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListMobileDeviceAccessOverrides">>, Input, Options).
+
+%% @doc Lists the mobile device access rules for the specified Amazon
+%% WorkMail organization.
+list_mobile_device_access_rules(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_mobile_device_access_rules(Client, Input, []).
+list_mobile_device_access_rules(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListMobileDeviceAccessRules">>, Input, Options).
 
 %% @doc Returns summaries of the customer's organizations.
 list_organizations(Client, Input)
@@ -509,6 +658,14 @@ put_access_control_rule(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutAccessControlRule">>, Input, Options).
 
+%% @doc Enables or disables a DMARC policy for a given organization.
+put_inbound_dmarc_settings(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_inbound_dmarc_settings(Client, Input, []).
+put_inbound_dmarc_settings(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutInboundDmarcSettings">>, Input, Options).
+
 %% @doc Sets permissions for a user, group, or resource.
 %%
 %% This replaces any pre-existing permissions.
@@ -519,6 +676,15 @@ put_mailbox_permissions(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutMailboxPermissions">>, Input, Options).
 
+%% @doc Creates or updates a mobile device access override for the given
+%% WorkMail organization, user, and device.
+put_mobile_device_access_override(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_mobile_device_access_override(Client, Input, []).
+put_mobile_device_access_override(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutMobileDeviceAccessOverride">>, Input, Options).
+
 %% @doc Puts a retention policy to the specified organization.
 put_retention_policy(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -526,6 +692,19 @@ put_retention_policy(Client, Input)
 put_retention_policy(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutRetentionPolicy">>, Input, Options).
+
+%% @doc Registers a new domain in Amazon WorkMail and SES, and configures it
+%% for use by WorkMail.
+%%
+%% Emails received by SES for this domain are routed to the specified
+%% WorkMail organization, and WorkMail has permanent permission to use the
+%% specified domain for sending your users' emails.
+register_mail_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    register_mail_domain(Client, Input, []).
+register_mail_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"RegisterMailDomain">>, Input, Options).
 
 %% @doc Registers an existing and disabled user, group, or resource for
 %% Amazon WorkMail use by associating a mailbox and calendaring capabilities.
@@ -584,6 +763,18 @@ untag_resource(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UntagResource">>, Input, Options).
 
+%% @doc Updates the default mail domain for an organization.
+%%
+%% The default mail domain is used by the WorkMail AWS Console to suggest an
+%% email address when enabling a mail user. You can only have one default
+%% domain.
+update_default_mail_domain(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_default_mail_domain(Client, Input, []).
+update_default_mail_domain(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateDefaultMailDomain">>, Input, Options).
+
 %% @doc Updates a user's current mailbox quota for a specified organization
 %% and user.
 update_mailbox_quota(Client, Input)
@@ -592,6 +783,15 @@ update_mailbox_quota(Client, Input)
 update_mailbox_quota(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateMailboxQuota">>, Input, Options).
+
+%% @doc Updates a mobile device access rule for the specified Amazon WorkMail
+%% organization.
+update_mobile_device_access_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_mobile_device_access_rule(Client, Input, []).
+update_mobile_device_access_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateMobileDeviceAccessRule">>, Input, Options).
 
 %% @doc Updates the primary email for a user, group, or resource.
 %%

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -110,6 +110,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -21,6 +21,10 @@
          create_ip_group/3,
          create_tags/2,
          create_tags/3,
+         create_updated_workspace_image/2,
+         create_updated_workspace_image/3,
+         create_workspace_bundle/2,
+         create_workspace_bundle/3,
          create_workspaces/2,
          create_workspaces/3,
          delete_connection_alias/2,
@@ -29,6 +33,8 @@
          delete_ip_group/3,
          delete_tags/2,
          delete_tags/3,
+         delete_workspace_bundle/2,
+         delete_workspace_bundle/3,
          delete_workspace_image/2,
          delete_workspace_image/3,
          deregister_workspace_directory/2,
@@ -105,6 +111,8 @@
          update_connection_alias_permission/3,
          update_rules_of_ip_group/2,
          update_rules_of_ip_group/3,
+         update_workspace_bundle/2,
+         update_workspace_bundle/3,
          update_workspace_image_permission/2,
          update_workspace_image_permission/3]).
 
@@ -157,14 +165,14 @@ authorize_ip_rules(Client, Input, Options)
 %% In the China (Ningxia) Region, you can copy images only within the same
 %% Region.
 %%
-%% In the AWS GovCloud (US-West) Region, to copy images to and from other AWS
-%% Regions, contact AWS Support.
+%% In Amazon Web Services GovCloud (US), to copy images to and from other
+%% Regions, contact Amazon Web Services Support.
 %%
 %% Before copying a shared image, be sure to verify that it has been shared
-%% from the correct AWS account. To determine if an image has been shared and
-%% to see the AWS account ID that owns an image, use the
-%% DescribeWorkSpaceImages and DescribeWorkspaceImagePermissions API
-%% operations.
+%% from the correct Amazon Web Services account. To determine if an image has
+%% been shared and to see the ID of the Amazon Web Services account that owns
+%% an image, use the DescribeWorkSpaceImages and
+%% DescribeWorkspaceImagePermissions API operations.
 copy_workspace_image(Client, Input)
   when is_map(Client), is_map(Input) ->
     copy_workspace_image(Client, Input, []).
@@ -210,6 +218,41 @@ create_tags(Client, Input)
 create_tags(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateTags">>, Input, Options).
+
+%% @doc Creates a new updated WorkSpace image based on the specified source
+%% image.
+%%
+%% The new updated WorkSpace image has the latest drivers and other updates
+%% required by the Amazon WorkSpaces components.
+%%
+%% To determine which WorkSpace images need to be updated with the latest
+%% Amazon WorkSpaces requirements, use DescribeWorkspaceImages.
+%%
+%% Only Windows 10 WorkSpace images can be programmatically updated at this
+%% time.
+%%
+%% Microsoft Windows updates and other application updates are not included
+%% in the update process.
+%%
+%% The source WorkSpace image is not deleted. You can delete the source image
+%% after you've verified your new updated image and created a new bundle.
+create_updated_workspace_image(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_updated_workspace_image(Client, Input, []).
+create_updated_workspace_image(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateUpdatedWorkspaceImage">>, Input, Options).
+
+%% @doc Creates the specified WorkSpace bundle.
+%%
+%% For more information about creating WorkSpace bundles, see Create a Custom
+%% WorkSpaces Image and Bundle.
+create_workspace_bundle(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_workspace_bundle(Client, Input, []).
+create_workspace_bundle(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateWorkspaceBundle">>, Input, Options).
 
 %% @doc Creates one or more WorkSpaces.
 %%
@@ -263,6 +306,17 @@ delete_tags(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteTags">>, Input, Options).
 
+%% @doc Deletes the specified WorkSpace bundle.
+%%
+%% For more information about deleting WorkSpace bundles, see Delete a Custom
+%% WorkSpaces Bundle or Image.
+delete_workspace_bundle(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_workspace_bundle(Client, Input, []).
+delete_workspace_bundle(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteWorkspaceBundle">>, Input, Options).
+
 %% @doc Deletes the specified image from your account.
 %%
 %% To delete an image, you must first delete any bundles that are associated
@@ -284,8 +338,7 @@ delete_workspace_image(Client, Input, Options)
 %% with WorkSpaces. If there are no WorkSpaces being used with your Simple AD
 %% or AD Connector directory for 30 consecutive days, this directory will be
 %% automatically deregistered for use with Amazon WorkSpaces, and you will be
-%% charged for this directory as per the AWS Directory Services pricing
-%% terms.
+%% charged for this directory as per the Directory Service pricing terms.
 %%
 %% To delete empty directories, see Delete the Directory for Your WorkSpaces.
 %% If you delete your Simple AD or AD Connector directory, you can always
@@ -325,7 +378,8 @@ describe_client_properties(Client, Input, Options)
     request(Client, <<"DescribeClientProperties">>, Input, Options).
 
 %% @doc Describes the permissions that the owner of a connection alias has
-%% granted to another AWS account for the specified connection alias.
+%% granted to another Amazon Web Services account for the specified
+%% connection alias.
 %%
 %% For more information, see Cross-Region Redirection for Amazon WorkSpaces.
 describe_connection_alias_permissions(Client, Input)
@@ -382,7 +436,7 @@ describe_workspace_directories(Client, Input, Options)
     request(Client, <<"DescribeWorkspaceDirectories">>, Input, Options).
 
 %% @doc Describes the permissions that the owner of an image has granted to
-%% other AWS accounts for an image.
+%% other Amazon Web Services accounts for an image.
 describe_workspace_image_permissions(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_workspace_image_permissions(Client, Input, []).
@@ -431,8 +485,8 @@ describe_workspaces_connection_status(Client, Input, Options)
 %% @doc Disassociates a connection alias from a directory.
 %%
 %% Disassociating a connection alias disables cross-Region redirection
-%% between two directories in different AWS Regions. For more information,
-%% see Cross-Region Redirection for Amazon WorkSpaces.
+%% between two directories in different Regions. For more information, see
+%% Cross-Region Redirection for Amazon WorkSpaces.
 %%
 %% Before performing this operation, call DescribeConnectionAliases to make
 %% sure that the current state of the connection alias is `CREATED'.
@@ -455,9 +509,10 @@ disassociate_ip_groups(Client, Input, Options)
 %% @doc Imports the specified Windows 10 Bring Your Own License (BYOL) image
 %% into Amazon WorkSpaces.
 %%
-%% The image must be an already licensed Amazon EC2 image that is in your AWS
-%% account, and you must own the image. For more information about creating
-%% BYOL images, see Bring Your Own Windows Desktop Licenses.
+%% The image must be an already licensed Amazon EC2 image that is in your
+%% Amazon Web Services account, and you must own the image. For more
+%% information about creating BYOL images, see Bring Your Own Windows Desktop
+%% Licenses.
 import_workspace_image(Client, Input)
   when is_map(Client), is_map(Input) ->
     import_workspace_image(Client, Input, []).
@@ -469,9 +524,9 @@ import_workspace_image(Client, Input, Options)
 %% that you can use for the network management interface when you enable
 %% Bring Your Own License (BYOL).
 %%
-%% This operation can be run only by AWS accounts that are enabled for BYOL.
-%% If your account isn't enabled for BYOL, you'll receive an
-%% `AccessDeniedException' error.
+%% This operation can be run only by Amazon Web Services accounts that are
+%% enabled for BYOL. If your account isn't enabled for BYOL, you'll receive
+%% an `AccessDeniedException' error.
 %%
 %% The management network interface is connected to a secure Amazon
 %% WorkSpaces management network. It is used for interactive streaming of the
@@ -673,7 +728,7 @@ stop_workspaces(Client, Input, Options)
 %%
 %% Terminating a WorkSpace is a permanent action and cannot be undone. The
 %% user's data is destroyed. If you need to archive any user data, contact
-%% AWS Support before terminating the WorkSpace.
+%% Amazon Web Services Support before terminating the WorkSpace.
 %%
 %% You can terminate a WorkSpace that is in any state except `SUSPENDED'.
 %%
@@ -689,8 +744,7 @@ stop_workspaces(Client, Input, Options)
 %% with WorkSpaces. If there are no WorkSpaces being used with your Simple AD
 %% or AD Connector directory for 30 consecutive days, this directory will be
 %% automatically deregistered for use with Amazon WorkSpaces, and you will be
-%% charged for this directory as per the AWS Directory Services pricing
-%% terms.
+%% charged for this directory as per the Directory Service pricing terms.
 %%
 %% To delete empty directories, see Delete the Directory for Your WorkSpaces.
 %% If you delete your Simple AD or AD Connector directory, you can always
@@ -736,21 +790,38 @@ update_rules_of_ip_group(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateRulesOfIpGroup">>, Input, Options).
 
-%% @doc Shares or unshares an image with one account in the same AWS Region
-%% by specifying whether that account has permission to copy the image.
+%% @doc Updates a WorkSpace bundle with a new image.
+%%
+%% For more information about updating WorkSpace bundles, see Update a Custom
+%% WorkSpaces Bundle.
+%%
+%% Existing WorkSpaces aren't automatically updated when you update the
+%% bundle that they're based on. To update existing WorkSpaces that are based
+%% on a bundle that you've updated, you must either rebuild the WorkSpaces or
+%% delete and recreate them.
+update_workspace_bundle(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    update_workspace_bundle(Client, Input, []).
+update_workspace_bundle(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"UpdateWorkspaceBundle">>, Input, Options).
+
+%% @doc Shares or unshares an image with one account in the same Amazon Web
+%% Services Region by specifying whether that account has permission to copy
+%% the image.
 %%
 %% If the copy image permission is granted, the image is shared with that
 %% account. If the copy image permission is revoked, the image is unshared
 %% with the account.
 %%
 %% After an image has been shared, the recipient account can copy the image
-%% to other AWS Regions as needed.
+%% to other Regions as needed.
 %%
 %% In the China (Ningxia) Region, you can copy images only within the same
 %% Region.
 %%
-%% In the AWS GovCloud (US-West) Region, to copy images to and from other AWS
-%% Regions, contact AWS Support.
+%% In Amazon Web Services GovCloud (US), to copy images to and from other
+%% Regions, contact Amazon Web Services Support.
 %%
 %% For more information about sharing images, see Share or Unshare a Custom
 %% WorkSpaces Image.
@@ -758,10 +829,10 @@ update_rules_of_ip_group(Client, Input, Options)
 %% To delete an image that has been shared, you must unshare the image before
 %% you delete it.
 %%
-%% Sharing Bring Your Own License (BYOL) images across AWS accounts isn't
-%% supported at this time in the AWS GovCloud (US-West) Region. To share BYOL
-%% images across accounts in the AWS GovCloud (US-West) Region, contact AWS
-%% Support.
+%% Sharing Bring Your Own License (BYOL) images across Amazon Web Services
+%% accounts isn't supported at this time in Amazon Web Services GovCloud
+%% (US). To share BYOL images across accounts in Amazon Web Services GovCloud
+%% (US), contact Amazon Web Services Support.
 update_workspace_image_permission(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_workspace_image_permission(Client, Input, []).

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -1,8 +1,8 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS X-Ray provides APIs for managing debug traces and retrieving
-%% service maps and other data created by processing those traces.
+%% @doc Amazon Web Services X-Ray provides APIs for managing debug traces and
+%% retrieving service maps and other data created by processing those traces.
 -module(aws_xray).
 
 -export([batch_get_traces/2,
@@ -118,13 +118,12 @@ create_group(Client, Input0, Options0) ->
 %% @doc Creates a rule to control sampling behavior for instrumented
 %% applications.
 %%
-%% Services retrieve rules with `GetSamplingRules', and evaluate each rule in
+%% Services retrieve rules with GetSamplingRules, and evaluate each rule in
 %% ascending order of priority for each request. If a rule matches, the
 %% service records a trace, borrowing it from the reservoir size. After 10
-%% seconds, the service reports back to X-Ray with `GetSamplingTargets' to
-%% get updated versions of each in-use rule. The updated rule contains a
-%% trace quota that the service can use instead of borrowing from the
-%% reservoir.
+%% seconds, the service reports back to X-Ray with GetSamplingTargets to get
+%% updated versions of each in-use rule. The updated rule contains a trace
+%% quota that the service can use instead of borrowing from the reservoir.
 create_sampling_rule(Client, Input) ->
     create_sampling_rule(Client, Input, []).
 create_sampling_rule(Client, Input0, Options0) ->
@@ -442,9 +441,9 @@ get_sampling_targets(Client, Input0, Options0) ->
 %% requests, and downstream services that they call as a result.
 %%
 %% Root services process incoming requests and make calls to downstream
-%% services. Root services are applications that use the AWS X-Ray SDK.
-%% Downstream services can be other applications, AWS resources, HTTP web
-%% APIs, or SQL databases.
+%% services. Root services are applications that use the Amazon Web Services
+%% X-Ray SDK. Downstream services can be other applications, Amazon Web
+%% Services resources, HTTP web APIs, or SQL databases.
 get_service_graph(Client, Input) ->
     get_service_graph(Client, Input, []).
 get_service_graph(Client, Input0, Options0) ->
@@ -532,8 +531,8 @@ get_trace_graph(Client, Input0, Options0) ->
 %% `annotation.account = "12345"'
 %%
 %% For a full list of indexed fields and keywords that you can use in filter
-%% expressions, see Using Filter Expressions in the AWS X-Ray Developer
-%% Guide.
+%% expressions, see Using Filter Expressions in the Amazon Web Services X-Ray
+%% Developer Guide.
 get_trace_summaries(Client, Input) ->
     get_trace_summaries(Client, Input, []).
 get_trace_summaries(Client, Input0, Options0) ->
@@ -556,8 +555,8 @@ get_trace_summaries(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of tags that are applied to the specified AWS X-Ray
-%% group or sampling rule.
+%% @doc Returns a list of tags that are applied to the specified Amazon Web
+%% Services X-Ray group or sampling rule.
 list_tags_for_resource(Client, Input) ->
     list_tags_for_resource(Client, Input, []).
 list_tags_for_resource(Client, Input0, Options0) ->
@@ -603,7 +602,7 @@ put_encryption_config(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Used by the AWS X-Ray daemon to upload telemetry.
+%% @doc Used by the Amazon Web Services X-Ray daemon to upload telemetry.
 put_telemetry_records(Client, Input) ->
     put_telemetry_records(Client, Input, []).
 put_telemetry_records(Client, Input0, Options0) ->
@@ -626,14 +625,15 @@ put_telemetry_records(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Uploads segment documents to AWS X-Ray.
+%% @doc Uploads segment documents to Amazon Web Services X-Ray.
 %%
 %% The X-Ray SDK generates segment documents and sends them to the X-Ray
 %% daemon, which uploads them in batches. A segment document can be a
 %% completed segment, an in-progress segment, or an array of subsegments.
 %%
 %% Segments must include the following fields. For the full segment document
-%% schema, see AWS X-Ray Segment Documents in the AWS X-Ray Developer Guide.
+%% schema, see Amazon Web Services X-Ray Segment Documents in the Amazon Web
+%% Services X-Ray Developer Guide.
 %%
 %% == Required segment document fields ==
 %%
@@ -697,7 +697,8 @@ put_trace_segments(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Applies tags to an existing AWS X-Ray group or sampling rule.
+%% @doc Applies tags to an existing Amazon Web Services X-Ray group or
+%% sampling rule.
 tag_resource(Client, Input) ->
     tag_resource(Client, Input, []).
 tag_resource(Client, Input0, Options0) ->
@@ -720,7 +721,8 @@ tag_resource(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Removes tags from an AWS X-Ray group or sampling rule.
+%% @doc Removes tags from an Amazon Web Services X-Ray group or sampling
+%% rule.
 %%
 %% You cannot edit or delete system tags (those with an `aws:' prefix).
 untag_resource(Client, Input) ->
@@ -826,6 +828,14 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).
 
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;


### PR DESCRIPTION
Based off: https://github.com/aws/aws-sdk-go/commit/258263306d5faf0fc5f629dfcccf0f5ffedca131

A few reasons for the large diff:
https://github.com/aws-beam/aws-codegen/pull/77 touches every module by updating the `handle_response/3`

Furthermore, a lot of action happened on aws-sdk-go which caused a lot of files to be touched due to updated docs and some new modules were added due to this. 

Command used to generate new code:
```shell
export SPEC_PATH=../aws-sdk-go/models/apis
export TEMPLATE_PATH=priv
export ERLANG_OUTPUT_PATH=../aws-erlang/src
mix run generate.exs erlang $SPEC_PATH $TEMPLATE_PATH $ERLANG_OUTPUT_PATH
```