### PR TITLE
Add retry mechanism to aws erlang

### DIFF
--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -824,6 +824,10 @@ validate_policy(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"access-analyzer">>},
     Host = build_host(<<"access-analyzer">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_account.erl
+++ b/src/aws_account.erl
@@ -111,6 +111,10 @@ put_alternate_contact(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"account">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"account">>, Client1),

--- a/src/aws_acm.erl
+++ b/src/aws_acm.erl
@@ -343,7 +343,11 @@ update_certificate_options(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"acm">>},
     Host = build_host(<<"acm">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_acm_pca.erl
+++ b/src/aws_acm_pca.erl
@@ -721,7 +721,11 @@ update_certificate_authority(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"acm-pca">>},
     Host = build_host(<<"acm-pca">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_alexa_for_business.erl
+++ b/src/aws_alexa_for_business.erl
@@ -1067,7 +1067,11 @@ update_skill_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"a4b">>},
     Host = build_host(<<"a4b">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_amp.erl
+++ b/src/aws_amp.erl
@@ -472,6 +472,10 @@ update_workspace_alias(Client, WorkspaceId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aps">>},
     Host = build_host(<<"aps">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -1016,6 +1016,10 @@ update_webhook(Client, WebhookId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"amplify">>},
     Host = build_host(<<"amplify">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_amplifybackend.erl
+++ b/src/aws_amplifybackend.erl
@@ -654,6 +654,10 @@ update_backend_job(Client, AppId, BackendEnvironmentName, JobId, Input0, Options
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"amplifybackend">>},
     Host = build_host(<<"amplifybackend">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -3311,6 +3311,10 @@ update_vpc_link(Client, VpcLinkId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"apigateway">>},
     Host = build_host(<<"apigateway">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -107,6 +107,10 @@ post_to_connection(Client, ConnectionId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"execute-api">>},
     Host = build_host(<<"execute-api">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_apigatewayv2.erl
+++ b/src/aws_apigatewayv2.erl
@@ -1928,6 +1928,10 @@ update_vpc_link(Client, VpcLinkId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"apigateway">>},
     Host = build_host(<<"apigateway">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -1195,6 +1195,10 @@ update_virtual_service(Client, MeshName, VirtualServiceName, Input0, Options0) -
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appmesh">>},
     Host = build_host(<<"appmesh">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -1085,6 +1085,10 @@ validate_configuration(Client, ApplicationId, ConfigurationProfileId, Input0, Op
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appconfig">>},
     Host = build_host(<<"appconfig">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -549,6 +549,10 @@ update_flow(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appflow">>},
     Host = build_host(<<"appflow">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_appintegrations.erl
+++ b/src/aws_appintegrations.erl
@@ -471,6 +471,10 @@ update_event_integration(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"app-integrations">>},
     Host = build_host(<<"app-integrations">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_application_auto_scaling.erl
+++ b/src/aws_application_auto_scaling.erl
@@ -297,7 +297,11 @@ register_scalable_target(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"application-autoscaling">>},
     Host = build_host(<<"application-autoscaling">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_application_discovery.erl
+++ b/src/aws_application_discovery.erl
@@ -479,7 +479,11 @@ update_application(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"discovery">>},
     Host = build_host(<<"discovery">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_application_insights.erl
+++ b/src/aws_application_insights.erl
@@ -351,7 +351,11 @@ update_log_pattern(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"applicationinsights">>},
     Host = build_host(<<"applicationinsights">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_applicationcostprofiler.erl
+++ b/src/aws_applicationcostprofiler.erl
@@ -203,6 +203,10 @@ update_report_definition(Client, ReportId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"application-cost-profiler">>},
     Host = build_host(<<"application-cost-profiler">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_apprunner.erl
+++ b/src/aws_apprunner.erl
@@ -379,7 +379,11 @@ update_service(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"apprunner">>},
     Host = build_host(<<"apprunner">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_appstream.erl
+++ b/src/aws_appstream.erl
@@ -647,7 +647,11 @@ update_stack(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"appstream">>},
     Host = build_host(<<"appstream2">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -1128,6 +1128,10 @@ update_type(Client, ApiId, TypeName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appsync">>},
     Host = build_host(<<"appsync">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_athena.erl
+++ b/src/aws_athena.erl
@@ -480,7 +480,11 @@ update_work_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"athena">>},
     Host = build_host(<<"athena">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_auditmanager.erl
+++ b/src/aws_auditmanager.erl
@@ -1558,6 +1558,10 @@ validate_assessment_report_integrity(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"auditmanager">>},
     Host = build_host(<<"auditmanager">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_auto_scaling.erl
+++ b/src/aws_auto_scaling.erl
@@ -1250,7 +1250,11 @@ update_auto_scaling_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"autoscaling">>},
     Host = build_host(<<"autoscaling">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_auto_scaling_plans.erl
+++ b/src/aws_auto_scaling_plans.erl
@@ -121,7 +121,11 @@ update_scaling_plan(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"autoscaling-plans">>},
     Host = build_host(<<"autoscaling-plans">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -1997,6 +1997,10 @@ update_report_plan(Client, ReportPlanName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"backup">>},
     Host = build_host(<<"backup">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -3,7 +3,8 @@
 
 %% @doc Batch
 %%
-%% Using Batch, you can run batch computing workloads on the Cloud.
+%% Using Batch, you can run batch computing workloads on the Amazon Web
+%% Services Cloud.
 %%
 %% Batch computing is a common means for developers, scientists, and
 %% engineers to access large amounts of compute resources. Batch uses the
@@ -29,10 +30,14 @@
          create_compute_environment/3,
          create_job_queue/2,
          create_job_queue/3,
+         create_scheduling_policy/2,
+         create_scheduling_policy/3,
          delete_compute_environment/2,
          delete_compute_environment/3,
          delete_job_queue/2,
          delete_job_queue/3,
+         delete_scheduling_policy/2,
+         delete_scheduling_policy/3,
          deregister_job_definition/2,
          deregister_job_definition/3,
          describe_compute_environments/2,
@@ -43,8 +48,12 @@
          describe_job_queues/3,
          describe_jobs/2,
          describe_jobs/3,
+         describe_scheduling_policies/2,
+         describe_scheduling_policies/3,
          list_jobs/2,
          list_jobs/3,
+         list_scheduling_policies/2,
+         list_scheduling_policies/3,
          list_tags_for_resource/2,
          list_tags_for_resource/4,
          list_tags_for_resource/5,
@@ -61,7 +70,9 @@
          update_compute_environment/2,
          update_compute_environment/3,
          update_job_queue/2,
-         update_job_queue/3]).
+         update_job_queue/3,
+         update_scheduling_policy/2,
+         update_scheduling_policy/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -198,6 +209,29 @@ create_job_queue(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Creates an Batch scheduling policy.
+create_scheduling_policy(Client, Input) ->
+    create_scheduling_policy(Client, Input, []).
+create_scheduling_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/createschedulingpolicy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Deletes an Batch compute environment.
 %%
 %% Before you can delete a compute environment, you must set its state to
@@ -243,6 +277,31 @@ delete_job_queue(Client, Input) ->
 delete_job_queue(Client, Input0, Options0) ->
     Method = post,
     Path = ["/v1/deletejobqueue"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes the specified scheduling policy.
+%%
+%% You can't delete a scheduling policy that is used in any job queues.
+delete_scheduling_policy(Client, Input) ->
+    delete_scheduling_policy(Client, Input, []).
+delete_scheduling_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/deleteschedulingpolicy"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -384,6 +443,29 @@ describe_jobs(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Describes one or more of your scheduling policies.
+describe_scheduling_policies(Client, Input) ->
+    describe_scheduling_policies(Client, Input, []).
+describe_scheduling_policies(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/describeschedulingpolicies"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Returns a list of Batch jobs.
 %%
 %% You must specify only one of the following items:
@@ -420,11 +502,34 @@ list_jobs(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Returns a list of Batch scheduling policies.
+list_scheduling_policies(Client, Input) ->
+    list_scheduling_policies(Client, Input, []).
+list_scheduling_policies(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/listschedulingpolicies"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Lists the tags for an Batch resource.
 %%
 %% Batch resources that support tags are compute environments, jobs, job
-%% definitions, and job queues. ARNs for child jobs of array and multi-node
-%% parallel (MNP) jobs are not supported.
+%% definitions, job queues, and scheduling policies. ARNs for child jobs of
+%% array and multi-node parallel (MNP) jobs are not supported.
 list_tags_for_resource(Client, ResourceArn)
   when is_map(Client) ->
     list_tags_for_resource(Client, ResourceArn, #{}, #{}).
@@ -474,11 +579,14 @@ register_job_definition(Client, Input0, Options0) ->
 %%
 %% Parameters that are specified during `SubmitJob' override parameters
 %% defined in the job definition. vCPU and memory requirements that are
-%% specified in the `ResourceRequirements' objects in the job definition are
+%% specified in the `resourceRequirements' objects in the job definition are
 %% the exception. They can't be overridden this way using the `memory' and
 %% `vcpus' parameters. Rather, you must specify updates to job definition
 %% parameters in a `ResourceRequirements' object that's included in the
 %% `containerOverrides' parameter.
+%%
+%% Job queues with a scheduling policy are limited to 500 active fair share
+%% identifiers at a time.
 %%
 %% Jobs that run on Fargate resources can't be guaranteed to run for more
 %% than 14 days. This is because, after 14 days, Fargate resources might
@@ -511,9 +619,9 @@ submit_job(Client, Input0, Options0) ->
 %% If existing tags on a resource aren't specified in the request parameters,
 %% they aren't changed. When a resource is deleted, the tags that are
 %% associated with that resource are deleted as well. Batch resources that
-%% support tags are compute environments, jobs, job definitions, and job
-%% queues. ARNs for child jobs of array and multi-node parallel (MNP) jobs
-%% are not supported.
+%% support tags are compute environments, jobs, job definitions, job queues,
+%% and scheduling policies. ARNs for child jobs of array and multi-node
+%% parallel (MNP) jobs are not supported.
 tag_resource(Client, ResourceArn, Input) ->
     tag_resource(Client, ResourceArn, Input, []).
 tag_resource(Client, ResourceArn, Input0, Options0) ->
@@ -633,6 +741,29 @@ update_job_queue(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Updates a scheduling policy.
+update_scheduling_policy(Client, Input) ->
+    update_scheduling_policy(Client, Input, []).
+update_scheduling_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/v1/updateschedulingpolicy"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -646,6 +777,10 @@ update_job_queue(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"batch">>},
     Host = build_host(<<"batch">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -254,6 +254,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"braket">>},
     Host = build_host(<<"braket">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_budgets.erl
+++ b/src/aws_budgets.erl
@@ -324,7 +324,11 @@ update_subscriber(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"budgets">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"budgets">>, Client1),

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -5705,6 +5705,10 @@ update_voice_connector_group(Client, VoiceConnectorGroupId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"chime">>, Client1),

--- a/src/aws_chime_sdk_identity.erl
+++ b/src/aws_chime_sdk_identity.erl
@@ -699,6 +699,10 @@ update_app_instance_user_endpoint(Client, AppInstanceUserArn, EndpointId, Input0
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
     Host = build_host(<<"identity-chime">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_chime_sdk_meetings.erl
+++ b/src/aws_chime_sdk_meetings.erl
@@ -349,6 +349,10 @@ stop_meeting_transcription(Client, MeetingId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
     Host = build_host(<<"meetings-chime">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_chime_sdk_messaging.erl
+++ b/src/aws_chime_sdk_messaging.erl
@@ -1642,6 +1642,10 @@ update_channel_read_marker(Client, ChannelArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
     Host = build_host(<<"messaging-chime">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_cloud9.erl
+++ b/src/aws_cloud9.erl
@@ -206,7 +206,11 @@ update_environment_membership(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloud9">>},
     Host = build_host(<<"cloud9">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudcontrol.erl
+++ b/src/aws_cloudcontrol.erl
@@ -171,7 +171,11 @@ update_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudcontrolapi">>},
     Host = build_host(<<"cloudcontrolapi">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -1964,6 +1964,10 @@ upgrade_published_schema(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"clouddirectory">>},
     Host = build_host(<<"clouddirectory">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_cloudformation.erl
+++ b/src/aws_cloudformation.erl
@@ -1245,7 +1245,11 @@ validate_template(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudformation">>},
     Host = build_host(<<"cloudformation">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -3927,6 +3927,10 @@ update_streaming_distribution(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudfront">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"cloudfront">>, Client1),

--- a/src/aws_cloudhsm.erl
+++ b/src/aws_cloudhsm.erl
@@ -435,7 +435,11 @@ remove_tags_from_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
     Host = build_host(<<"cloudhsm">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudhsm_v2.erl
+++ b/src/aws_cloudhsm_v2.erl
@@ -217,7 +217,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
     Host = build_host(<<"cloudhsmv2">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudsearch.erl
+++ b/src/aws_cloudsearch.erl
@@ -417,7 +417,11 @@ update_service_access_policies(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudsearch">>},
     Host = build_host(<<"cloudsearch">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudsearchdomain.erl
+++ b/src/aws_cloudsearchdomain.erl
@@ -195,6 +195,10 @@ upload_documents(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudsearch">>},
     Host = build_host(<<"cloudsearchdomain">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_cloudtrail.erl
+++ b/src/aws_cloudtrail.erl
@@ -386,7 +386,11 @@ update_trail(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudtrail">>},
     Host = build_host(<<"cloudtrail">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudwatch.erl
+++ b/src/aws_cloudwatch.erl
@@ -882,7 +882,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"monitoring">>},
     Host = build_host(<<"monitoring">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudwatch_events.erl
+++ b/src/aws_cloudwatch_events.erl
@@ -973,7 +973,11 @@ update_connection(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"events">>},
     Host = build_host(<<"events">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cloudwatch_logs.erl
+++ b/src/aws_cloudwatch_logs.erl
@@ -852,7 +852,11 @@ untag_log_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"logs">>},
     Host = build_host(<<"logs">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -1370,6 +1370,10 @@ update_repository(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeartifact">>},
     Host = build_host(<<"codeartifact">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_codebuild.erl
+++ b/src/aws_codebuild.erl
@@ -554,7 +554,11 @@ update_webhook(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codebuild">>},
     Host = build_host(<<"codebuild">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codecommit.erl
+++ b/src/aws_codecommit.erl
@@ -1260,7 +1260,11 @@ update_repository_name(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codecommit">>},
     Host = build_host(<<"codecommit">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codedeploy.erl
+++ b/src/aws_codedeploy.erl
@@ -653,7 +653,11 @@ update_deployment_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codedeploy">>},
     Host = build_host(<<"codedeploy">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -476,6 +476,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeguru-reviewer">>},
     Host = build_host(<<"codeguru-reviewer">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -791,6 +791,10 @@ update_profiling_group(Client, ProfilingGroupName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeguru-profiler">>},
     Host = build_host(<<"codeguru-profiler">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_codepipeline.erl
+++ b/src/aws_codepipeline.erl
@@ -688,7 +688,11 @@ update_pipeline(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codepipeline">>},
     Host = build_host(<<"codepipeline">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codestar.erl
+++ b/src/aws_codestar.erl
@@ -292,7 +292,11 @@ update_user_profile(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codestar">>},
     Host = build_host(<<"codestar">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codestar_connections.erl
+++ b/src/aws_codestar_connections.erl
@@ -230,7 +230,11 @@ update_host(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codestar-connections">>},
     Host = build_host(<<"codestar-connections">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -416,6 +416,10 @@ update_notification_rule(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codestar-notifications">>},
     Host = build_host(<<"codestar-notifications">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_cognito_identity.erl
+++ b/src/aws_cognito_identity.erl
@@ -426,7 +426,11 @@ update_identity_pool(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cognito-identity">>},
     Host = build_host(<<"cognito-identity">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cognito_identity_provider.erl
+++ b/src/aws_cognito_identity_provider.erl
@@ -1628,7 +1628,11 @@ verify_user_attribute(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cognito-idp">>},
     Host = build_host(<<"cognito-idp">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cognito_sync.erl
+++ b/src/aws_cognito_sync.erl
@@ -599,6 +599,10 @@ update_records(Client, DatasetName, IdentityId, IdentityPoolId, Input0, Options0
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cognito-sync">>},
     Host = build_host(<<"cognito-sync">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_comprehend.erl
+++ b/src/aws_comprehend.erl
@@ -833,7 +833,11 @@ update_endpoint(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"comprehend">>},
     Host = build_host(<<"comprehend">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_comprehendmedical.erl
+++ b/src/aws_comprehendmedical.erl
@@ -293,7 +293,11 @@ stop_rx_norm_inference_job(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"comprehendmedical">>},
     Host = build_host(<<"comprehendmedical">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_compute_optimizer.erl
+++ b/src/aws_compute_optimizer.erl
@@ -284,7 +284,11 @@ update_enrollment_status(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"compute-optimizer">>},
     Host = build_host(<<"compute-optimizer">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -1596,7 +1596,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"config">>},
     Host = build_host(<<"config">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -3530,6 +3530,10 @@ update_user_security_profiles(Client, InstanceId, UserId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect">>},
     Host = build_host(<<"connect">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -14,9 +14,8 @@
 %% per second. For more information, see Amazon Connect Service Quotas in the
 %% Amazon Connect Administrator Guide.
 %%
-%% You can connect programmatically to an Amazon Web Services service by
-%% using an endpoint. For a list of Amazon Connect endpoints, see Amazon
-%% Connect Endpoints.
+%% You can connect programmatically to an AWS service by using an endpoint.
+%% For a list of Amazon Connect endpoints, see Amazon Connect Endpoints.
 %%
 %% Working with contact flows? Check out the Amazon Connect Flow language.
 -module(aws_connect).
@@ -80,6 +79,9 @@
          describe_agent_status/3,
          describe_agent_status/5,
          describe_agent_status/6,
+         describe_contact/3,
+         describe_contact/5,
+         describe_contact/6,
          describe_contact_flow/3,
          describe_contact_flow/5,
          describe_contact_flow/6,
@@ -154,6 +156,9 @@
          list_contact_flows/2,
          list_contact_flows/4,
          list_contact_flows/5,
+         list_contact_references/4,
+         list_contact_references/6,
+         list_contact_references/7,
          list_hours_of_operations/2,
          list_hours_of_operations/4,
          list_hours_of_operations/5,
@@ -243,12 +248,16 @@
          untag_resource/4,
          update_agent_status/4,
          update_agent_status/5,
+         update_contact/4,
+         update_contact/5,
          update_contact_attributes/2,
          update_contact_attributes/3,
          update_contact_flow_content/4,
          update_contact_flow_content/5,
          update_contact_flow_name/4,
          update_contact_flow_name/5,
+         update_contact_schedule/2,
+         update_contact_schedule/3,
          update_hours_of_operation/4,
          update_hours_of_operation/5,
          update_instance_attribute/4,
@@ -626,8 +635,7 @@ create_instance(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Creates an Amazon Web Services resource association with an Amazon
-%% Connect instance.
+%% @doc Creates an AWS resource association with an Amazon Connect instance.
 create_integration_association(Client, InstanceId, Input) ->
     create_integration_association(Client, InstanceId, Input, []).
 create_integration_association(Client, InstanceId, Input0, Options0) ->
@@ -875,8 +883,7 @@ delete_instance(Client, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Deletes an Amazon Web Services resource association from an Amazon
-%% Connect instance.
+%% @doc Deletes an AWS resource association from an Amazon Connect instance.
 %%
 %% The association must not have any use cases associated with it.
 delete_integration_association(Client, InstanceId, IntegrationAssociationId, Input) ->
@@ -1040,6 +1047,35 @@ describe_agent_status(Client, AgentStatusId, InstanceId, QueryMap, HeadersMap)
 describe_agent_status(Client, AgentStatusId, InstanceId, QueryMap, HeadersMap, Options0)
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["/agent-status/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(AgentStatusId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Describes the specified contact.
+%%
+%% Contact information is available in Amazon Connect for 24 months, and then
+%% it is deleted.
+describe_contact(Client, ContactId, InstanceId)
+  when is_map(Client) ->
+    describe_contact(Client, ContactId, InstanceId, #{}, #{}).
+
+describe_contact(Client, ContactId, InstanceId, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    describe_contact(Client, ContactId, InstanceId, QueryMap, HeadersMap, []).
+
+describe_contact(Client, ContactId, InstanceId, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/contacts/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(ContactId), ""],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -1816,6 +1852,38 @@ list_contact_flows(Client, InstanceId, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% For the specified `referenceTypes', returns a list of references
+%% associated with the contact.
+list_contact_references(Client, ContactId, InstanceId, ReferenceTypes)
+  when is_map(Client) ->
+    list_contact_references(Client, ContactId, InstanceId, ReferenceTypes, #{}, #{}).
+
+list_contact_references(Client, ContactId, InstanceId, ReferenceTypes, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_contact_references(Client, ContactId, InstanceId, ReferenceTypes, QueryMap, HeadersMap, []).
+
+list_contact_references(Client, ContactId, InstanceId, ReferenceTypes, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/contact/references/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(ContactId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"referenceTypes">>, ReferenceTypes}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
 %% @doc Provides information about the hours of operation for the specified
 %% Amazon Connect instance.
 %%
@@ -1946,8 +2014,8 @@ list_instances(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Provides summary information about the Amazon Web Services resource
-%% associations for the specified Amazon Connect instance.
+%% @doc Provides summary information about the AWS resource associations for
+%% the specified Amazon Connect instance.
 list_integration_associations(Client, InstanceId)
   when is_map(Client) ->
     list_integration_associations(Client, InstanceId, #{}, #{}).
@@ -2325,11 +2393,8 @@ list_security_profile_permissions(Client, InstanceId, SecurityProfileId, QueryMa
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc This API is in preview release for Amazon Connect and is subject to
-%% change.
-%%
-%% Provides summary information about the security profiles for the specified
-%% Amazon Connect instance.
+%% @doc Provides summary information about the security profiles for the
+%% specified Amazon Connect instance.
 %%
 %% For more information about security profiles, see Security Profiles in the
 %% Amazon Connect Administrator Guide.
@@ -2651,7 +2716,8 @@ start_outbound_voice_contact(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Initiates a contact flow to start a new task.
+%% @doc Initiates a contact flow to start a new task immediately or at a
+%% future date and time.
 start_task_contact(Client, Input) ->
     start_task_contact(Client, Input, []).
 start_task_contact(Client, Input0, Options0) ->
@@ -2867,6 +2933,37 @@ update_agent_status(Client, AgentStatusId, InstanceId, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc This API is in preview release for Amazon Connect and is subject to
+%% change.
+%%
+%% Adds or updates user defined contact information associated with the
+%% specified contact. At least one field to be updated must be present in the
+%% request.
+%%
+%% You can add or update user-defined contact information for both ongoing
+%% and completed contacts.
+update_contact(Client, ContactId, InstanceId, Input) ->
+    update_contact(Client, ContactId, InstanceId, Input, []).
+update_contact(Client, ContactId, InstanceId, Input0, Options0) ->
+    Method = post,
+    Path = ["/contacts/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(ContactId), ""],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Creates or updates user-defined contact attributes associated with
 %% the specified contact.
 %%
@@ -2948,6 +3045,30 @@ update_contact_flow_name(Client, ContactFlowId, InstanceId, Input) ->
 update_contact_flow_name(Client, ContactFlowId, InstanceId, Input0, Options0) ->
     Method = post,
     Path = ["/contact-flows/", aws_util:encode_uri(InstanceId), "/", aws_util:encode_uri(ContactFlowId), "/name"],
+    SuccessStatusCode = undefined,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates the scheduled time of a task contact that is already
+%% scheduled.
+update_contact_schedule(Client, Input) ->
+    update_contact_schedule(Client, Input, []).
+update_contact_schedule(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/contact/schedule"],
     SuccessStatusCode = undefined,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}

--- a/src/aws_connect_contact_lens.erl
+++ b/src/aws_connect_contact_lens.erl
@@ -60,6 +60,10 @@ list_realtime_contact_analysis_segments(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect">>},
     Host = build_host(<<"contact-lens">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -317,6 +317,10 @@ start_attachment_upload(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"execute-api">>},
     Host = build_host(<<"participant.connect">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_cost_and_usage_report.erl
+++ b/src/aws_cost_and_usage_report.erl
@@ -76,7 +76,11 @@ put_report_definition(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cur">>},
     Host = build_host(<<"cur">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_cost_explorer.erl
+++ b/src/aws_cost_explorer.erl
@@ -511,7 +511,11 @@ update_cost_category_definition(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ce">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"ce">>, Client1),

--- a/src/aws_customer_profiles.erl
+++ b/src/aws_customer_profiles.erl
@@ -987,6 +987,10 @@ update_profile(Client, DomainName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"profile">>},
     Host = build_host(<<"profile">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -342,7 +342,11 @@ validate_pipeline_definition(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"datapipeline">>},
     Host = build_host(<<"datapipeline">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_database_migration.erl
+++ b/src/aws_database_migration.erl
@@ -768,7 +768,11 @@ test_connection(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dms">>},
     Host = build_host(<<"dms">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -1100,6 +1100,10 @@ update_schedule(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"databrew">>},
     Host = build_host(<<"databrew">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -749,6 +749,10 @@ update_revision(Client, DataSetId, RevisionId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"dataexchange">>},
     Host = build_host(<<"dataexchange">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_datasync.erl
+++ b/src/aws_datasync.erl
@@ -528,7 +528,11 @@ update_task_execution(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"datasync">>},
     Host = build_host(<<"datasync">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_dax.erl
+++ b/src/aws_dax.erl
@@ -305,7 +305,11 @@ update_subnet_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dax">>},
     Host = build_host(<<"dax">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_detective.erl
+++ b/src/aws_detective.erl
@@ -550,6 +550,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"detective">>},
     Host = build_host(<<"api.detective">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_device_farm.erl
+++ b/src/aws_device_farm.erl
@@ -913,7 +913,11 @@ update_vpce_configuration(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"devicefarm">>},
     Host = build_host(<<"devicefarm">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_devops_guru.erl
+++ b/src/aws_devops_guru.erl
@@ -666,6 +666,10 @@ update_service_integration(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"devops-guru">>},
     Host = build_host(<<"devops-guru">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_devops_guru.erl
+++ b/src/aws_devops_guru.erl
@@ -4,17 +4,19 @@
 %% @doc Amazon DevOps Guru is a fully managed service that helps you identify
 %% anomalous behavior in business critical operational applications.
 %%
-%% You specify the AWS resources that you want DevOps Guru to cover, then the
-%% Amazon CloudWatch metrics and AWS CloudTrail events related to those
-%% resources are analyzed. When anomalous behavior is detected, DevOps Guru
-%% creates an insight that includes recommendations, related events, and
-%% related metrics that can help you improve your operational applications.
-%% For more information, see What is Amazon DevOps Guru.
+%% You specify the Amazon Web Services resources that you want DevOps Guru to
+%% cover, then the Amazon CloudWatch metrics and Amazon Web Services
+%% CloudTrail events related to those resources are analyzed. When anomalous
+%% behavior is detected, DevOps Guru creates an insight that includes
+%% recommendations, related events, and related metrics that can help you
+%% improve your operational applications. For more information, see What is
+%% Amazon DevOps Guru.
 %%
 %% You can specify 1 or 2 Amazon Simple Notification Service topics so you
 %% are notified every time a new insight is created. You can also enable
-%% DevOps Guru to generate an OpsItem in AWS Systems Manager for each insight
-%% to help you manage and track your work addressing insights.
+%% DevOps Guru to generate an OpsItem in Amazon Web Services Systems Manager
+%% for each insight to help you manage and track your work addressing
+%% insights.
 %%
 %% To learn about the DevOps Guru workflow, see How DevOps Guru works. To
 %% learn about DevOps Guru concepts, see Concepts in DevOps Guru.
@@ -35,6 +37,12 @@
          describe_insight/2,
          describe_insight/4,
          describe_insight/5,
+         describe_organization_health/2,
+         describe_organization_health/3,
+         describe_organization_overview/2,
+         describe_organization_overview/3,
+         describe_organization_resource_collection_health/2,
+         describe_organization_resource_collection_health/3,
          describe_resource_collection_health/2,
          describe_resource_collection_health/4,
          describe_resource_collection_health/5,
@@ -55,6 +63,8 @@
          list_insights/3,
          list_notification_channels/2,
          list_notification_channels/3,
+         list_organization_insights/2,
+         list_organization_insights/3,
          list_recommendations/2,
          list_recommendations/3,
          put_feedback/2,
@@ -63,6 +73,8 @@
          remove_notification_channel/4,
          search_insights/2,
          search_insights/3,
+         search_organization_insights/2,
+         search_organization_insights/3,
          start_cost_estimation/2,
          start_cost_estimation/3,
          update_resource_collection/2,
@@ -87,10 +99,10 @@
 %% using Amazon SNS in your account. For more information, see Permissions
 %% for cross account Amazon SNS topics.
 %%
-%% If you use an Amazon SNS topic that is encrypted by an AWS Key Management
-%% Service customer-managed key (CMK), then you must add permissions to the
-%% CMK. For more information, see Permissions for AWS KMS–encrypted Amazon
-%% SNS topics.
+%% If you use an Amazon SNS topic that is encrypted by an Amazon Web Services
+%% Key Management Service customer-managed key (CMK), then you must add
+%% permissions to the CMK. For more information, see Permissions for Amazon
+%% Web Services KMS–encrypted Amazon SNS topics.
 add_notification_channel(Client, Input) ->
     add_notification_channel(Client, Input, []).
 add_notification_channel(Client, Input0, Options0) ->
@@ -114,10 +126,11 @@ add_notification_channel(Client, Input0, Options0) ->
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Returns the number of open reactive insights, the number of open
-%% proactive insights, and the number of metrics analyzed in your AWS
-%% account.
+%% proactive insights, and the number of metrics analyzed in your Amazon Web
+%% Services account.
 %%
-%% Use these numbers to gauge the health of operations in your AWS account.
+%% Use these numbers to gauge the health of operations in your Amazon Web
+%% Services account.
 describe_account_health(Client)
   when is_map(Client) ->
     describe_account_health(Client, #{}, #{}).
@@ -185,12 +198,16 @@ describe_anomaly(Client, Id, QueryMap, HeadersMap, Options0)
 
     Headers = [],
 
-    Query_ = [],
+    Query0_ =
+      [
+        {<<"AccountId">>, maps:get(<<"AccountId">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns the most recent feedback submitted in the current AWS account
-%% and Region.
+%% @doc Returns the most recent feedback submitted in the current Amazon Web
+%% Services account and Region.
 describe_feedback(Client, Input) ->
     describe_feedback(Client, Input, []).
 describe_feedback(Client, Input0, Options0) ->
@@ -232,18 +249,99 @@ describe_insight(Client, Id, QueryMap, HeadersMap, Options0)
 
     Headers = [],
 
-    Query_ = [],
+    Query0_ =
+      [
+        {<<"AccountId">>, maps:get(<<"AccountId">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Returns active insights, predictive insights, and resource hours
+%% analyzed in last hour.
+describe_organization_health(Client, Input) ->
+    describe_organization_health(Client, Input, []).
+describe_organization_health(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/organization/health"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns an overview of your organization's history based on the
+%% specified time range.
+%%
+%% The overview includes the total reactive and proactive insights.
+describe_organization_overview(Client, Input) ->
+    describe_organization_overview(Client, Input, []).
+describe_organization_overview(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/organization/overview"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Provides an overview of your system's health.
+%%
+%% If additional member accounts are part of your organization, you can
+%% filter those accounts using the `AccountIds' field.
+describe_organization_resource_collection_health(Client, Input) ->
+    describe_organization_resource_collection_health(Client, Input, []).
+describe_organization_resource_collection_health(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/organization/health/resource-collection/"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
 %% @doc Returns the number of open proactive insights, open reactive
 %% insights, and the Mean Time to Recover (MTTR) for all closed insights in
 %% resource collections in your account.
 %%
-%% You specify the type of AWS resources collection. The one type of AWS
-%% resource collection supported is AWS CloudFormation stacks. DevOps Guru
-%% can be configured to analyze only the AWS resources that are defined in
-%% the stacks. You can specify up to 500 AWS CloudFormation stacks.
+%% You specify the type of Amazon Web Services resources collection. The one
+%% type of Amazon Web Services resource collection supported is Amazon Web
+%% Services CloudFormation stacks. DevOps Guru can be configured to analyze
+%% only the Amazon Web Services resources that are defined in the stacks. You
+%% can specify up to 500 Amazon Web Services CloudFormation stacks.
 describe_resource_collection_health(Client, ResourceCollectionType)
   when is_map(Client) ->
     describe_resource_collection_health(Client, ResourceCollectionType, #{}, #{}).
@@ -273,9 +371,9 @@ describe_resource_collection_health(Client, ResourceCollectionType, QueryMap, He
 %% @doc Returns the integration status of services that are integrated with
 %% DevOps Guru.
 %%
-%% The one service that can be integrated with DevOps Guru is AWS Systems
-%% Manager, which can be used to create an OpsItem for each generated
-%% insight.
+%% The one service that can be integrated with DevOps Guru is Amazon Web
+%% Services Systems Manager, which can be used to create an OpsItem for each
+%% generated insight.
 describe_service_integration(Client)
   when is_map(Client) ->
     describe_service_integration(Client, #{}, #{}).
@@ -299,7 +397,7 @@ describe_service_integration(Client, QueryMap, HeadersMap, Options0)
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
 %% @doc Returns an estimate of the monthly cost for DevOps Guru to analyze
-%% your AWS resources.
+%% your Amazon Web Services resources.
 %%
 %% For more information, see Estimate your Amazon DevOps Guru costs and
 %% Amazon DevOps Guru pricing.
@@ -329,13 +427,14 @@ get_cost_estimation(Client, QueryMap, HeadersMap, Options0)
 
     request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
 
-%% @doc Returns lists AWS resources that are of the specified resource
-%% collection type.
+%% @doc Returns lists Amazon Web Services resources that are of the specified
+%% resource collection type.
 %%
-%% The one type of AWS resource collection supported is AWS CloudFormation
-%% stacks. DevOps Guru can be configured to analyze only the AWS resources
-%% that are defined in the stacks. You can specify up to 500 AWS
-%% CloudFormation stacks.
+%% The one type of Amazon Web Services resource collection supported is
+%% Amazon Web Services CloudFormation stacks. DevOps Guru can be configured
+%% to analyze only the Amazon Web Services resources that are defined in the
+%% stacks. You can specify up to 500 Amazon Web Services CloudFormation
+%% stacks.
 get_resource_collection(Client, ResourceCollectionType)
   when is_map(Client) ->
     get_resource_collection(Client, ResourceCollectionType, #{}, #{}).
@@ -412,7 +511,7 @@ list_events(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of insights in your AWS account.
+%% @doc Returns a list of insights in your Amazon Web Services account.
 %%
 %% You can specify which insights are returned by their start time and status
 %% (`ONGOING', `CLOSED', or `ANY').
@@ -449,6 +548,29 @@ list_notification_channels(Client, Input) ->
 list_notification_channels(Client, Input0, Options0) ->
     Method = post,
     Path = ["/channels"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns a list of insights associated with the account or OU Id.
+list_organization_insights(Client, Input) ->
+    list_organization_insights(Client, Input, []).
+list_organization_insights(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/organization/insights"],
     SuccessStatusCode = 200,
     Options = [{send_body_as_binary, false},
                {receive_body_as_binary, false}
@@ -541,7 +663,7 @@ remove_notification_channel(Client, Id, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
-%% @doc Returns a list of insights in your AWS account.
+%% @doc Returns a list of insights in your Amazon Web Services account.
 %%
 %% You can specify which insights are returned by their start time, one or
 %% more statuses (`ONGOING', `CLOSED', and `CLOSED'), one or more severities
@@ -572,8 +694,39 @@ search_insights(Client, Input0, Options0) ->
 
     request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
 
+%% @doc Returns a list of insights in your organization.
+%%
+%% You can specify which insights are returned by their start time, one or
+%% more statuses (`ONGOING', `CLOSED', and `CLOSED'), one or more severities
+%% (`LOW', `MEDIUM', and `HIGH'), and type (`REACTIVE' or `PROACTIVE').
+%%
+%% Use the `Filters' parameter to specify status and severity search
+%% parameters. Use the `Type' parameter to specify `REACTIVE' or `PROACTIVE'
+%% in your search.
+search_organization_insights(Client, Input) ->
+    search_organization_insights(Client, Input, []).
+search_organization_insights(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/organization/insights/search"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
 %% @doc Starts the creation of an estimate of the monthly cost to analyze
-%% your AWS resources.
+%% your Amazon Web Services resources.
 start_cost_estimation(Client, Input) ->
     start_cost_estimation(Client, Input, []).
 start_cost_estimation(Client, Input0, Options0) ->
@@ -598,11 +751,12 @@ start_cost_estimation(Client, Input0, Options0) ->
 
 %% @doc Updates the collection of resources that DevOps Guru analyzes.
 %%
-%% The one type of AWS resource collection supported is AWS CloudFormation
-%% stacks. DevOps Guru can be configured to analyze only the AWS resources
-%% that are defined in the stacks. You can specify up to 500 AWS
-%% CloudFormation stacks. This method also creates the IAM role required for
-%% you to use DevOps Guru.
+%% The one type of Amazon Web Services resource collection supported is
+%% Amazon Web Services CloudFormation stacks. DevOps Guru can be configured
+%% to analyze only the Amazon Web Services resources that are defined in the
+%% stacks. You can specify up to 500 Amazon Web Services CloudFormation
+%% stacks. This method also creates the IAM role required for you to use
+%% DevOps Guru.
 update_resource_collection(Client, Input) ->
     update_resource_collection(Client, Input, []).
 update_resource_collection(Client, Input0, Options0) ->
@@ -628,9 +782,9 @@ update_resource_collection(Client, Input0, Options0) ->
 %% @doc Enables or disables integration with a service that can be integrated
 %% with DevOps Guru.
 %%
-%% The one service that can be integrated with DevOps Guru is AWS Systems
-%% Manager, which can be used to create an OpsItem for each generated
-%% insight.
+%% The one service that can be integrated with DevOps Guru is Amazon Web
+%% Services Systems Manager, which can be used to create an OpsItem for each
+%% generated insight.
 update_service_integration(Client, Input) ->
     update_service_integration(Client, Input, []).
 update_service_integration(Client, Input0, Options0) ->

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -1115,7 +1115,11 @@ update_virtual_interface_attributes(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"directconnect">>},
     Host = build_host(<<"directconnect">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_directory.erl
+++ b/src/aws_directory.erl
@@ -880,7 +880,11 @@ verify_trust(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ds">>},
     Host = build_host(<<"ds">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -253,6 +253,10 @@ update_lifecycle_policy(Client, PolicyId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"dlm">>},
     Host = build_host(<<"dlm">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_docdb.erl
+++ b/src/aws_docdb.erl
@@ -787,7 +787,11 @@ stop_db_cluster(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
     Host = build_host(<<"rds">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_dynamodb.erl
+++ b/src/aws_dynamodb.erl
@@ -14,15 +14,15 @@
 %% With DynamoDB, you can create database tables that can store and retrieve
 %% any amount of data, and serve any level of request traffic. You can scale
 %% up or scale down your tables' throughput capacity without downtime or
-%% performance degradation, and use the AWS Management Console to monitor
-%% resource utilization and performance metrics.
+%% performance degradation, and use the Amazon Web Services Management
+%% Console to monitor resource utilization and performance metrics.
 %%
 %% DynamoDB automatically spreads the data and traffic for your tables over a
 %% sufficient number of servers to handle your throughput and storage
 %% requirements, while maintaining consistent and fast performance. All of
 %% your data is stored on solid state disks (SSDs) and automatically
-%% replicated across multiple Availability Zones in an AWS region, providing
-%% built-in high availability and data durability.
+%% replicated across multiple Availability Zones in an Amazon Web Services
+%% Region, providing built-in high availability and data durability.
 -module(aws_dynamodb).
 
 -export([batch_execute_statement/2,
@@ -132,8 +132,11 @@
 %% API
 %%====================================================================
 
-%% @doc This operation allows you to perform batch reads and writes on data
+%% @doc This operation allows you to perform batch reads or writes on data
 %% stored in DynamoDB, using PartiQL.
+%%
+%% The entire batch must consist of either read statements or write
+%% statements, you cannot mix both in one batch.
 batch_execute_statement(Client, Input)
   when is_map(Client), is_map(Input) ->
     batch_execute_statement(Client, Input, []).
@@ -386,9 +389,9 @@ create_global_table(Client, Input, Options)
 
 %% @doc The `CreateTable' operation adds a new table to your account.
 %%
-%% In an AWS account, table names must be unique within each Region. That is,
-%% you can have two tables with same name if you create the tables in
-%% different Regions.
+%% In an Amazon Web Services account, table names must be unique within each
+%% Region. That is, you can have two tables with same name if you create the
+%% tables in different Regions.
 %%
 %% `CreateTable' is an asynchronous operation. Upon receiving a `CreateTable'
 %% request, DynamoDB immediately returns a response with a `TableStatus' of
@@ -558,24 +561,25 @@ describe_kinesis_streaming_destination(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeKinesisStreamingDestination">>, Input, Options).
 
-%% @doc Returns the current provisioned-capacity quotas for your AWS account
-%% in a Region, both for the Region as a whole and for any one DynamoDB table
-%% that you create there.
+%% @doc Returns the current provisioned-capacity quotas for your Amazon Web
+%% Services account in a Region, both for the Region as a whole and for any
+%% one DynamoDB table that you create there.
 %%
-%% When you establish an AWS account, the account has initial quotas on the
-%% maximum read capacity units and write capacity units that you can
-%% provision across all of your DynamoDB tables in a given Region. Also,
-%% there are per-table quotas that apply when you create a table there. For
-%% more information, see Service, Account, and Table Quotas page in the
+%% When you establish an Amazon Web Services account, the account has initial
+%% quotas on the maximum read capacity units and write capacity units that
+%% you can provision across all of your DynamoDB tables in a given Region.
+%% Also, there are per-table quotas that apply when you create a table there.
+%% For more information, see Service, Account, and Table Quotas page in the
 %% Amazon DynamoDB Developer Guide.
 %%
-%% Although you can increase these quotas by filing a case at AWS Support
-%% Center, obtaining the increase is not instantaneous. The `DescribeLimits'
-%% action lets you write code to compare the capacity you are currently using
-%% to those quotas imposed by your account so that you have enough time to
-%% apply for an increase before you hit a quota.
+%% Although you can increase these quotas by filing a case at Amazon Web
+%% Services Support Center, obtaining the increase is not instantaneous. The
+%% `DescribeLimits' action lets you write code to compare the capacity you
+%% are currently using to those quotas imposed by your account so that you
+%% have enough time to apply for an increase before you hit a quota.
 %%
-%% For example, you could use one of the AWS SDKs to do the following:
+%% For example, you could use one of the Amazon Web Services SDKs to do the
+%% following:
 %%
 %% <ol> <li> Call `DescribeLimits' for a particular Region to obtain your
 %% current account quotas on provisioned capacity there.
@@ -695,6 +699,12 @@ execute_statement(Client, Input, Options)
 
 %% @doc This operation allows you to perform transactional reads or writes on
 %% data stored in DynamoDB, using PartiQL.
+%%
+%% The entire transaction must consist of either read statements or write
+%% statements, you cannot mix both in one transaction. The EXISTS function is
+%% an exception and can be used to check the condition of specific attributes
+%% of the item in a similar manner to `ConditionCheck' in the
+%% TransactWriteItems API.
 execute_transaction(Client, Input)
   when is_map(Client), is_map(Input) ->
     execute_transaction(Client, Input, []).
@@ -730,7 +740,7 @@ get_item(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetItem">>, Input, Options).
 
-%% @doc List backups associated with an AWS account.
+%% @doc List backups associated with an Amazon Web Services account.
 %%
 %% To list backups for a given table, specify `TableName'. `ListBackups'
 %% returns a paginated list of results with at most 1 MB worth of items in a
@@ -812,26 +822,26 @@ list_tags_of_resource(Client, Input, Options)
 %%
 %% This topic provides general information about the `PutItem' API.
 %%
-%% For information on how to call the `PutItem' API using the AWS SDK in
-%% specific languages, see the following:
+%% For information on how to call the `PutItem' API using the Amazon Web
+%% Services SDK in specific languages, see the following:
 %%
-%% PutItem in the AWS Command Line Interface
+%% PutItem in the Command Line Interface
 %%
-%% PutItem in the AWS SDK for .NET
+%% PutItem in the SDK for .NET
 %%
-%% PutItem in the AWS SDK for C++
+%% PutItem in the SDK for C++
 %%
-%% PutItem in the AWS SDK for Go
+%% PutItem in the SDK for Go
 %%
-%% PutItem in the AWS SDK for Java
+%% PutItem in the SDK for Java
 %%
-%% PutItem in the AWS SDK for JavaScript
+%% PutItem in the SDK for JavaScript
 %%
-%% PutItem in the AWS SDK for PHP V3
+%% PutItem in the SDK for PHP V3
 %%
-%% PutItem in the AWS SDK for Python
+%% PutItem in the SDK for Python (Boto)
 %%
-%% PutItem in the AWS SDK for Ruby V2
+%% PutItem in the SDK for Ruby V2
 %%
 %% When you add an item, the primary key attributes are the only required
 %% attributes. Attribute values cannot be null.
@@ -859,10 +869,12 @@ put_item(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutItem">>, Input, Options).
 
-%% @doc The `Query' operation finds items based on primary key values.
+%% @doc You must provide the name of the partition key attribute and a single
+%% value for that attribute.
 %%
-%% You can query any table or secondary index that has a composite primary
-%% key (a partition key and a sort key).
+%% `Query' returns all items with that partition key value. Optionally, you
+%% can provide a sort key attribute and use a comparison operator to refine
+%% the search results.
 %%
 %% Use the `KeyConditionExpression' parameter to provide a specific value for
 %% the partition key. The `Query' operation will return all of the items from
@@ -1057,9 +1069,9 @@ tag_resource(Client, Input, Options)
 %% A `TransactGetItems' call can contain up to 25 `TransactGetItem' objects,
 %% each of which contains a `Get' structure that specifies an item to
 %% retrieve from a table in the account and Region. A call to
-%% `TransactGetItems' cannot retrieve items from tables in more than one AWS
-%% account or Region. The aggregate size of the items in the transaction
-%% cannot exceed 4 MB.
+%% `TransactGetItems' cannot retrieve items from tables in more than one
+%% Amazon Web Services account or Region. The aggregate size of the items in
+%% the transaction cannot exceed 4 MB.
 %%
 %% DynamoDB rejects the entire `TransactGetItems' request if any of the
 %% following is true:
@@ -1087,9 +1099,10 @@ transact_get_items(Client, Input, Options)
 %% to 25 action requests.
 %%
 %% These actions can target items in different tables, but not in different
-%% AWS accounts or Regions, and no two actions can target the same item. For
-%% example, you cannot both `ConditionCheck' and `Update' the same item. The
-%% aggregate size of the items in the transaction cannot exceed 4 MB.
+%% Amazon Web Services accounts or Regions, and no two actions can target the
+%% same item. For example, you cannot both `ConditionCheck' and `Update' the
+%% same item. The aggregate size of the items in the transaction cannot
+%% exceed 4 MB.
 %%
 %% The actions are completed atomically so that either all of them succeed,
 %% or all of them fail. They are defined by the following objects:
@@ -1186,6 +1199,13 @@ update_continuous_backups(Client, Input, Options)
 
 %% @doc Updates the status for contributor insights for a specific table or
 %% index.
+%%
+%% CloudWatch Contributor Insights for DynamoDB graphs display the partition
+%% key and (if applicable) sort key of frequently accessed items and
+%% frequently throttled items in plaintext. If you require the use of AWS Key
+%% Management Service (KMS) to encrypt this table’s partition key and sort
+%% key data with an AWS managed key or customer managed key, you should not
+%% enable CloudWatch Contributor Insights for DynamoDB for this table.
 update_contributor_insights(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_contributor_insights(Client, Input, []).
@@ -1332,7 +1352,11 @@ update_time_to_live(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
     Host = build_host(<<"dynamodb">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_dynamodb_streams.erl
+++ b/src/aws_dynamodb_streams.erl
@@ -101,7 +101,11 @@ list_streams(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
     Host = build_host(<<"streams.dynamodb">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -283,6 +283,10 @@ start_snapshot(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ebs">>},
     Host = build_host(<<"ebs">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_ec2_instance_connect.erl
+++ b/src/aws_ec2_instance_connect.erl
@@ -51,7 +51,11 @@ send_ssh_public_key(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ec2-instance-connect">>},
     Host = build_host(<<"ec2-instance-connect">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ecr.erl
+++ b/src/aws_ecr.erl
@@ -529,7 +529,11 @@ upload_layer_part(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecr">>},
     Host = build_host(<<"api.ecr">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ecr_public.erl
+++ b/src/aws_ecr_public.erl
@@ -352,7 +352,11 @@ upload_layer_part(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecr-public">>},
     Host = build_host(<<"api.ecr-public">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -1166,7 +1166,11 @@ update_task_set(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecs">>},
     Host = build_host(<<"ecs">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -4,24 +4,24 @@
 %% @doc Amazon Elastic Container Service
 %%
 %% Amazon Elastic Container Service (Amazon ECS) is a highly scalable, fast,
-%% container management service that makes it easy to run, stop, and manage
-%% Docker containers on a cluster.
+%% container management service.
 %%
-%% You can host your cluster on a serverless infrastructure that is managed
-%% by Amazon ECS by launching your services or tasks on Fargate. For more
+%% It makes it easy to run, stop, and manage Docker containers on a cluster.
+%% You can host your cluster on a serverless infrastructure that's managed by
+%% Amazon ECS by launching your services or tasks on Fargate. For more
 %% control, you can host your tasks on a cluster of Amazon Elastic Compute
 %% Cloud (Amazon EC2) instances that you manage.
 %%
 %% Amazon ECS makes it easy to launch and stop container-based applications
-%% with simple API calls, allows you to get the state of your cluster from a
-%% centralized service, and gives you access to many familiar Amazon EC2
-%% features.
+%% with simple API calls. This makes it easy to get the state of your cluster
+%% from a centralized service, and gives you access to many familiar Amazon
+%% EC2 features.
 %%
 %% You can use Amazon ECS to schedule the placement of containers across your
 %% cluster based on your resource needs, isolation policies, and availability
-%% requirements. Amazon ECS eliminates the need for you to operate your own
-%% cluster management and configuration management systems or worry about
-%% scaling your management infrastructure.
+%% requirements. With Amazon ECS, you don't need to operate your own cluster
+%% management and configuration management systems. You also don't need to
+%% worry about scaling your management infrastructure.
 -module(aws_ecs).
 
 -export([create_capacity_provider/2,
@@ -140,10 +140,10 @@
 %% Capacity providers are associated with an Amazon ECS cluster and are used
 %% in capacity provider strategies to facilitate cluster auto scaling.
 %%
-%% Only capacity providers using an Auto Scaling group can be created. Amazon
-%% ECS tasks on Fargate use the `FARGATE' and `FARGATE_SPOT' capacity
-%% providers which are already created and available to all accounts in
-%% Regions supported by Fargate.
+%% Only capacity providers that use an Auto Scaling group can be created.
+%% Amazon ECS tasks on Fargate use the `FARGATE' and `FARGATE_SPOT' capacity
+%% providers. These providers are available to all accounts in the Amazon Web
+%% Services Regions that Fargate supports.
 create_capacity_provider(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_capacity_provider(Client, Input, []).
@@ -158,12 +158,12 @@ create_capacity_provider(Client, Input, Options)
 %% unique name with the `CreateCluster' action.
 %%
 %% When you call the `CreateCluster' API operation, Amazon ECS attempts to
-%% create the Amazon ECS service-linked role for your account so that
-%% required resources in other Amazon Web Services services can be managed on
-%% your behalf. However, if the IAM user that makes the call does not have
-%% permissions to create the service-linked role, it is not created. For more
-%% information, see Using Service-Linked Roles for Amazon ECS in the Amazon
-%% Elastic Container Service Developer Guide.
+%% create the Amazon ECS service-linked role for your account. This is so
+%% that it can manage required resources in other Amazon Web Services
+%% services on your behalf. However, if the IAM user that makes the call
+%% doesn't have permissions to create the service-linked role, it isn't
+%% created. For more information, see Using Service-Linked Roles for Amazon
+%% ECS in the Amazon Elastic Container Service Developer Guide.
 create_cluster(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_cluster(Client, Input, []).
@@ -171,7 +171,7 @@ create_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateCluster">>, Input, Options).
 
-%% @doc Runs and maintains a desired number of tasks from a specified task
+%% @doc Runs and maintains your desired number of tasks from a specified task
 %% definition.
 %%
 %% If the number of tasks running in a service drops below the
@@ -184,8 +184,8 @@ create_cluster(Client, Input, Options)
 %% with the service. For more information, see Service Load Balancing in the
 %% Amazon Elastic Container Service Developer Guide.
 %%
-%% Tasks for services that do not use a load balancer are considered healthy
-%% if they're in the `RUNNING' state. Tasks for services that do use a load
+%% Tasks for services that don't use a load balancer are considered healthy
+%% if they're in the `RUNNING' state. Tasks for services that use a load
 %% balancer are considered healthy if they're in the `RUNNING' state and the
 %% container instance that they're hosted on is reported as healthy by the
 %% load balancer.
@@ -193,7 +193,7 @@ create_cluster(Client, Input, Options)
 %% There are two service scheduler strategies available:
 %%
 %% <ul> <li> `REPLICA' - The replica scheduling strategy places and maintains
-%% the desired number of tasks across your cluster. By default, the service
+%% your desired number of tasks across your cluster. By default, the service
 %% scheduler spreads tasks across Availability Zones. You can use task
 %% placement strategies and constraints to customize task placement
 %% decisions. For more information, see Service Scheduler Concepts in the
@@ -202,55 +202,59 @@ create_cluster(Client, Input, Options)
 %% </li> <li> `DAEMON' - The daemon scheduling strategy deploys exactly one
 %% task on each active container instance that meets all of the task
 %% placement constraints that you specify in your cluster. The service
-%% scheduler also evaluates the task placement constraints for running tasks
-%% and will stop tasks that do not meet the placement constraints. When using
+%% scheduler also evaluates the task placement constraints for running tasks.
+%% It also stops tasks that don't meet the placement constraints. When using
 %% this strategy, you don't need to specify a desired number of tasks, a task
 %% placement strategy, or use Service Auto Scaling policies. For more
 %% information, see Service Scheduler Concepts in the Amazon Elastic
 %% Container Service Developer Guide.
 %%
 %% </li> </ul> You can optionally specify a deployment configuration for your
-%% service. The deployment is triggered by changing properties, such as the
-%% task definition or the desired count of a service, with an `UpdateService'
+%% service. The deployment is initiated by changing properties. For example,
+%% the deployment might be initiated by the task definition or by your
+%% desired count of a service. This is done with an `UpdateService'
 %% operation. The default value for a replica service for
 %% `minimumHealthyPercent' is 100%. The default value for a daemon service
 %% for `minimumHealthyPercent' is 0%.
 %%
-%% If a service is using the `ECS' deployment controller, the minimum healthy
+%% If a service uses the `ECS' deployment controller, the minimum healthy
 %% percent represents a lower limit on the number of tasks in a service that
-%% must remain in the `RUNNING' state during a deployment, as a percentage of
-%% the desired number of tasks (rounded up to the nearest integer), and while
-%% any container instances are in the `DRAINING' state if the service
-%% contains tasks using the EC2 launch type. This parameter enables you to
-%% deploy without using additional cluster capacity. For example, if your
-%% service has a desired number of four tasks and a minimum healthy percent
-%% of 50%, the scheduler might stop two existing tasks to free up cluster
-%% capacity before starting two new tasks. Tasks for services that do not use
-%% a load balancer are considered healthy if they're in the `RUNNING' state.
-%% Tasks for services that do use a load balancer are considered healthy if
-%% they're in the `RUNNING' state and they're reported as healthy by the load
-%% balancer. The default value for minimum healthy percent is 100%.
+%% must remain in the `RUNNING' state during a deployment. Specifically, it
+%% represents it as a percentage of your desired number of tasks (rounded up
+%% to the nearest integer). This happens when any of your container instances
+%% are in the `DRAINING' state if the service contains tasks using the EC2
+%% launch type. Using this parameter, you can deploy without using additional
+%% cluster capacity. For example, if you set your service to have desired
+%% number of four tasks and a minimum healthy percent of 50%, the scheduler
+%% might stop two existing tasks to free up cluster capacity before starting
+%% two new tasks. If they're in the `RUNNING' state, tasks for services that
+%% don't use a load balancer are considered healthy . If they're in the
+%% `RUNNING' state and reported as healthy by the load balancer, tasks for
+%% services that do use a load balancer are considered healthy . The default
+%% value for minimum healthy percent is 100%.
 %%
-%% If a service is using the `ECS' deployment controller, the maximum percent
+%% If a service uses the `ECS' deployment controller, the maximum percent
 %% parameter represents an upper limit on the number of tasks in a service
-%% that are allowed in the `RUNNING' or `PENDING' state during a deployment,
-%% as a percentage of the desired number of tasks (rounded down to the
-%% nearest integer), and while any container instances are in the `DRAINING'
-%% state if the service contains tasks using the EC2 launch type. This
-%% parameter enables you to define the deployment batch size. For example, if
-%% your service has a desired number of four tasks and a maximum percent
-%% value of 200%, the scheduler may start four new tasks before stopping the
-%% four older tasks (provided that the cluster resources required to do this
-%% are available). The default value for maximum percent is 200%.
+%% that are allowed in the `RUNNING' or `PENDING' state during a deployment.
+%% Specifically, it represents it as a percentage of the desired number of
+%% tasks (rounded down to the nearest integer). This happens when any of your
+%% container instances are in the `DRAINING' state if the service contains
+%% tasks using the EC2 launch type. Using this parameter, you can define the
+%% deployment batch size. For example, if your service has a desired number
+%% of four tasks and a maximum percent value of 200%, the scheduler may start
+%% four new tasks before stopping the four older tasks (provided that the
+%% cluster resources required to do this are available). The default value
+%% for maximum percent is 200%.
 %%
-%% If a service is using either the `CODE_DEPLOY' or `EXTERNAL' deployment
+%% If a service uses either the `CODE_DEPLOY' or `EXTERNAL' deployment
 %% controller types and tasks that use the EC2 launch type, the minimum
 %% healthy percent and maximum percent values are used only to define the
 %% lower and upper limit on the number of the tasks in the service that
-%% remain in the `RUNNING' state while the container instances are in the
-%% `DRAINING' state. If the tasks in the service use the Fargate launch type,
-%% the minimum healthy percent and maximum percent values aren't used,
-%% although they're currently visible when describing your service.
+%% remain in the `RUNNING' state. This is while the container instances are
+%% in the `DRAINING' state. If the tasks in the service use the Fargate
+%% launch type, the minimum healthy percent and maximum percent values aren't
+%% used. This is the case even if they're currently visible when describing
+%% your service.
 %%
 %% When creating a service that uses the `EXTERNAL' deployment controller,
 %% you can specify only parameters that aren't controlled at the task set
@@ -263,12 +267,13 @@ create_cluster(Client, Input, Options)
 %% placement in your cluster using the following logic:
 %%
 %% <ul> <li> Determine which of the container instances in your cluster can
-%% support your service's task definition (for example, they have the
-%% required CPU, memory, ports, and container instance attributes).
+%% support the task definition of your service. For example, they have the
+%% required CPU, memory, ports, and container instance attributes.
 %%
 %% </li> <li> By default, the service scheduler attempts to balance tasks
-%% across Availability Zones in this manner (although you can choose a
-%% different placement strategy) with the `placementStrategy' parameter):
+%% across Availability Zones in this manner. This is the case even if you can
+%% choose a different placement strategy with the `placementStrategy'
+%% parameter.
 %%
 %% <ul> <li> Sort the valid container instances, giving priority to instances
 %% that have the fewest number of running tasks for this service in their
@@ -277,9 +282,8 @@ create_cluster(Client, Input, Options)
 %% in either zone B or C are considered optimal for placement.
 %%
 %% </li> <li> Place the new service task on a valid container instance in an
-%% optimal Availability Zone (based on the previous steps), favoring
-%% container instances with the fewest number of running tasks for this
-%% service.
+%% optimal Availability Zone based on the previous steps, favoring container
+%% instances with the fewest number of running tasks for this service.
 %%
 %% </li> </ul> </li> </ul>
 create_service(Client, Input)
@@ -320,9 +324,9 @@ delete_attributes(Client, Input, Options)
 
 %% @doc Deletes the specified capacity provider.
 %%
-%% The `FARGATE' and `FARGATE_SPOT' capacity providers are reserved and
-%% cannot be deleted. You can disassociate them from a cluster using either
-%% the `PutClusterCapacityProviders' API or by deleting the cluster.
+%% The `FARGATE' and `FARGATE_SPOT' capacity providers are reserved and can't
+%% be deleted. You can disassociate them from a cluster using either the
+%% `PutClusterCapacityProviders' API or by deleting the cluster.
 %%
 %% Prior to a capacity provider being deleted, the capacity provider must be
 %% removed from the capacity provider strategy from all services. The
@@ -331,7 +335,7 @@ delete_attributes(Client, Input, Options)
 %% `forceNewDeployment' option can be used to ensure that any tasks using the
 %% Amazon EC2 instance capacity provided by the capacity provider are
 %% transitioned to use the capacity from the remaining capacity providers.
-%% Only capacity providers that are not associated with a cluster can be
+%% Only capacity providers that aren't associated with a cluster can be
 %% deleted. To remove a capacity provider from a cluster, you can either use
 %% `PutClusterCapacityProviders' or delete the cluster.
 delete_capacity_provider(Client, Input)
@@ -343,10 +347,10 @@ delete_capacity_provider(Client, Input, Options)
 
 %% @doc Deletes the specified cluster.
 %%
-%% The cluster will transition to the `INACTIVE' state. Clusters with an
-%% `INACTIVE' status may remain discoverable in your account for a period of
-%% time. However, this behavior is subject to change in the future, so you
-%% should not rely on `INACTIVE' clusters persisting.
+%% The cluster transitions to the `INACTIVE' state. Clusters with an
+%% `INACTIVE' status might remain discoverable in your account for a period
+%% of time. However, this behavior is subject to change in the future. We
+%% don't recommend that you rely on `INACTIVE' clusters persisting.
 %%
 %% You must deregister all container instances from this cluster before you
 %% may delete it. You can list the container instances in a cluster with
@@ -363,7 +367,7 @@ delete_cluster(Client, Input, Options)
 %%
 %% You can delete a service if you have no running tasks in it and the
 %% desired task count is zero. If the service is actively maintaining tasks,
-%% you cannot delete it, and you must update the service to a desired task
+%% you can't delete it, and you must update the service to a desired task
 %% count of zero. For more information, see `UpdateService'.
 %%
 %% When you delete a service, if there are still running tasks that require
@@ -404,18 +408,18 @@ delete_task_set(Client, Input, Options)
 %% This instance is no longer available to run tasks.
 %%
 %% If you intend to use the container instance for some other purpose after
-%% deregistration, you should stop all of the tasks running on the container
-%% instance before deregistration. That prevents any orphaned tasks from
-%% consuming resources.
+%% deregistration, we recommend that you stop all of the tasks running on the
+%% container instance before deregistration. That prevents any orphaned tasks
+%% from consuming resources.
 %%
 %% Deregistering a container instance removes the instance from a cluster,
-%% but it does not terminate the EC2 instance. If you are finished using the
+%% but it doesn't terminate the EC2 instance. If you are finished using the
 %% instance, be sure to terminate it in the Amazon EC2 console to stop
 %% billing.
 %%
 %% If you terminate a running container instance, Amazon ECS automatically
 %% deregisters the instance from your cluster (stopped container instances or
-%% instances with disconnected agents are not automatically deregistered when
+%% instances with disconnected agents aren't automatically deregistered when
 %% terminated).
 deregister_container_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -432,16 +436,16 @@ deregister_container_instance(Client, Input, Options)
 %% task definition can still scale up or down by modifying the service's
 %% desired count.
 %%
-%% You cannot use an `INACTIVE' task definition to run new tasks or create
-%% new services, and you cannot update an existing service to reference an
+%% You can't use an `INACTIVE' task definition to run new tasks or create new
+%% services, and you can't update an existing service to reference an
 %% `INACTIVE' task definition. However, there may be up to a 10-minute window
 %% following deregistration where these restrictions have not yet taken
 %% effect.
 %%
 %% At this time, `INACTIVE' task definitions remain discoverable in your
 %% account indefinitely. However, this behavior is subject to change in the
-%% future, so you should not rely on `INACTIVE' task definitions persisting
-%% beyond the lifecycle of any associated tasks and services.
+%% future. We don't recommend that you rely on `INACTIVE' task definitions
+%% persisting beyond the lifecycle of any associated tasks and services.
 deregister_task_definition(Client, Input)
   when is_map(Client), is_map(Input) ->
     deregister_task_definition(Client, Input, []).
@@ -552,8 +556,8 @@ list_account_settings(Client, Input, Options)
 %% list of attribute objects, one for each attribute on each resource. You
 %% can filter the list of results to a single attribute name to only return
 %% results that have that name. You can also filter the results by attribute
-%% name and value, for example, to see which container instances in a cluster
-%% are running a Linux AMI (`ecs.os-type=linux').
+%% name and value. You can do this, for example, to see which container
+%% instances in a cluster are running a Linux AMI (`ecs.os-type=linux').
 list_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
     list_attributes(Client, Input, []).
@@ -602,10 +606,12 @@ list_tags_for_resource(Client, Input, Options)
     request(Client, <<"ListTagsForResource">>, Input, Options).
 
 %% @doc Returns a list of task definition families that are registered to
-%% your account (which may include task definition families that no longer
-%% have any `ACTIVE' task definition revisions).
+%% your account.
 %%
-%% You can filter out task definition families that do not contain any
+%% This list includes task definition families that no longer have any
+%% `ACTIVE' task definition revisions.
+%%
+%% You can filter out task definition families that don't contain any
 %% `ACTIVE' task definition revisions by setting the `status' parameter to
 %% `ACTIVE'. You can also filter the results with the `familyPrefix'
 %% parameter.
@@ -648,19 +654,18 @@ list_tasks(Client, Input, Options)
 %% Account settings are set on a per-Region basis.
 %%
 %% If you change the account setting for the root user, the default settings
-%% for all of the IAM users and roles for which no individual account setting
-%% has been specified are reset. For more information, see Account Settings
-%% in the Amazon Elastic Container Service Developer Guide.
+%% for all of the IAM users and roles that no individual account setting was
+%% specified are reset for. For more information, see Account Settings in the
+%% Amazon Elastic Container Service Developer Guide.
 %%
 %% When `serviceLongArnFormat', `taskLongArnFormat', or
 %% `containerInstanceLongArnFormat' are specified, the Amazon Resource Name
 %% (ARN) and resource ID format of the resource type for a specified IAM
 %% user, IAM role, or the root user for an account is affected. The opt-in
 %% and opt-out account setting must be set for each Amazon ECS resource
-%% separately. The ARN and resource ID format of a resource will be defined
-%% by the opt-in status of the IAM user or role that created the resource.
-%% You must enable this setting to use Amazon ECS features such as resource
-%% tagging.
+%% separately. The ARN and resource ID format of a resource is defined by the
+%% opt-in status of the IAM user or role that created the resource. You must
+%% enable this setting to use Amazon ECS features such as resource tagging.
 %%
 %% When `awsvpcTrunking' is specified, the elastic network interface (ENI)
 %% limit for any new container instances that support the feature is changed.
@@ -695,9 +700,9 @@ put_account_setting_default(Client, Input, Options)
 
 %% @doc Create or update an attribute on an Amazon ECS resource.
 %%
-%% If the attribute does not exist, it is created. If the attribute exists,
-%% its value is replaced with the specified value. To delete an attribute,
-%% use `DeleteAttributes'. For more information, see Attributes in the Amazon
+%% If the attribute doesn't exist, it's created. If the attribute exists, its
+%% value is replaced with the specified value. To delete an attribute, use
+%% `DeleteAttributes'. For more information, see Attributes in the Amazon
 %% Elastic Container Service Developer Guide.
 put_attributes(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -713,16 +718,17 @@ put_attributes(Client, Input, Options)
 %% capacity provider strategy for the cluster. If the specified cluster has
 %% existing capacity providers associated with it, you must specify all
 %% existing capacity providers in addition to any new ones you want to add.
-%% Any existing capacity providers associated with a cluster that are omitted
-%% from a `PutClusterCapacityProviders' API call will be disassociated with
-%% the cluster. You can only disassociate an existing capacity provider from
-%% a cluster if it's not being used by any existing tasks.
+%% Any existing capacity providers that are associated with a cluster that
+%% are omitted from a `PutClusterCapacityProviders' API call will be
+%% disassociated with the cluster. You can only disassociate an existing
+%% capacity provider from a cluster if it's not being used by any existing
+%% tasks.
 %%
 %% When creating a service or running a task on a cluster, if no capacity
 %% provider or launch type is specified, then the cluster's default capacity
-%% provider strategy is used. It is recommended to define a default capacity
-%% provider strategy for your cluster, however you may specify an empty array
-%% (`[]') to bypass defining a default strategy.
+%% provider strategy is used. We recommend that you define a default capacity
+%% provider strategy for your cluster. However, you must specify an empty
+%% array (`[]') to bypass defining a default strategy.
 put_cluster_capacity_providers(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_cluster_capacity_providers(Client, Input, []).
@@ -754,8 +760,8 @@ register_container_instance(Client, Input, Options)
 %% parameter. When you specify an IAM role for a task, its containers can
 %% then use the latest versions of the CLI or SDKs to make API requests to
 %% the Amazon Web Services services that are specified in the IAM policy
-%% associated with the role. For more information, see IAM Roles for Tasks in
-%% the Amazon Elastic Container Service Developer Guide.
+%% that's associated with the role. For more information, see IAM Roles for
+%% Tasks in the Amazon Elastic Container Service Developer Guide.
 %%
 %% You can specify a Docker networking mode for the containers in your task
 %% definition with the `networkMode' parameter. The available network modes
@@ -782,12 +788,12 @@ register_task_definition(Client, Input, Options)
 %% Alternatively, you can use `StartTask' to use your own scheduler or place
 %% tasks manually on specific container instances.
 %%
-%% The Amazon ECS API follows an eventual consistency model, due to the
-%% distributed nature of the system supporting the API. This means that the
-%% result of an API command you run that affects your Amazon ECS resources
-%% might not be immediately visible to all subsequent commands you run. Keep
-%% this in mind when you carry out an API command that immediately follows a
-%% previous API command.
+%% The Amazon ECS API follows an eventual consistency model. This is because
+%% the distributed nature of the system supporting the API. This means that
+%% the result of an API command you run that affects your Amazon ECS
+%% resources might not be immediately visible to all subsequent commands you
+%% run. Keep this in mind when you carry out an API command that immediately
+%% follows a previous API command.
 %%
 %% To manage eventual consistency, you can do the following:
 %%
@@ -882,8 +888,8 @@ submit_task_state_change(Client, Input, Options)
 %% @doc Associates the specified tags to a resource with the specified
 %% `resourceArn'.
 %%
-%% If existing tags on a resource are not specified in the request
-%% parameters, they are not changed. When a resource is deleted, the tags
+%% If existing tags on a resource aren't specified in the request parameters,
+%% they aren't changed. When a resource is deleted, the tags that are
 %% associated with that resource are deleted as well.
 tag_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
@@ -927,16 +933,16 @@ update_cluster_settings(Client, Input, Options)
 %% @doc Updates the Amazon ECS container agent on a specified container
 %% instance.
 %%
-%% Updating the Amazon ECS container agent does not interrupt running tasks
-%% or services on the container instance. The process for updating the agent
+%% Updating the Amazon ECS container agent doesn't interrupt running tasks or
+%% services on the container instance. The process for updating the agent
 %% differs depending on whether your container instance was launched with the
 %% Amazon ECS-optimized AMI or another operating system.
 %%
 %% The `UpdateContainerAgent' API isn't supported for container instances
 %% using the Amazon ECS-optimized Amazon Linux 2 (arm64) AMI. To update the
-%% container agent, you can update the `ecs-init' package which will update
-%% the agent. For more information, see Updating the Amazon ECS container
-%% agent in the Amazon Elastic Container Service Developer Guide.
+%% container agent, you can update the `ecs-init' package. This updates the
+%% agent. For more information, see Updating the Amazon ECS container agent
+%% in the Amazon Elastic Container Service Developer Guide.
 %%
 %% The `UpdateContainerAgent' API requires an Amazon ECS-optimized AMI or
 %% Amazon Linux AMI with the `ecs-init' service installed and running. For
@@ -957,7 +963,7 @@ update_container_agent(Client, Input, Options)
 %% instance from a cluster, for example to perform system updates, update the
 %% Docker daemon, or scale down the cluster size.
 %%
-%% A container instance cannot be changed to `DRAINING' until it has reached
+%% A container instance can't be changed to `DRAINING' until it has reached
 %% an `ACTIVE' status. If the instance is in any other status, an error will
 %% be received.
 %%
@@ -979,13 +985,13 @@ update_container_agent(Client, Input, Options)
 %% stop two existing tasks before starting two new tasks. If the minimum is
 %% 100%, the service scheduler can't remove existing tasks until the
 %% replacement tasks are considered healthy. Tasks for services that do not
-%% use a load balancer are considered healthy if they are in the `RUNNING'
+%% use a load balancer are considered healthy if they're in the `RUNNING'
 %% state. Tasks for services that use a load balancer are considered healthy
-%% if they are in the `RUNNING' state and the container instance they are
+%% if they're in the `RUNNING' state and the container instance they're
 %% hosted on is reported as healthy by the load balancer.
 %%
 %% </li> <li> The `maximumPercent' parameter represents an upper limit on the
-%% number of running tasks during task replacement, which enables you to
+%% number of running tasks during task replacement. You can use this to
 %% define the replacement batch size. For example, if `desiredCount' is four
 %% tasks, a maximum of 200% starts four new tasks before stopping the four
 %% tasks to be drained, provided that the cluster resources required to do
@@ -993,7 +999,7 @@ update_container_agent(Client, Input, Options)
 %% start until the draining tasks have stopped.
 %%
 %% </li> </ul> Any `PENDING' or `RUNNING' tasks that do not belong to a
-%% service are not affected. You must wait for them to finish or stop them
+%% service aren't affected. You must wait for them to finish or stop them
 %% manually.
 %%
 %% A container instance has completed draining when it has no more `RUNNING'
@@ -1027,16 +1033,14 @@ update_container_instances_state(Client, Input, Options)
 %% only the desired count, deployment configuration, task placement
 %% constraints and strategies, and health check grace period can be updated
 %% using this API. If the network configuration, platform version, or task
-%% definition need to be updated, a new CodeDeploy deployment should be
-%% created. For more information, see CreateDeployment in the CodeDeploy API
-%% Reference.
+%% definition need to be updated, a new CodeDeploy deployment is created. For
+%% more information, see CreateDeployment in the CodeDeploy API Reference.
 %%
 %% For services using an external deployment controller, you can update only
 %% the desired count, task placement constraints and strategies, and health
 %% check grace period using this API. If the launch type, load balancer,
 %% network configuration, platform version, or task definition need to be
-%% updated, you should create a new task set. For more information, see
-%% `CreateTaskSet'.
+%% updated, create a new task set. For more information, see `CreateTaskSet'.
 %%
 %% You can add to or subtract from the number of instantiations of a task
 %% definition in a service by specifying the cluster that the service is
@@ -1049,11 +1053,11 @@ update_container_instances_state(Client, Input, Options)
 %% deployment strategy.
 %%
 %% If your updated Docker image uses the same tag as what is in the existing
-%% task definition for your service (for example, `my_image:latest'), you do
-%% not need to create a new revision of your task definition. You can update
-%% the service using the `forceNewDeployment' option. The new tasks launched
-%% by the deployment pull the current image/tag combination from your
-%% repository when they start.
+%% task definition for your service (for example, `my_image:latest'), you
+%% don't need to create a new revision of your task definition. You can
+%% update the service using the `forceNewDeployment' option. The new tasks
+%% launched by the deployment pull the current image/tag combination from
+%% your repository when they start.
 %%
 %% You can also update the deployment configuration of a service. When a
 %% deployment is triggered by updating the task definition of a service, the
@@ -1065,34 +1069,34 @@ update_container_instances_state(Client, Input, Options)
 %% ignore `desiredCount' temporarily during a deployment. For example, if
 %% `desiredCount' is four tasks, a minimum of 50% allows the scheduler to
 %% stop two existing tasks before starting two new tasks. Tasks for services
-%% that do not use a load balancer are considered healthy if they are in the
+%% that don't use a load balancer are considered healthy if they're in the
 %% `RUNNING' state. Tasks for services that use a load balancer are
-%% considered healthy if they are in the `RUNNING' state and the container
-%% instance they are hosted on is reported as healthy by the load balancer.
+%% considered healthy if they're in the `RUNNING' state and the container
+%% instance they're hosted on is reported as healthy by the load balancer.
 %%
 %% </li> <li> The `maximumPercent' parameter represents an upper limit on the
-%% number of running tasks during a deployment, which enables you to define
-%% the deployment batch size. For example, if `desiredCount' is four tasks, a
+%% number of running tasks during a deployment. You can use it to define the
+%% deployment batch size. For example, if `desiredCount' is four tasks, a
 %% maximum of 200% starts four new tasks before stopping the four older tasks
 %% (provided that the cluster resources required to do this are available).
 %%
 %% </li> </ul> When `UpdateService' stops a task during a deployment, the
 %% equivalent of `docker stop' is issued to the containers running in the
-%% task. This results in a `SIGTERM' and a 30-second timeout, after which
+%% task. This results in a `SIGTERM' and a 30-second timeout. After this,
 %% `SIGKILL' is sent and the containers are forcibly stopped. If the
 %% container handles the `SIGTERM' gracefully and exits within 30 seconds
 %% from receiving it, no `SIGKILL' is sent.
 %%
 %% When the service scheduler launches new tasks, it determines task
-%% placement in your cluster with the following logic:
+%% placement in your cluster with the following logic.
 %%
 %% <ul> <li> Determine which of the container instances in your cluster can
-%% support your service's task definition (for example, they have the
-%% required CPU, memory, ports, and container instance attributes).
+%% support your service's task definition. For example, they have the
+%% required CPU, memory, ports, and container instance attributes.
 %%
 %% </li> <li> By default, the service scheduler attempts to balance tasks
-%% across Availability Zones in this manner (although you can choose a
-%% different placement strategy):
+%% across Availability Zones in this manner even though you can choose a
+%% different placement strategy.
 %%
 %% <ul> <li> Sort the valid container instances by the fewest number of
 %% running tasks for this service in the same Availability Zone as the

--- a/src/aws_efs.erl
+++ b/src/aws_efs.erl
@@ -1204,6 +1204,10 @@ update_file_system(Client, FileSystemId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"elasticfilesystem">>},
     Host = build_host(<<"elasticfilesystem">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_eks.erl
+++ b/src/aws_eks.erl
@@ -1182,6 +1182,10 @@ update_nodegroup_version(Client, ClusterName, NodegroupName, Input0, Options0) -
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"eks">>},
     Host = build_host(<<"eks">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_elastic_beanstalk.erl
+++ b/src/aws_elastic_beanstalk.erl
@@ -736,7 +736,11 @@ validate_configuration_settings(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticbeanstalk">>},
     Host = build_host(<<"elasticbeanstalk">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_elastic_inference.erl
+++ b/src/aws_elastic_inference.erl
@@ -180,6 +180,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"elastic-inference">>},
     Host = build_host(<<"api.elastic-inference">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_elastic_load_balancing.erl
+++ b/src/aws_elastic_load_balancing.erl
@@ -582,7 +582,11 @@ set_load_balancer_policies_of_listener(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticloadbalancing">>},
     Host = build_host(<<"elasticloadbalancing">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_elastic_load_balancing_v2.erl
+++ b/src/aws_elastic_load_balancing_v2.erl
@@ -605,7 +605,11 @@ set_subnets(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticloadbalancing">>},
     Host = build_host(<<"elasticloadbalancing">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_elastic_transcoder.erl
+++ b/src/aws_elastic_transcoder.erl
@@ -552,6 +552,10 @@ update_pipeline_status(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"elastictranscoder">>},
     Host = build_host(<<"elastictranscoder">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_elasticache.erl
+++ b/src/aws_elasticache.erl
@@ -1131,7 +1131,11 @@ test_failover(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticache">>},
     Host = build_host(<<"elasticache">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -1164,6 +1164,10 @@ upgrade_elasticsearch_domain(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"es">>},
     Host = build_host(<<"es">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -782,7 +782,11 @@ update_studio_session_mapping(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticmapreduce">>},
     Host = build_host(<<"elasticmapreduce">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_emr_containers.erl
+++ b/src/aws_emr_containers.erl
@@ -521,6 +521,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"emr-containers">>},
     Host = build_host(<<"emr-containers">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_entitlement_marketplace.erl
+++ b/src/aws_entitlement_marketplace.erl
@@ -50,7 +50,11 @@ get_entitlements(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
     Host = build_host(<<"entitlement.marketplace">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_eventbridge.erl
+++ b/src/aws_eventbridge.erl
@@ -973,7 +973,11 @@ update_connection(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"events">>},
     Host = build_host(<<"events">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_finspace.erl
+++ b/src/aws_finspace.erl
@@ -234,6 +234,10 @@ update_environment(Client, EnvironmentId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"finspace">>},
     Host = build_host(<<"finspace">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_finspace_data.erl
+++ b/src/aws_finspace_data.erl
@@ -107,6 +107,10 @@ get_working_location(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"finspace-api">>},
     Host = build_host(<<"finspace-api">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_firehose.erl
+++ b/src/aws_firehose.erl
@@ -479,7 +479,11 @@ update_destination(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"firehose">>},
     Host = build_host(<<"firehose">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_fis.erl
+++ b/src/aws_fis.erl
@@ -417,6 +417,10 @@ update_experiment_template(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"fis">>},
     Host = build_host(<<"fis">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_fms.erl
+++ b/src/aws_fms.erl
@@ -377,7 +377,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"fms">>},
     Host = build_host(<<"fms">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_forecast.erl
+++ b/src/aws_forecast.erl
@@ -812,7 +812,11 @@ update_dataset_group(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"forecast">>},
     Host = build_host(<<"forecast">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_forecastquery.erl
+++ b/src/aws_forecastquery.erl
@@ -45,7 +45,11 @@ query_forecast(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"forecast">>},
     Host = build_host(<<"forecastquery">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_frauddetector.erl
+++ b/src/aws_frauddetector.erl
@@ -914,7 +914,11 @@ update_variable(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"frauddetector">>},
     Host = build_host(<<"frauddetector">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_fsx.erl
+++ b/src/aws_fsx.erl
@@ -666,7 +666,11 @@ update_volume(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"fsx">>},
     Host = build_host(<<"fsx">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_gamelift.erl
+++ b/src/aws_gamelift.erl
@@ -3583,7 +3583,11 @@ validate_matchmaking_rule_set(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"gamelift">>},
     Host = build_host(<<"gamelift">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -1750,6 +1750,10 @@ upload_multipart_part(Client, AccountId, UploadId, VaultName, Input0, Options0) 
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"glacier">>},
     Host = build_host(<<"glacier">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_global_accelerator.erl
+++ b/src/aws_global_accelerator.erl
@@ -845,7 +845,11 @@ withdraw_byoip_cidr(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"globalaccelerator">>},
     Host = build_host(<<"globalaccelerator">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_glue.erl
+++ b/src/aws_glue.erl
@@ -2115,7 +2115,11 @@ update_workflow(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"glue">>},
     Host = build_host(<<"glue">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_grafana.erl
+++ b/src/aws_grafana.erl
@@ -363,6 +363,10 @@ update_workspace_authentication(Client, WorkspaceId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"grafana">>},
     Host = build_host(<<"grafana">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -2630,6 +2630,10 @@ update_thing_runtime_configuration(Client, ThingName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"greengrass">>},
     Host = build_host(<<"greengrass">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_greengrassv2.erl
+++ b/src/aws_greengrassv2.erl
@@ -221,6 +221,9 @@ cancel_deployment(Client, DeploymentId, Input0, Options0) ->
 %% </li> </ul> To create a component from a Lambda function, specify
 %% `lambdaFunction' when you call this operation.
 %%
+%% IoT Greengrass currently supports Lambda functions on only Linux core
+%% devices.
+%%
 %% </li> </ul>
 create_component_version(Client, Input) ->
     create_component_version(Client, Input, []).
@@ -804,6 +807,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"greengrass">>},
     Host = build_host(<<"greengrass">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -716,6 +716,10 @@ update_mission_profile(Client, MissionProfileId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"groundstation">>},
     Host = build_host(<<"groundstation">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -1646,6 +1646,10 @@ update_threat_intel_set(Client, DetectorId, ThreatIntelSetId, Input0, Options0) 
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"guardduty">>},
     Host = build_host(<<"guardduty">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_health.erl
+++ b/src/aws_health.erl
@@ -402,7 +402,11 @@ enable_health_service_access_for_organization(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"health">>},
     Host = build_host(<<"health">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_health.erl
+++ b/src/aws_health.erl
@@ -1,43 +1,43 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/aws-beam/aws-codegen for more details.
 
-%% @doc AWS Health
+%% @doc Health
 %%
-%% The AWS Health API provides programmatic access to the AWS Health
-%% information that appears in the AWS Personal Health Dashboard.
+%% The Health API provides programmatic access to the Health information that
+%% appears in the Personal Health Dashboard.
 %%
-%% You can use the API operations to get information about AWS Health events
-%% that affect your AWS services and resources.
+%% You can use the API operations to get information about events that might
+%% affect your Amazon Web Services services and resources.
 %%
-%% You must have a Business or Enterprise Support plan from AWS Support to
-%% use the AWS Health API. If you call the AWS Health API from an AWS account
-%% that doesn't have a Business or Enterprise Support plan, you receive a
-%% `SubscriptionRequiredException' error.
+%% You must have a Business or Enterprise Support plan from Amazon Web
+%% Services Support to use the Health API. If you call the Health API from an
+%% Amazon Web Services account that doesn't have a Business or Enterprise
+%% Support plan, you receive a `SubscriptionRequiredException' error.
 %%
-%% You can use the AWS Health endpoint health.us-east-1.amazonaws.com (HTTPS)
-%% to call the AWS Health API operations. AWS Health supports a multi-Region
-%% application architecture and has two regional endpoints in an
-%% active-passive configuration. You can use the high availability endpoint
-%% example to determine which AWS Region is active, so that you can get the
-%% latest information from the API. For more information, see Accessing the
-%% AWS Health API in the AWS Health User Guide.
+%% You can use the Health endpoint health.us-east-1.amazonaws.com (HTTPS) to
+%% call the Health API operations. Health supports a multi-Region application
+%% architecture and has two regional endpoints in an active-passive
+%% configuration. You can use the high availability endpoint example to
+%% determine which Amazon Web Services Region is active, so that you can get
+%% the latest information from the API. For more information, see Accessing
+%% the Health API in the Health User Guide.
 %%
-%% For authentication of requests, AWS Health uses the Signature Version 4
+%% For authentication of requests, Health uses the Signature Version 4
 %% Signing Process.
 %%
-%% If your AWS account is part of AWS Organizations, you can use the AWS
-%% Health organizational view feature. This feature provides a centralized
-%% view of AWS Health events across all accounts in your organization. You
-%% can aggregate AWS Health events in real time to identify accounts in your
-%% organization that are affected by an operational event or get notified of
-%% security vulnerabilities. Use the organizational view API operations to
-%% enable this feature and return event information. For more information,
-%% see Aggregating AWS Health events in the AWS Health User Guide.
+%% If your Amazon Web Services account is part of Organizations, you can use
+%% the Health organizational view feature. This feature provides a
+%% centralized view of Health events across all accounts in your
+%% organization. You can aggregate Health events in real time to identify
+%% accounts in your organization that are affected by an operational event or
+%% get notified of security vulnerabilities. Use the organizational view API
+%% operations to enable this feature and return event information. For more
+%% information, see Aggregating Health events in the Health User Guide.
 %%
-%% When you use the AWS Health API operations to return AWS Health events,
-%% see the following recommendations:
+%% When you use the Health API operations to return Health events, see the
+%% following recommendations:
 %%
-%% Use the eventScopeCode parameter to specify whether to return AWS Health
+%% Use the eventScopeCode parameter to specify whether to return Health
 %% events that are public or account-specific.
 %%
 %% Use pagination to view all events from the response. For example, if you
@@ -79,14 +79,14 @@
 %% API
 %%====================================================================
 
-%% @doc Returns a list of accounts in the organization from AWS Organizations
+%% @doc Returns a list of accounts in the organization from Organizations
 %% that are affected by the provided event.
 %%
-%% For more information about the different types of AWS Health events, see
+%% For more information about the different types of Health events, see
 %% Event.
 %%
-%% Before you can call this operation, you must first enable AWS Health to
-%% work with AWS Organizations. To do this, call the
+%% Before you can call this operation, you must first enable Health to work
+%% with Organizations. To do this, call the
 %% EnableHealthServiceAccessForOrganization operation from your
 %% organization's management account.
 %%
@@ -103,20 +103,20 @@ describe_affected_accounts_for_organization(Client, Input, Options)
 %% events, based on the specified filter criteria.
 %%
 %% Entities can refer to individual customer resources, groups of customer
-%% resources, or any other construct, depending on the AWS service. Events
-%% that have impact beyond that of the affected entities, or where the extent
-%% of impact is unknown, include at least one entity indicating this.
+%% resources, or any other construct, depending on the Amazon Web Services
+%% service. Events that have impact beyond that of the affected entities, or
+%% where the extent of impact is unknown, include at least one entity
+%% indicating this.
 %%
-%% At least one event ARN is required. Results are sorted by the
-%% `lastUpdatedTime' of the entity, starting with the most recent.
+%% At least one event ARN is required.
 %%
 %% This API operation uses pagination. Specify the `nextToken' parameter in
 %% the next request to return more results.
 %%
 %% This operation supports resource-level permissions. You can use this
-%% operation to allow or deny access to specific AWS Health events. For more
-%% information, see Resource- and action-based conditions in the AWS Health
-%% User Guide.
+%% operation to allow or deny access to specific Health events. For more
+%% information, see Resource- and action-based conditions in the Health User
+%% Guide.
 describe_affected_entities(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_affected_entities(Client, Input, []).
@@ -125,18 +125,17 @@ describe_affected_entities(Client, Input, Options)
     request(Client, <<"DescribeAffectedEntities">>, Input, Options).
 
 %% @doc Returns a list of entities that have been affected by one or more
-%% events for one or more accounts in your organization in AWS Organizations,
+%% events for one or more accounts in your organization in Organizations,
 %% based on the filter criteria.
 %%
 %% Entities can refer to individual customer resources, groups of customer
-%% resources, or any other construct, depending on the AWS service.
+%% resources, or any other construct, depending on the Amazon Web Services
+%% service.
 %%
 %% At least one event Amazon Resource Name (ARN) and account ID are required.
-%% Results are sorted by the `lastUpdatedTime' of the entity, starting with
-%% the most recent.
 %%
-%% Before you can call this operation, you must first enable AWS Health to
-%% work with AWS Organizations. To do this, call the
+%% Before you can call this operation, you must first enable Health to work
+%% with Organizations. To do this, call the
 %% EnableHealthServiceAccessForOrganization operation from your
 %% organization's management account.
 %%
@@ -144,9 +143,9 @@ describe_affected_entities(Client, Input, Options)
 %% the next request to return more results.
 %%
 %% This operation doesn't support resource-level permissions. You can't use
-%% this operation to allow or deny access to specific AWS Health events. For
-%% more information, see Resource- and action-based conditions in the AWS
-%% Health User Guide.
+%% this operation to allow or deny access to specific Health events. For more
+%% information, see Resource- and action-based conditions in the Health User
+%% Guide.
 describe_affected_entities_for_organization(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_affected_entities_for_organization(Client, Input, []).
@@ -156,9 +155,6 @@ describe_affected_entities_for_organization(Client, Input, Options)
 
 %% @doc Returns the number of entities that are affected by each of the
 %% specified events.
-%%
-%% If no events are specified, the counts of all affected entities are
-%% returned.
 describe_entity_aggregates(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_entity_aggregates(Client, Input, []).
@@ -183,19 +179,19 @@ describe_event_aggregates(Client, Input, Options)
 
 %% @doc Returns detailed information about one or more specified events.
 %%
-%% Information includes standard event data (AWS Region, service, and so on,
-%% as returned by DescribeEvents), a detailed event description, and possible
-%% additional metadata that depends upon the nature of the event. Affected
-%% entities are not included. To retrieve the entities, use the
-%% DescribeAffectedEntities operation.
+%% Information includes standard event data (Amazon Web Services Region,
+%% service, and so on, as returned by DescribeEvents), a detailed event
+%% description, and possible additional metadata that depends upon the nature
+%% of the event. Affected entities are not included. To retrieve the
+%% entities, use the DescribeAffectedEntities operation.
 %%
 %% If a specified event can't be retrieved, an error message is returned for
 %% that event.
 %%
 %% This operation supports resource-level permissions. You can use this
-%% operation to allow or deny access to specific AWS Health events. For more
-%% information, see Resource- and action-based conditions in the AWS Health
-%% User Guide.
+%% operation to allow or deny access to specific Health events. For more
+%% information, see Resource- and action-based conditions in the Health User
+%% Guide.
 describe_event_details(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_event_details(Client, Input, []).
@@ -204,40 +200,40 @@ describe_event_details(Client, Input, Options)
     request(Client, <<"DescribeEventDetails">>, Input, Options).
 
 %% @doc Returns detailed information about one or more specified events for
-%% one or more AWS accounts in your organization.
+%% one or more Amazon Web Services accounts in your organization.
 %%
-%% This information includes standard event data (such as the AWS Region and
-%% service), an event description, and (depending on the event) possible
-%% metadata. This operation doesn't return affected entities, such as the
-%% resources related to the event. To return affected entities, use the
-%% DescribeAffectedEntitiesForOrganization operation.
+%% This information includes standard event data (such as the Amazon Web
+%% Services Region and service), an event description, and (depending on the
+%% event) possible metadata. This operation doesn't return affected entities,
+%% such as the resources related to the event. To return affected entities,
+%% use the DescribeAffectedEntitiesForOrganization operation.
 %%
-%% Before you can call this operation, you must first enable AWS Health to
-%% work with AWS Organizations. To do this, call the
+%% Before you can call this operation, you must first enable Health to work
+%% with Organizations. To do this, call the
 %% EnableHealthServiceAccessForOrganization operation from your
 %% organization's management account.
 %%
 %% When you call the `DescribeEventDetailsForOrganization' operation, specify
 %% the `organizationEventDetailFilters' object in the request. Depending on
-%% the AWS Health event type, note the following differences:
+%% the Health event type, note the following differences:
 %%
 %% <ul> <li> To return event details for a public event, you must specify a
 %% null value for the `awsAccountId' parameter. If you specify an account ID
-%% for a public event, AWS Health returns an error message because public
-%% events aren't specific to an account.
+%% for a public event, Health returns an error message because public events
+%% aren't specific to an account.
 %%
 %% </li> <li> To return event details for an event that is specific to an
 %% account in your organization, you must specify the `awsAccountId'
-%% parameter in the request. If you don't specify an account ID, AWS Health
+%% parameter in the request. If you don't specify an account ID, Health
 %% returns an error message because the event is specific to an account in
 %% your organization.
 %%
 %% </li> </ul> For more information, see Event.
 %%
 %% This operation doesn't support resource-level permissions. You can't use
-%% this operation to allow or deny access to specific AWS Health events. For
-%% more information, see Resource- and action-based conditions in the AWS
-%% Health User Guide.
+%% this operation to allow or deny access to specific Health events. For more
+%% information, see Resource- and action-based conditions in the Health User
+%% Guide.
 describe_event_details_for_organization(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_event_details_for_organization(Client, Input, []).
@@ -247,9 +243,9 @@ describe_event_details_for_organization(Client, Input, Options)
 
 %% @doc Returns the event types that meet the specified filter criteria.
 %%
-%% You can use this API operation to find information about the AWS Health
-%% event, such as the category, AWS service, and event code. The metadata for
-%% each event appears in the EventType object.
+%% You can use this API operation to find information about the Health event,
+%% such as the category, Amazon Web Services service, and event code. The
+%% metadata for each event appears in the EventType object.
 %%
 %% If you don't specify a filter criteria, the API operation returns all
 %% event types, in no particular order.
@@ -275,13 +271,12 @@ describe_event_types(Client, Input, Options)
 %% sorted by `lastModifiedTime', starting with the most recent event.
 %%
 %% When you call the `DescribeEvents' operation and specify an entity for the
-%% `entityValues' parameter, AWS Health might return public events that
-%% aren't specific to that resource. For example, if you call
-%% `DescribeEvents' and specify an ID for an Amazon Elastic Compute Cloud
-%% (Amazon EC2) instance, AWS Health might return events that aren't specific
-%% to that resource or service. To get events that are specific to a service,
-%% use the `services' parameter in the `filter' object. For more information,
-%% see Event.
+%% `entityValues' parameter, Health might return public events that aren't
+%% specific to that resource. For example, if you call `DescribeEvents' and
+%% specify an ID for an Amazon Elastic Compute Cloud (Amazon EC2) instance,
+%% Health might return events that aren't specific to that resource or
+%% service. To get events that are specific to a service, use the `services'
+%% parameter in the `filter' object. For more information, see Event.
 %%
 %% This API operation uses pagination. Specify the `nextToken' parameter in
 %% the next request to return more results.
@@ -292,7 +287,7 @@ describe_events(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeEvents">>, Input, Options).
 
-%% @doc Returns information about events across your organization in AWS
+%% @doc Returns information about events across your organization in
 %% Organizations.
 %%
 %% You can use the`filters' parameter to specify the events that you want to
@@ -312,11 +307,11 @@ describe_events(Client, Input, Options)
 %% organization. Results are sorted by `lastModifiedTime', starting with the
 %% most recent event.
 %%
-%% For more information about the different types of AWS Health events, see
+%% For more information about the different types of Health events, see
 %% Event.
 %%
-%% Before you can call this operation, you must first enable AWS Health to
-%% work with AWS Organizations. To do this, call the
+%% Before you can call this operation, you must first enable Health to work
+%% with Organizations. To do this, call the
 %% EnableHealthServiceAccessForOrganization operation from your
 %% organization's management account.
 %%
@@ -330,7 +325,7 @@ describe_events_for_organization(Client, Input, Options)
     request(Client, <<"DescribeEventsForOrganization">>, Input, Options).
 
 %% @doc This operation provides status information on enabling or disabling
-%% AWS Health to work with your organization.
+%% Health to work with your organization.
 %%
 %% To call this operation, you must sign in as an IAM user, assume an IAM
 %% role, or sign in as the root user (not recommended) in the organization's
@@ -342,26 +337,24 @@ describe_health_service_status_for_organization(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeHealthServiceStatusForOrganization">>, Input, Options).
 
-%% @doc Disables AWS Health from working with AWS Organizations.
+%% @doc Disables Health from working with Organizations.
 %%
-%% To call this operation, you must sign in as an AWS Identity and Access
+%% To call this operation, you must sign in as an Identity and Access
 %% Management (IAM) user, assume an IAM role, or sign in as the root user
 %% (not recommended) in the organization's management account. For more
-%% information, see Aggregating AWS Health events in the AWS Health User
-%% Guide.
+%% information, see Aggregating Health events in the Health User Guide.
 %%
 %% This operation doesn't remove the service-linked role from the management
-%% account in your organization. You must use the IAM console, API, or AWS
-%% Command Line Interface (AWS CLI) to remove the service-linked role. For
-%% more information, see Deleting a Service-Linked Role in the IAM User
-%% Guide.
+%% account in your organization. You must use the IAM console, API, or
+%% Command Line Interface (CLI) to remove the service-linked role. For more
+%% information, see Deleting a Service-Linked Role in the IAM User Guide.
 %%
 %% You can also disable the organizational feature by using the Organizations
-%% DisableAWSServiceAccess API operation. After you call this operation, AWS
-%% Health stops aggregating events for all other AWS accounts in your
-%% organization. If you call the AWS Health API operations for organizational
-%% view, AWS Health returns an error. AWS Health continues to aggregate
-%% health events for your AWS account.
+%% DisableAWSServiceAccess API operation. After you call this operation,
+%% Health stops aggregating events for all other Amazon Web Services accounts
+%% in your organization. If you call the Health API operations for
+%% organizational view, Health returns an error. Health continues to
+%% aggregate health events for your Amazon Web Services account.
 disable_health_service_access_for_organization(Client, Input)
   when is_map(Client), is_map(Input) ->
     disable_health_service_access_for_organization(Client, Input, []).
@@ -369,29 +362,29 @@ disable_health_service_access_for_organization(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableHealthServiceAccessForOrganization">>, Input, Options).
 
-%% @doc Enables AWS Health to work with AWS Organizations.
+%% @doc Enables Health to work with Organizations.
 %%
 %% You can use the organizational view feature to aggregate events from all
-%% AWS accounts in your organization in a centralized location.
+%% Amazon Web Services accounts in your organization in a centralized
+%% location.
 %%
 %% This operation also creates a service-linked role for the management
 %% account in the organization.
 %%
 %% To call this operation, you must meet the following requirements:
 %%
-%% You must have a Business or Enterprise Support plan from AWS Support to
-%% use the AWS Health API. If you call the AWS Health API from an AWS account
-%% that doesn't have a Business or Enterprise Support plan, you receive a
-%% `SubscriptionRequiredException' error.
+%% You must have a Business or Enterprise Support plan from Amazon Web
+%% Services Support to use the Health API. If you call the Health API from an
+%% Amazon Web Services account that doesn't have a Business or Enterprise
+%% Support plan, you receive a `SubscriptionRequiredException' error.
 %%
 %% You must have permission to call this operation from the organization's
-%% management account. For example IAM policies, see AWS Health
-%% identity-based policy examples.
+%% management account. For example IAM policies, see Health identity-based
+%% policy examples.
 %%
-%% If you don't have the required support plan, you can instead use the AWS
+%% If you don't have the required support plan, you can instead use the
 %% Health console to enable the organizational view feature. For more
-%% information, see Aggregating AWS Health events in the AWS Health User
-%% Guide.
+%% information, see Aggregating Health events in the Health User Guide.
 enable_health_service_access_for_organization(Client, Input)
   when is_map(Client), is_map(Input) ->
     enable_health_service_access_for_organization(Client, Input, []).

--- a/src/aws_healthlake.erl
+++ b/src/aws_healthlake.erl
@@ -160,7 +160,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"healthlake">>},
     Host = build_host(<<"healthlake">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_honeycode.erl
+++ b/src/aws_honeycode.erl
@@ -395,6 +395,10 @@ start_table_data_import_job(Client, DestinationTableId, WorkbookId, Input0, Opti
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"honeycode">>},
     Host = build_host(<<"honeycode">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -3504,7 +3504,11 @@ upload_ssh_public_key(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"iam">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"iam">>, Client1),

--- a/src/aws_identitystore.erl
+++ b/src/aws_identitystore.erl
@@ -76,7 +76,11 @@ list_users(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"identitystore">>},
     Host = build_host(<<"identitystore">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -1416,6 +1416,10 @@ update_infrastructure_configuration(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"imagebuilder">>},
     Host = build_host(<<"imagebuilder">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_importexport.erl
+++ b/src/aws_importexport.erl
@@ -114,7 +114,11 @@ update_job(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"importexport">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"importexport">>, Client1),

--- a/src/aws_inspector.erl
+++ b/src/aws_inspector.erl
@@ -463,7 +463,11 @@ update_assessment_target(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"inspector">>},
     Host = build_host(<<"inspector">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -7249,6 +7249,10 @@ validate_security_profile_behaviors(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"execute-api">>},
     Host = build_host(<<"iot">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_1click_devices.erl
+++ b/src/aws_iot_1click_devices.erl
@@ -404,6 +404,10 @@ update_device_state(Client, DeviceId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iot1click">>},
     Host = build_host(<<"devices.iot1click">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_1click_projects.erl
+++ b/src/aws_iot_1click_projects.erl
@@ -464,6 +464,10 @@ update_project(Client, ProjectName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iot1click">>},
     Host = build_host(<<"projects.iot1click">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -283,6 +283,10 @@ update_thing_shadow(Client, ThingName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotdata">>},
     Host = build_host(<<"data.iot">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_events.erl
+++ b/src/aws_iot_events.erl
@@ -782,6 +782,10 @@ update_input(Client, InputName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotevents">>},
     Host = build_host(<<"iotevents">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -349,6 +349,10 @@ list_detectors(Client, DetectorModelName, QueryMap, HeadersMap, Options0)
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ioteventsdata">>},
     Host = build_host(<<"data.iotevents">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -150,6 +150,10 @@ update_job_execution(Client, JobId, ThingName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iot-jobs-data">>},
     Host = build_host(<<"data.jobs.iot">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iot_wireless.erl
+++ b/src/aws_iot_wireless.erl
@@ -2259,6 +2259,10 @@ update_wireless_gateway(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotwireless">>},
     Host = build_host(<<"api.iotwireless">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iotanalytics.erl
+++ b/src/aws_iotanalytics.erl
@@ -1001,6 +1001,10 @@ update_pipeline(Client, PipelineName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotanalytics">>},
     Host = build_host(<<"iotanalytics">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iotdeviceadvisor.erl
+++ b/src/aws_iotdeviceadvisor.erl
@@ -387,6 +387,10 @@ update_suite_definition(Client, SuiteDefinitionId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotdeviceadvisor">>},
     Host = build_host(<<"api.iotdeviceadvisor">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iotfleethub.erl
+++ b/src/aws_iotfleethub.erl
@@ -267,6 +267,10 @@ update_application(Client, ApplicationId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotfleethub">>},
     Host = build_host(<<"api.fleethub.iot">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iotsecuretunneling.erl
+++ b/src/aws_iotsecuretunneling.erl
@@ -105,7 +105,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"IoTSecuredTunneling">>},
     Host = build_host(<<"api.tunneling.iot">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -1898,6 +1898,10 @@ update_project(Client, ProjectId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotsitewise">>},
     Host = build_host(<<"iotsitewise">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_iotthingsgraph.erl
+++ b/src/aws_iotthingsgraph.erl
@@ -544,7 +544,11 @@ upload_entity_definitions(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"iotthingsgraph">>},
     Host = build_host(<<"iotthingsgraph">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -907,6 +907,10 @@ update_channel(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ivs">>},
     Host = build_host(<<"ivs">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -874,6 +874,10 @@ update_security(Client, ClusterArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kafka">>},
     Host = build_host(<<"kafka">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kafkaconnect.erl
+++ b/src/aws_kafkaconnect.erl
@@ -329,6 +329,10 @@ update_connector(Client, ConnectorArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kafkaconnect">>},
     Host = build_host(<<"kafkaconnect">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kendra.erl
+++ b/src/aws_kendra.erl
@@ -626,7 +626,11 @@ update_thesaurus(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kendra">>},
     Host = build_host(<<"kendra">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_kinesis.erl
+++ b/src/aws_kinesis.erl
@@ -910,7 +910,11 @@ update_shard_count(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesis">>},
     Host = build_host(<<"kinesis">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_kinesis_analytics.erl
+++ b/src/aws_kinesis_analytics.erl
@@ -521,7 +521,11 @@ update_application(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesisanalytics">>},
     Host = build_host(<<"kinesisanalytics">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_kinesis_analytics_v2.erl
+++ b/src/aws_kinesis_analytics_v2.erl
@@ -529,7 +529,11 @@ update_application_maintenance_configuration(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesisanalytics">>},
     Host = build_host(<<"kinesisanalytics">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -638,6 +638,10 @@ update_stream(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
     Host = build_host(<<"kinesisvideo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -539,6 +539,10 @@ list_fragments(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
     Host = build_host(<<"kinesisvideo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -106,6 +106,10 @@ get_media(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
     Host = build_host(<<"kinesisvideo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -101,6 +101,10 @@ send_alexa_offer_to_master(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
     Host = build_host(<<"kinesisvideo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_kms.erl
+++ b/src/aws_kms.erl
@@ -2693,7 +2693,11 @@ verify(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kms">>},
     Host = build_host(<<"kms">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_lakeformation.erl
+++ b/src/aws_lakeformation.erl
@@ -336,7 +336,11 @@ update_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"lakeformation">>},
     Host = build_host(<<"lakeformation">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -2015,6 +2015,10 @@ update_function_event_invoke_config(Client, FunctionName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lambda">>},
     Host = build_host(<<"lambda">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lex_model_building.erl
+++ b/src/aws_lex_model_building.erl
@@ -1549,6 +1549,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
     Host = build_host(<<"models.lex">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lex_models_v2.erl
+++ b/src/aws_lex_models_v2.erl
@@ -1672,6 +1672,10 @@ update_slot_type(Client, BotId, BotVersion, LocaleId, SlotTypeId, Input0, Option
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
     Host = build_host(<<"models-v2-lex">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -347,6 +347,10 @@ put_session(Client, BotAlias, BotName, UserId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
     Host = build_host(<<"runtime.lex">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lex_runtime_v2.erl
+++ b/src/aws_lex_runtime_v2.erl
@@ -369,6 +369,10 @@ start_conversation(Client, BotAliasId, BotId, LocaleId, SessionId, Input0, Optio
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
     Host = build_host(<<"runtime-v2-lex">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_license_manager.erl
+++ b/src/aws_license_manager.erl
@@ -548,7 +548,11 @@ update_service_settings(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"license-manager">>},
     Host = build_host(<<"license-manager">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_lightsail.erl
+++ b/src/aws_lightsail.erl
@@ -2373,7 +2373,11 @@ update_relational_database_parameters(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"lightsail">>},
     Host = build_host(<<"lightsail">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_location.erl
+++ b/src/aws_location.erl
@@ -1495,6 +1495,10 @@ update_tracker(Client, TrackerName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"geo">>},
     Host = build_host(<<"geo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lookoutequipment.erl
+++ b/src/aws_lookoutequipment.erl
@@ -301,7 +301,11 @@ update_inference_scheduler(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"lookoutequipment">>},
     Host = build_host(<<"lookoutequipment">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_lookoutmetrics.erl
+++ b/src/aws_lookoutmetrics.erl
@@ -685,6 +685,10 @@ update_metric_set(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lookoutmetrics">>},
     Host = build_host(<<"lookoutmetrics">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_lookoutvision.erl
+++ b/src/aws_lookoutvision.erl
@@ -718,6 +718,10 @@ update_dataset_entries(Client, DatasetType, ProjectName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lookoutvision">>},
     Host = build_host(<<"lookoutvision">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_machine_learning.erl
+++ b/src/aws_machine_learning.erl
@@ -506,7 +506,11 @@ update_ml_model(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"machinelearning">>},
     Host = build_host(<<"machinelearning">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_macie.erl
+++ b/src/aws_macie.erl
@@ -125,7 +125,11 @@ update_s3_resources(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"macie">>},
     Host = build_host(<<"macie">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -1550,6 +1550,10 @@ update_organization_configuration(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"macie2">>},
     Host = build_host(<<"macie2">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -760,6 +760,10 @@ vote_on_proposal(Client, NetworkId, ProposalId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"managedblockchain">>},
     Host = build_host(<<"managedblockchain">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -222,6 +222,10 @@ start_change_set(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
     Host = build_host(<<"catalog.marketplace">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_marketplace_commerce_analytics.erl
+++ b/src/aws_marketplace_commerce_analytics.erl
@@ -65,7 +65,11 @@ start_support_data_export(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"marketplacecommerceanalytics">>},
     Host = build_host(<<"marketplacecommerceanalytics">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_marketplace_metering.erl
+++ b/src/aws_marketplace_metering.erl
@@ -173,7 +173,11 @@ resolve_customer(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
     Host = build_host(<<"metering.marketplace">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -868,6 +868,10 @@ update_flow_source(Client, FlowArn, SourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediaconnect">>},
     Host = build_host(<<"mediaconnect">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -810,6 +810,10 @@ update_queue(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediaconvert">>},
     Host = build_host(<<"mediaconvert">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -1583,6 +1583,10 @@ update_reservation(Client, ReservationId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"medialive">>},
     Host = build_host(<<"medialive">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -529,6 +529,10 @@ update_origin_endpoint(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediapackage">>},
     Host = build_host(<<"mediapackage">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -484,6 +484,10 @@ update_packaging_group(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediapackage-vod">>},
     Host = build_host(<<"mediapackage-vod">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mediastore.erl
+++ b/src/aws_mediastore.erl
@@ -328,7 +328,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mediastore">>},
     Host = build_host(<<"mediastore">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -219,6 +219,10 @@ put_object(Client, Path, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediastore">>},
     Host = build_host(<<"data.mediastore">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -1032,6 +1032,10 @@ update_vod_source(Client, SourceLocationName, VodSourceName, Input0, Options0) -
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediatailor">>},
     Host = build_host(<<"api.mediatailor">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_memorydb.erl
+++ b/src/aws_memorydb.erl
@@ -471,7 +471,11 @@ update_user(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"memorydb">>},
     Host = build_host(<<"memory-db">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_mgn.erl
+++ b/src/aws_mgn.erl
@@ -719,6 +719,10 @@ update_replication_configuration_template(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mgn">>},
     Host = build_host(<<"mgn">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_migration_hub.erl
+++ b/src/aws_migration_hub.erl
@@ -334,7 +334,11 @@ put_resource_attributes(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mgh">>},
     Host = build_host(<<"mgh">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_migrationhub_config.erl
+++ b/src/aws_migrationhub_config.erl
@@ -78,7 +78,11 @@ get_home_region(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mgh">>},
     Host = build_host(<<"migrationhub-config">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_mobile.erl
+++ b/src/aws_mobile.erl
@@ -283,6 +283,10 @@ update_project(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"AWSMobileHubService">>},
     Host = build_host(<<"mobile">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mobileanalytics.erl
+++ b/src/aws_mobileanalytics.erl
@@ -57,6 +57,10 @@ put_events(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mobileanalytics">>},
     Host = build_host(<<"mobileanalytics">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -671,6 +671,10 @@ update_user(Client, BrokerId, Username, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mq">>},
     Host = build_host(<<"mq">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_mturk.erl
+++ b/src/aws_mturk.erl
@@ -731,7 +731,11 @@ update_qualification_type(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mturk-requester">>,
                       region => <<"">>},
     Host = build_host(<<"mturk-requester">>, Client1),

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -327,6 +327,10 @@ update_environment(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"airflow">>},
     Host = build_host(<<"airflow">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_neptune.erl
+++ b/src/aws_neptune.erl
@@ -1009,7 +1009,11 @@ stop_db_cluster(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
     Host = build_host(<<"rds">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_network_firewall.erl
+++ b/src/aws_network_firewall.erl
@@ -548,7 +548,11 @@ update_subnet_change_protection(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"network-firewall">>},
     Host = build_host(<<"network-firewall">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -1305,6 +1305,10 @@ update_site(Client, GlobalNetworkId, SiteId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"networkmanager">>,
                       region => <<"us-west-2">>},
     Host = build_host(<<"networkmanager">>, Client1),

--- a/src/aws_nimble.erl
+++ b/src/aws_nimble.erl
@@ -1418,6 +1418,10 @@ update_studio_component(Client, StudioComponentId, StudioId, Input0, Options0) -
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"nimble">>},
     Host = build_host(<<"nimble">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_opensearch.erl
+++ b/src/aws_opensearch.erl
@@ -1130,6 +1130,10 @@ upgrade_domain(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"es">>},
     Host = build_host(<<"es">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_opsworks.erl
+++ b/src/aws_opsworks.erl
@@ -1359,7 +1359,11 @@ update_volume(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"opsworks">>},
     Host = build_host(<<"opsworks">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_opsworkscm.erl
+++ b/src/aws_opsworkscm.erl
@@ -478,7 +478,11 @@ update_server_engine_attributes(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"opsworks-cm">>},
     Host = build_host(<<"opsworks-cm">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_organizations.erl
+++ b/src/aws_organizations.erl
@@ -1485,7 +1485,11 @@ update_policy(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"organizations">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"organizations">>, Client1),

--- a/src/aws_outposts.erl
+++ b/src/aws_outposts.erl
@@ -338,6 +338,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"outposts">>},
     Host = build_host(<<"outposts">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_panorama.erl
+++ b/src/aws_panorama.erl
@@ -947,6 +947,10 @@ update_device_metadata(Client, DeviceId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"panorama">>},
     Host = build_host(<<"panorama">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_personalize.erl
+++ b/src/aws_personalize.erl
@@ -964,7 +964,11 @@ update_campaign(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"personalize">>},
     Host = build_host(<<"personalize">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -109,6 +109,10 @@ put_users(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"personalize">>},
     Host = build_host(<<"personalize-events">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -90,6 +90,10 @@ get_recommendations(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"personalize">>},
     Host = build_host(<<"personalize-runtime">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_pi.erl
+++ b/src/aws_pi.erl
@@ -97,7 +97,11 @@ get_resource_metrics(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"pi">>},
     Host = build_host(<<"pi">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -3247,6 +3247,10 @@ update_voice_template(Client, TemplateName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mobiletargeting">>},
     Host = build_host(<<"pinpoint">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -1377,6 +1377,10 @@ update_configuration_set_event_destination(Client, ConfigurationSetName, EventDe
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ses">>},
     Host = build_host(<<"email">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -241,6 +241,10 @@ update_configuration_set_event_destination(Client, ConfigurationSetName, EventDe
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sms-voice">>},
     Host = build_host(<<"sms-voice.pinpoint">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -357,6 +357,10 @@ synthesize_speech(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"polly">>},
     Host = build_host(<<"polly">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_pricing.erl
+++ b/src/aws_pricing.erl
@@ -93,7 +93,11 @@ get_products(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"pricing">>},
     Host = build_host(<<"api.pricing">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_proton.erl
+++ b/src/aws_proton.erl
@@ -967,7 +967,11 @@ update_service_template_version(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"proton">>},
     Host = build_host(<<"proton">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_qldb.erl
+++ b/src/aws_qldb.erl
@@ -667,6 +667,10 @@ update_ledger_permissions_mode(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"qldb">>},
     Host = build_host(<<"qldb">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_qldb_session.erl
+++ b/src/aws_qldb_session.erl
@@ -59,7 +59,11 @@ send_command(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"qldb">>},
     Host = build_host(<<"session.qldb">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -3498,6 +3498,10 @@ update_user(Client, AwsAccountId, Namespace, UserName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"quicksight">>},
     Host = build_host(<<"quicksight">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -676,6 +676,10 @@ update_resource_share(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ram">>},
     Host = build_host(<<"ram">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_rds.erl
+++ b/src/aws_rds.erl
@@ -2533,7 +2533,11 @@ stop_db_instance_automated_backups_replication(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
     Host = build_host(<<"rds">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -213,6 +213,10 @@ rollback_transaction(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rds-data">>},
     Host = build_host(<<"rds-data">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_redshift.erl
+++ b/src/aws_redshift.erl
@@ -1818,7 +1818,11 @@ update_partner_status(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"redshift">>},
     Host = build_host(<<"redshift">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_redshift_data.erl
+++ b/src/aws_redshift_data.erl
@@ -225,7 +225,11 @@ list_tables(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"redshift-data">>},
     Host = build_host(<<"redshift-data">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_rekognition.erl
+++ b/src/aws_rekognition.erl
@@ -1797,7 +1797,11 @@ update_dataset_entries(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rekognition">>},
     Host = build_host(<<"rekognition">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_resiliencehub.erl
+++ b/src/aws_resiliencehub.erl
@@ -1,0 +1,1179 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/aws-beam/aws-codegen for more details.
+
+%% @doc AWS Resilience Hub helps you proactively prepare and protect your
+%% Amazon Web Services applications from disruptions.
+%%
+%% Resilience Hub offers continuous resiliency assessment and validation that
+%% integrates into your software development lifecycle. This enables you to
+%% uncover resiliency weaknesses, ensure recovery time objective (RTO) and
+%% recovery point objective (RPO) targets for your applications are met, and
+%% resolve issues before they are released into production.
+-module(aws_resiliencehub).
+
+-export([add_draft_app_version_resource_mappings/2,
+         add_draft_app_version_resource_mappings/3,
+         create_app/2,
+         create_app/3,
+         create_recommendation_template/2,
+         create_recommendation_template/3,
+         create_resiliency_policy/2,
+         create_resiliency_policy/3,
+         delete_app/2,
+         delete_app/3,
+         delete_app_assessment/2,
+         delete_app_assessment/3,
+         delete_recommendation_template/2,
+         delete_recommendation_template/3,
+         delete_resiliency_policy/2,
+         delete_resiliency_policy/3,
+         describe_app/2,
+         describe_app/3,
+         describe_app_assessment/2,
+         describe_app_assessment/3,
+         describe_app_version_resources_resolution_status/2,
+         describe_app_version_resources_resolution_status/3,
+         describe_app_version_template/2,
+         describe_app_version_template/3,
+         describe_draft_app_version_resources_import_status/2,
+         describe_draft_app_version_resources_import_status/3,
+         describe_resiliency_policy/2,
+         describe_resiliency_policy/3,
+         import_resources_to_draft_app_version/2,
+         import_resources_to_draft_app_version/3,
+         list_alarm_recommendations/2,
+         list_alarm_recommendations/3,
+         list_app_assessments/1,
+         list_app_assessments/3,
+         list_app_assessments/4,
+         list_app_component_compliances/2,
+         list_app_component_compliances/3,
+         list_app_component_recommendations/2,
+         list_app_component_recommendations/3,
+         list_app_version_resource_mappings/2,
+         list_app_version_resource_mappings/3,
+         list_app_version_resources/2,
+         list_app_version_resources/3,
+         list_app_versions/2,
+         list_app_versions/3,
+         list_apps/1,
+         list_apps/3,
+         list_apps/4,
+         list_recommendation_templates/2,
+         list_recommendation_templates/4,
+         list_recommendation_templates/5,
+         list_resiliency_policies/1,
+         list_resiliency_policies/3,
+         list_resiliency_policies/4,
+         list_sop_recommendations/2,
+         list_sop_recommendations/3,
+         list_suggested_resiliency_policies/1,
+         list_suggested_resiliency_policies/3,
+         list_suggested_resiliency_policies/4,
+         list_tags_for_resource/2,
+         list_tags_for_resource/4,
+         list_tags_for_resource/5,
+         list_test_recommendations/2,
+         list_test_recommendations/3,
+         list_unsupported_app_version_resources/2,
+         list_unsupported_app_version_resources/3,
+         publish_app_version/2,
+         publish_app_version/3,
+         put_draft_app_version_template/2,
+         put_draft_app_version_template/3,
+         remove_draft_app_version_resource_mappings/2,
+         remove_draft_app_version_resource_mappings/3,
+         resolve_app_version_resources/2,
+         resolve_app_version_resources/3,
+         start_app_assessment/2,
+         start_app_assessment/3,
+         tag_resource/3,
+         tag_resource/4,
+         untag_resource/3,
+         untag_resource/4,
+         update_app/2,
+         update_app/3,
+         update_resiliency_policy/2,
+         update_resiliency_policy/3]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Adds the resource mapping for the draft application version.
+add_draft_app_version_resource_mappings(Client, Input) ->
+    add_draft_app_version_resource_mappings(Client, Input, []).
+add_draft_app_version_resource_mappings(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/add-draft-app-version-resource-mappings"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a Resilience Hub application.
+%%
+%% A Resilience Hub application is a collection of Amazon Web Services
+%% resources structured to prevent and recover Amazon Web Services
+%% application disruptions. To describe a Resilience Hub application, you
+%% provide an application name, resources from one or more–up to
+%% five–CloudFormation stacks, and an appropriate resiliency policy.
+%%
+%% <p>After you create a Resilience Hub application, you publish it so that
+%% you can run a resiliency assessment on it. You can then use
+%% recommendations from the assessment to improve resiliency by running
+%% another assessment, comparing results, and then iterating the process
+%% until you achieve your goals for recovery time objective (RTO) and
+%% recovery point objective (RPO).</p>
+create_app(Client, Input) ->
+    create_app(Client, Input, []).
+create_app(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/create-app"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new recommendation template.
+create_recommendation_template(Client, Input) ->
+    create_recommendation_template(Client, Input, []).
+create_recommendation_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/create-recommendation-template"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a resiliency policy for an application.
+create_resiliency_policy(Client, Input) ->
+    create_resiliency_policy(Client, Input, []).
+create_resiliency_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/create-resiliency-policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an AWS Resilience Hub application.
+%%
+%% This is a destructive action that can't be undone.
+delete_app(Client, Input) ->
+    delete_app(Client, Input, []).
+delete_app(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/delete-app"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes an AWS Resilience Hub application assessment.
+%%
+%% This is a destructive action that can't be undone.
+delete_app_assessment(Client, Input) ->
+    delete_app_assessment(Client, Input, []).
+delete_app_assessment(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/delete-app-assessment"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a recommendation template.
+%%
+%% This is a destructive action that can't be undone.
+delete_recommendation_template(Client, Input) ->
+    delete_recommendation_template(Client, Input, []).
+delete_recommendation_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/delete-recommendation-template"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Deletes a resiliency policy.
+%%
+%% This is a destructive action that can't be undone.
+delete_resiliency_policy(Client, Input) ->
+    delete_resiliency_policy(Client, Input, []).
+delete_resiliency_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/delete-resiliency-policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes an AWS Resilience Hub application.
+describe_app(Client, Input) ->
+    describe_app(Client, Input, []).
+describe_app(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-app"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes an assessment for an AWS Resilience Hub application.
+describe_app_assessment(Client, Input) ->
+    describe_app_assessment(Client, Input, []).
+describe_app_assessment(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-app-assessment"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Returns the resolution status for the specified resolution identifier
+%% for an application version.
+%%
+%% If `resolutionId' is not specified, the current resolution status is
+%% returned.
+describe_app_version_resources_resolution_status(Client, Input) ->
+    describe_app_version_resources_resolution_status(Client, Input, []).
+describe_app_version_resources_resolution_status(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-app-version-resources-resolution-status"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes details about an AWS Resilience Hub
+describe_app_version_template(Client, Input) ->
+    describe_app_version_template(Client, Input, []).
+describe_app_version_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-app-version-template"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes the status of importing resources to an application
+%% version.
+describe_draft_app_version_resources_import_status(Client, Input) ->
+    describe_draft_app_version_resources_import_status(Client, Input, []).
+describe_draft_app_version_resources_import_status(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-draft-app-version-resources-import-status"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Describes a specified resiliency policy for an AWS Resilience Hub
+%% application.
+%%
+%% The returned policy object includes creation time, data location
+%% constraints, the Amazon Resource Name (ARN) for the policy, tags, tier,
+%% and more.
+describe_resiliency_policy(Client, Input) ->
+    describe_resiliency_policy(Client, Input, []).
+describe_resiliency_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/describe-resiliency-policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Imports resources from sources such as a CloudFormation stack,
+%% resource-groups, or application registry app to a draft application
+%% version.
+import_resources_to_draft_app_version(Client, Input) ->
+    import_resources_to_draft_app_version(Client, Input, []).
+import_resources_to_draft_app_version(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/import-resources-to-draft-app-version"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the alarm recommendations for a AWS Resilience Hub application.
+list_alarm_recommendations(Client, Input) ->
+    list_alarm_recommendations(Client, Input, []).
+list_alarm_recommendations(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-alarm-recommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the assessments for an AWS Resilience Hub application.
+%%
+%% You can use request parameters to refine the results for the response
+%% object.
+list_app_assessments(Client)
+  when is_map(Client) ->
+    list_app_assessments(Client, #{}, #{}).
+
+list_app_assessments(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_app_assessments(Client, QueryMap, HeadersMap, []).
+
+list_app_assessments(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/list-app-assessments"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"appArn">>, maps:get(<<"appArn">>, QueryMap, undefined)},
+        {<<"assessmentName">>, maps:get(<<"assessmentName">>, QueryMap, undefined)},
+        {<<"assessmentStatus">>, maps:get(<<"assessmentStatus">>, QueryMap, undefined)},
+        {<<"complianceStatus">>, maps:get(<<"complianceStatus">>, QueryMap, undefined)},
+        {<<"invoker">>, maps:get(<<"invoker">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"reverseOrder">>, maps:get(<<"reverseOrder">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the compliances for an AWS Resilience Hub component.
+list_app_component_compliances(Client, Input) ->
+    list_app_component_compliances(Client, Input, []).
+list_app_component_compliances(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-app-component-compliances"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the recommendations for an AWS Resilience Hub component.
+list_app_component_recommendations(Client, Input) ->
+    list_app_component_recommendations(Client, Input, []).
+list_app_component_recommendations(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-app-component-recommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists how the resources in an application version are mapped/sourced
+%% from.
+%%
+%% Mappings can be physical resource identifiers, CloudFormation stacks,
+%% resource-groups, or an application registry app.
+list_app_version_resource_mappings(Client, Input) ->
+    list_app_version_resource_mappings(Client, Input, []).
+list_app_version_resource_mappings(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-app-version-resource-mappings"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists all the resources in an application version.
+list_app_version_resources(Client, Input) ->
+    list_app_version_resources(Client, Input, []).
+list_app_version_resources(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-app-version-resources"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the different versions for the Resilience Hub applications.
+list_app_versions(Client, Input) ->
+    list_app_versions(Client, Input, []).
+list_app_versions(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-app-versions"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists your Resilience Hub applications.
+list_apps(Client)
+  when is_map(Client) ->
+    list_apps(Client, #{}, #{}).
+
+list_apps(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_apps(Client, QueryMap, HeadersMap, []).
+
+list_apps(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/list-apps"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"appArn">>, maps:get(<<"appArn">>, QueryMap, undefined)},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"name">>, maps:get(<<"name">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the recommendation templates for the Resilience Hub
+%% applications.
+list_recommendation_templates(Client, AssessmentArn)
+  when is_map(Client) ->
+    list_recommendation_templates(Client, AssessmentArn, #{}, #{}).
+
+list_recommendation_templates(Client, AssessmentArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_recommendation_templates(Client, AssessmentArn, QueryMap, HeadersMap, []).
+
+list_recommendation_templates(Client, AssessmentArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/list-recommendation-templates"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"assessmentArn">>, AssessmentArn},
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"name">>, maps:get(<<"name">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"recommendationTemplateArn">>, maps:get(<<"recommendationTemplateArn">>, QueryMap, undefined)},
+        {<<"reverseOrder">>, maps:get(<<"reverseOrder">>, QueryMap, undefined)},
+        {<<"status">>, maps:get(<<"status">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the resiliency policies for the Resilience Hub applications.
+list_resiliency_policies(Client)
+  when is_map(Client) ->
+    list_resiliency_policies(Client, #{}, #{}).
+
+list_resiliency_policies(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_resiliency_policies(Client, QueryMap, HeadersMap, []).
+
+list_resiliency_policies(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/list-resiliency-policies"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)},
+        {<<"policyName">>, maps:get(<<"policyName">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the standard operating procedure (SOP) recommendations for the
+%% Resilience Hub applications.
+list_sop_recommendations(Client, Input) ->
+    list_sop_recommendations(Client, Input, []).
+list_sop_recommendations(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-sop-recommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the suggested resiliency policies for the Resilience Hub
+%% applications.
+list_suggested_resiliency_policies(Client)
+  when is_map(Client) ->
+    list_suggested_resiliency_policies(Client, #{}, #{}).
+
+list_suggested_resiliency_policies(Client, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_suggested_resiliency_policies(Client, QueryMap, HeadersMap, []).
+
+list_suggested_resiliency_policies(Client, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/list-suggested-resiliency-policies"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query0_ =
+      [
+        {<<"maxResults">>, maps:get(<<"maxResults">>, QueryMap, undefined)},
+        {<<"nextToken">>, maps:get(<<"nextToken">>, QueryMap, undefined)}
+      ],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the tags for your resources in your Resilience Hub
+%% applications.
+list_tags_for_resource(Client, ResourceArn)
+  when is_map(Client) ->
+    list_tags_for_resource(Client, ResourceArn, #{}, #{}).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, []).
+
+list_tags_for_resource(Client, ResourceArn, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+    Headers = [],
+
+    Query_ = [],
+
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).
+
+%% @doc Lists the test recommendations for the Resilience Hub application.
+list_test_recommendations(Client, Input) ->
+    list_test_recommendations(Client, Input, []).
+list_test_recommendations(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-test-recommendations"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Lists the resources that are not currently supported in AWS
+%% Resilience Hub.
+%%
+%% An unsupported resource is a resource that exists in the object that was
+%% used to create an app, but is not supported by Resilience Hub.
+list_unsupported_app_version_resources(Client, Input) ->
+    list_unsupported_app_version_resources(Client, Input, []).
+list_unsupported_app_version_resources(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/list-unsupported-app-version-resources"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Publishes a new version of a specific Resilience Hub application.
+publish_app_version(Client, Input) ->
+    publish_app_version(Client, Input, []).
+publish_app_version(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/publish-app-version"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Adds or updates the app template for a draft version of a Resilience
+%% Hub app.
+put_draft_app_version_template(Client, Input) ->
+    put_draft_app_version_template(Client, Input, []).
+put_draft_app_version_template(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/put-draft-app-version-template"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes resource mappings from a draft application version.
+remove_draft_app_version_resource_mappings(Client, Input) ->
+    remove_draft_app_version_resource_mappings(Client, Input, []).
+remove_draft_app_version_resource_mappings(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/remove-draft-app-version-resource-mappings"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Resolves the resources for an application version.
+resolve_app_version_resources(Client, Input) ->
+    resolve_app_version_resources(Client, Input, []).
+resolve_app_version_resources(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/resolve-app-version-resources"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Creates a new application assessment for an application.
+start_app_assessment(Client, Input) ->
+    start_app_assessment(Client, Input, []).
+start_app_assessment(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/start-app-assessment"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Applies one or more tags to a resource.
+tag_resource(Client, ResourceArn, Input) ->
+    tag_resource(Client, ResourceArn, Input, []).
+tag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = post,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Removes one or more tags from a resource.
+untag_resource(Client, ResourceArn, Input) ->
+    untag_resource(Client, ResourceArn, Input, []).
+untag_resource(Client, ResourceArn, Input0, Options0) ->
+    Method = delete,
+    Path = ["/tags/", aws_util:encode_uri(ResourceArn), ""],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    QueryMapping = [
+                     {<<"tagKeys">>, <<"tagKeys">>}
+                   ],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates an application.
+update_app(Client, Input) ->
+    update_app(Client, Input, []).
+update_app(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/update-app"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%% @doc Updates a resiliency policy.
+update_resiliency_policy(Client, Input) ->
+    update_resiliency_policy(Client, Input, []).
+update_resiliency_policy(Client, Input0, Options0) ->
+    Method = post,
+    Path = ["/update-resiliency-policy"],
+    SuccessStatusCode = 200,
+    Options = [{send_body_as_binary, false},
+               {receive_body_as_binary, false}
+               | Options0],
+
+
+    Headers = [],
+    Input1 = Input0,
+
+    CustomHeaders = [],
+    Input2 = Input1,
+
+    Query_ = [],
+    Input = Input2,
+
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(), list(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, {integer(), list()}} |
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map(),
+    Error :: map().
+request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"resiliencehub">>},
+    Host = build_host(<<"resiliencehub">>, Client1),
+    URL0 = build_url(Host, Path, Client1),
+    URL = aws_request:add_query(URL0, Query),
+    AdditionalHeaders = [ {<<"Host">>, Host}
+                        , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+                        ],
+    Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
+
+    Payload =
+      case proplists:get_value(send_body_as_binary, Options) of
+        true ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        false ->
+          encode_payload(Input)
+      end,
+
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
+
+handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    {ok, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
+    {error, {StatusCode, ResponseHeaders}};
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = case DecodeBody of
+                       true -> jsx:decode(Body);
+                       false -> #{<<"Body">> => Body}
+                     end,
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body),
+    {error, Error, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _, _DecodeBody) ->
+  {error, Reason}.
+
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
+
+build_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -644,6 +644,10 @@ update_group_query(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"resource-groups">>},
     Host = build_host(<<"resource-groups">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_resource_groups_tagging_api.erl
+++ b/src/aws_resource_groups_tagging_api.erl
@@ -233,7 +233,11 @@ untag_resources(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"tagging">>},
     Host = build_host(<<"tagging">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_robomaker.erl
+++ b/src/aws_robomaker.erl
@@ -1499,6 +1499,10 @@ update_world_template(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"robomaker">>},
     Host = build_host(<<"robomaker">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -2717,6 +2717,10 @@ update_traffic_policy_instance(Client, Id, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"route53">>, Client1),

--- a/src/aws_route53_domains.erl
+++ b/src/aws_route53_domains.erl
@@ -531,7 +531,11 @@ view_billing(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53domains">>},
     Host = build_host(<<"route53domains">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_route53_recovery_cluster.erl
+++ b/src/aws_route53_recovery_cluster.erl
@@ -109,7 +109,11 @@ update_routing_control_states(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53-recovery-cluster">>},
     Host = build_host(<<"route53-recovery-cluster">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_route53_recovery_control_config.erl
+++ b/src/aws_route53_recovery_control_config.erl
@@ -626,6 +626,10 @@ update_safety_rule(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53-recovery-control-config">>},
     Host = build_host(<<"route53-recovery-control-config">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_route53_recovery_readiness.erl
+++ b/src/aws_route53_recovery_readiness.erl
@@ -904,6 +904,10 @@ update_resource_set(Client, ResourceSetName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53-recovery-readiness">>},
     Host = build_host(<<"route53-recovery-readiness">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_route53resolver.erl
+++ b/src/aws_route53resolver.erl
@@ -909,7 +909,11 @@ update_resolver_rule(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53resolver">>},
     Host = build_host(<<"route53resolver">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -7415,6 +7415,10 @@ write_get_object_response(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3">>},
     Host = build_host(<<"s3">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -2777,6 +2777,10 @@ update_job_status(Client, JobId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3">>},
     AccountId = proplists:get_value(<<"x-amz-account-id">>, Headers0),
     Host = build_host(AccountId, <<"s3-control">>, Client1),

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -157,6 +157,10 @@ list_endpoints(Client, QueryMap, HeadersMap, Options0)
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3-outposts">>},
     Host = build_host(<<"s3-outposts">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sagemaker.erl
+++ b/src/aws_sagemaker.erl
@@ -3526,7 +3526,11 @@ update_workteam(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sagemaker">>},
     Host = build_host(<<"api.sagemaker">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -201,6 +201,10 @@ stop_human_loop(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
     Host = build_host(<<"a2i-runtime.sagemaker">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sagemaker_edge.erl
+++ b/src/aws_sagemaker_edge.erl
@@ -76,6 +76,10 @@ send_heartbeat(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
     Host = build_host(<<"edge.sagemaker">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sagemaker_featurestore_runtime.erl
+++ b/src/aws_sagemaker_featurestore_runtime.erl
@@ -162,6 +162,10 @@ put_record(Client, FeatureGroupName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
     Host = build_host(<<"featurestore-runtime.sagemaker">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sagemaker_runtime.erl
+++ b/src/aws_sagemaker_runtime.erl
@@ -160,6 +160,10 @@ invoke_endpoint_async(Client, EndpointName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
     Host = build_host(<<"runtime.sagemaker">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -254,6 +254,10 @@ untag_resource(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"savingsplans">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"savingsplans">>, Client1),

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -872,6 +872,10 @@ update_schema(Client, RegistryName, SchemaName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"schemas">>},
     Host = build_host(<<"schemas">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sdb.erl
+++ b/src/aws_sdb.erl
@@ -315,7 +315,11 @@ select(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sdb">>},
     Host = build_host(<<"sdb">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_secrets_manager.erl
+++ b/src/aws_secrets_manager.erl
@@ -1033,7 +1033,11 @@ validate_resource_policy(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"secretsmanager">>},
     Host = build_host(<<"secretsmanager">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -1886,6 +1886,10 @@ update_standards_control(Client, StandardsControlArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"securityhub">>},
     Host = build_host(<<"securityhub">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -454,6 +454,10 @@ update_application(Client, ApplicationId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"serverlessrepo">>},
     Host = build_host(<<"serverlessrepo">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_service_catalog.erl
+++ b/src/aws_service_catalog.erl
@@ -1150,7 +1150,11 @@ update_tag_option(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicecatalog">>},
     Host = build_host(<<"servicecatalog">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -639,6 +639,10 @@ update_attribute_group(Client, AttributeGroup, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"servicecatalog">>},
     Host = build_host(<<"servicecatalog-appregistry">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_service_quotas.erl
+++ b/src/aws_service_quotas.erl
@@ -244,7 +244,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicequotas">>},
     Host = build_host(<<"servicequotas">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_servicediscovery.erl
+++ b/src/aws_servicediscovery.erl
@@ -425,7 +425,11 @@ update_service(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicediscovery">>},
     Host = build_host(<<"servicediscovery">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ses.erl
+++ b/src/aws_ses.erl
@@ -1441,7 +1441,11 @@ verify_email_identity(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ses">>},
     Host = build_host(<<"email">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -2529,6 +2529,10 @@ update_email_template(Client, TemplateName, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ses">>},
     Host = build_host(<<"email">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sfn.erl
+++ b/src/aws_sfn.erl
@@ -434,7 +434,11 @@ update_state_machine(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"states">>},
     Host = build_host(<<"states">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_shield.erl
+++ b/src/aws_shield.erl
@@ -501,7 +501,11 @@ update_subscription(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"shield">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"shield">>, Client1),

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -584,6 +584,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"signer">>},
     Host = build_host(<<"signer">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sms.erl
+++ b/src/aws_sms.erl
@@ -426,7 +426,11 @@ update_replication_job(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sms">>},
     Host = build_host(<<"sms">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_snow_device_management.erl
+++ b/src/aws_snow_device_management.erl
@@ -398,6 +398,10 @@ untag_resource(Client, ResourceArn, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"snow-device-management">>},
     Host = build_host(<<"snow-device-management">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_snowball.erl
+++ b/src/aws_snowball.erl
@@ -461,7 +461,11 @@ update_long_term_pricing(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"snowball">>},
     Host = build_host(<<"snowball">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sns.erl
+++ b/src/aws_sns.erl
@@ -708,7 +708,11 @@ verify_sms_sandbox_phone_number(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sns">>},
     Host = build_host(<<"sns">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sqs.erl
+++ b/src/aws_sqs.erl
@@ -667,7 +667,11 @@ untag_queue(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sqs">>},
     Host = build_host(<<"sqs">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ssm.erl
+++ b/src/aws_ssm.erl
@@ -2139,7 +2139,11 @@ update_service_setting(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ssm">>},
     Host = build_host(<<"ssm">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ssm_contacts.erl
+++ b/src/aws_ssm_contacts.erl
@@ -341,7 +341,11 @@ update_contact_channel(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ssm-contacts">>},
     Host = build_host(<<"ssm-contacts">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_ssm_incidents.erl
+++ b/src/aws_ssm_incidents.erl
@@ -815,6 +815,10 @@ update_timeline_event(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ssm-incidents">>},
     Host = build_host(<<"ssm-incidents">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -182,6 +182,10 @@ logout(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"awsssoportal">>},
     Host = build_host(<<"portal.sso">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_sso_admin.erl
+++ b/src/aws_sso_admin.erl
@@ -407,7 +407,11 @@ update_permission_set(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sso">>},
     Host = build_host(<<"sso">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -127,6 +127,10 @@ start_device_authorization(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"awsssooidc">>},
     Host = build_host(<<"oidc">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_storage_gateway.erl
+++ b/src/aws_storage_gateway.erl
@@ -1734,7 +1734,11 @@ update_vtl_device_type(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"storagegateway">>},
     Host = build_host(<<"storagegateway">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_sts.erl
+++ b/src/aws_sts.erl
@@ -730,7 +730,11 @@ get_session_token(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sts">>},
     Host = build_host(<<"sts">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -474,7 +474,11 @@ resolve_case(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"support">>},
     Host = build_host(<<"support">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_swf.erl
+++ b/src/aws_swf.erl
@@ -1512,7 +1512,11 @@ untag_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"swf">>},
     Host = build_host(<<"swf">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -455,6 +455,10 @@ update_canary(Client, Name, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"synthetics">>},
     Host = build_host(<<"synthetics">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_textract.erl
+++ b/src/aws_textract.erl
@@ -329,7 +329,11 @@ start_expense_analysis(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"textract">>},
     Host = build_host(<<"textract">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_timestream_query.erl
+++ b/src/aws_timestream_query.erl
@@ -77,7 +77,11 @@ query(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"timestream">>},
     Host = build_host(<<"query.timestream">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_timestream_write.erl
+++ b/src/aws_timestream_write.erl
@@ -276,7 +276,11 @@ write_records(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"timestream">>},
     Host = build_host(<<"ingest.timestream">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_transcribe.erl
+++ b/src/aws_transcribe.erl
@@ -487,7 +487,11 @@ update_vocabulary_filter(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"transcribe">>},
     Host = build_host(<<"transcribe">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -178,6 +178,10 @@ start_stream_transcription(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"transcribe">>},
     Host = build_host(<<"transcribestreaming">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_transfer.erl
+++ b/src/aws_transfer.erl
@@ -498,7 +498,11 @@ update_user(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"transfer">>},
     Host = build_host(<<"transfer">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_translate.erl
+++ b/src/aws_translate.erl
@@ -206,7 +206,11 @@ update_parallel_data(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"translate">>},
     Host = build_host(<<"translate">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_voice_id.erl
+++ b/src/aws_voice_id.erl
@@ -259,7 +259,11 @@ update_domain(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"voiceid">>},
     Host = build_host(<<"voiceid">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_waf.erl
+++ b/src/aws_waf.erl
@@ -2515,7 +2515,11 @@ update_xss_match_set(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"waf">>,
                       region => <<"us-east-1">>},
     Host = build_host(<<"waf">>, Client1),

--- a/src/aws_waf_regional.erl
+++ b/src/aws_waf_regional.erl
@@ -2592,7 +2592,11 @@ update_xss_match_set(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"waf-regional">>},
     Host = build_host(<<"waf-regional">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_wafv2.erl
+++ b/src/aws_wafv2.erl
@@ -806,7 +806,11 @@ update_web_acl(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"wafv2">>},
     Host = build_host(<<"wafv2">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_wellarchitected.erl
+++ b/src/aws_wellarchitected.erl
@@ -898,6 +898,10 @@ upgrade_lens_review(Client, LensAlias, WorkloadId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wellarchitected">>},
     Host = build_host(<<"wellarchitected">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_wisdom.erl
+++ b/src/aws_wisdom.erl
@@ -907,6 +907,10 @@ update_knowledge_base_template_uri(Client, KnowledgeBaseId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wisdom">>},
     Host = build_host(<<"wisdom">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -1403,6 +1403,10 @@ update_user(Client, UserId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"workdocs">>},
     Host = build_host(<<"workdocs">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_worklink.erl
+++ b/src/aws_worklink.erl
@@ -888,6 +888,10 @@ update_identity_provider_configuration(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"worklink">>},
     Host = build_host(<<"worklink">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_workmail.erl
+++ b/src/aws_workmail.erl
@@ -827,7 +827,11 @@ update_resource(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"workmail">>},
     Host = build_host(<<"workmail">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -88,6 +88,10 @@ put_raw_message_content(Client, MessageId, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"workmailmessageflow">>},
     Host = build_host(<<"workmailmessageflow">>, Client1),
     URL0 = build_url(Host, Path, Client1),

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -850,7 +850,11 @@ update_workspace_image_permission(Client, Input, Options)
     {error, term()} when
     Result :: map() | undefined,
     Error :: map().
-request(Client, Action, Input0, Options) ->
+request(Client, Action, Input, Options) ->
+    RequestFun = fun() -> do_request(Client, Action, Input, Options) end,
+    aws_request:request(RequestFun, Options).
+
+do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"workspaces">>},
     Host = build_host(<<"workspaces">>, Client1),
     URL = build_url(Host, Client1),

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -806,6 +806,10 @@ update_sampling_rule(Client, Input0, Options0) ->
     Result :: map(),
     Error :: map().
 request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
+  RequestFun = fun() -> do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) end,
+  aws_request:request(RequestFun, Options).
+
+do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"xray">>},
     Host = build_host(<<"xray">>, Client1),
     URL0 = build_url(Host, Path, Client1),


### PR DESCRIPTION
Interesting diff sits in `aws_request.erl` where we implemented retries and allow a caller to set some basic retry options. The rest is re-generated code which I've placed in a separate commit for easier reviewing. 

At the moment, we only added support for `exponential_with_jitter` so at the moment it's still somewhat basic but usable :+1: It is however easily extendable by extending `aws_request:init_retry_state/1` and implementing whatever relevant logic for that mechanism in `aws_request:should_retry/1`. 

This PR should bring `aws-erlang` closer to `erlcloud` and provide one of the (IMHO) key missing features which `erlcloud` provides yet `aws-erlang` doesn't which is retries. :slightly_smiling_face: 

--- 
Co-authored-by: @anha0825 

