### PR TITLE
Update hackney to latest version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info, {d, maps_support}]}.
 {edoc_opts, [{dir, "edoc"}]}.
 {deps, [{erlware_commons, "1.3.1"},
-        {hackney, "1.16.0"},
+        {hackney, "1.18.0"},
         {jsx, "3.0.0"}
        ]}.


### PR DESCRIPTION
This update includes 1.17.0 which fixes an issue with streaming
responses. This issue can cause s3 list object to crash.