### PR TITLE
Open PR with changes on releases of AWS Go SDK

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,118 @@
+name: aws-codegen
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    ## Scheduled nightly at 00:23
+    - cron: '23 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-18.04
+    name: Check if changed
+    strategy:
+      fail-fast: false
+
+    outputs:
+      current_tag: ${{ steps.current-tag.outputs.CURRENT_TAG }}
+      latest_tag: ${{ steps.latest-tag.outputs.LATEST_TAG }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get tag used for generated files
+        id: current-tag
+        run: |
+          # check if the file exist before
+          [[ -f .latest-tag-aws-sdk-go ]] && CURRENT_TAG=$(<.latest-tag-aws-sdk-go) || CURRENT_TAG=''
+          echo "::set-output name=CURRENT_TAG::${CURRENT_TAG}"
+
+      - name: Get latest AWS SDK Go tag
+        id: latest-tag
+        run: |
+          wget https://api.github.com/repos/aws/aws-sdk-go/releases/latest
+          tag_name=$(cat latest | jq -r '.tag_name')
+          echo "::set-output name=LATEST_TAG::${tag_name}"
+
+  generate:
+    runs-on: ubuntu-18.04
+    name: Update services
+    needs: check
+    if: ${{ needs.check.outputs.current_tag != needs.check.outputs.latest_tag }}
+
+    env:
+      LATEST_AWS_SDK_GO_TAG: ${{ needs.check.outputs.latest_tag }}
+      OTP_VERSION: "23.3.4"
+      ELIXIR_VERSION: "1.13.2"
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Checkout aws/aws-sdk-go (official Go SDK)
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go
+          path: tmp/aws-sdk-go
+          ref: ${{ env.LATEST_AWS_SDK_GO_TAG }}
+
+      - name: Checkout aws-codegen
+        uses: actions/checkout@v2
+        with:
+          repository: aws-beam/aws-codegen
+          path: tmp/aws-codegen
+
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          rebar3 compile
+
+      - name: Generate aws-erlang
+        env:
+          SPEC_PATH: ../aws-sdk-go/models/apis
+          TEMPLATE_PATH: priv
+          ERLANG_OUTPUT_PATH: ../../src
+        run: |
+          # Jump to the codegen
+          cd tmp/aws-codegen
+          mix deps.get
+
+          mkdir -p $ERLANG_OUTPUT_PATH
+          mix run generate.exs erlang $SPEC_PATH $TEMPLATE_PATH $ERLANG_OUTPUT_PATH
+
+      - name: Test generated code
+        run: |
+          rebar3 eunit
+
+      - name: Update latest tag file
+        run: |
+          echo "${LATEST_AWS_SDK_GO_TAG}" > .latest-tag-aws-sdk-go
+
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: master
+          branch: update-services-aws-sdk-go-${{ env.LATEST_AWS_SDK_GO_TAG }}
+          title: Update services based on ${{ env.LATEST_AWS_SDK_GO_TAG }} of AWS Go SDK 
+          commit-message: Update services based on ${{ env.LATEST_AWS_SDK_GO_TAG }} of AWS Go SDK 
+          author: GitHub <noreply@github.com>
+          delete-branch: true
+          body: |
+            This is an automated pull request.
+            It was triggered GitHub actions. The details can be found at
+            https://github.com/aws-beam/aws-erlang/actions/workflows/codegen.yml
+
+            For changes, please check https://github.com/aws/aws-sdk-go/releases/tag/${{ env.LATEST_AWS_SDK_GO_TAG }}
+
+          add-paths: |
+            src/*
+            .latest-tag-aws-sdk-go


### PR DESCRIPTION
This new workflow will run nighthly and will open a new pull request
when the official AWS Go SDK releases a new tag.

This is based in aws-beam/aws-codegen#80