### PR TITLE
Add another function clause to handle responses with only a StatusCode and ResponseHeaders

### DIFF
--- a/src/aws_request.erl
+++ b/src/aws_request.erl
@@ -267,6 +267,9 @@ init_retry_state({exponential_with_jitter, {MaxAttempts, BaseSleepTime, CapSleep
 classify_response({error, _, {StatusCode, _, _}})
   when is_integer(StatusCode) andalso StatusCode >= 500 ->
   retriable;
+classify_response({error, {StatusCode, _}})
+  when is_integer(StatusCode) andalso StatusCode >= 500 ->
+  retriable;
 classify_response({error, _, {StatusCode, _, _}})
   when is_integer(StatusCode) ->
   error;


### PR DESCRIPTION
AWS is extremely good at replying with a `500 Internal Server Error` every now and then. 

The retry logic that was recently introduced does not take into account a response from `handle_response` as can be seen here: https://github.com/aws-beam/aws-erlang/blob/7430a17a9a3ecca9bb7491e75b6c7fb4b1f23498/src/aws_s3.erl#L7543

Which only responds with `{error, {StatusCode, ResponseHeaders}}` which at the very least `aws_s3:head_object/4` responds with every now and then. The clause for this particular error-tuple was missing from `aws_request:classify_response/1` causing us to miss retries and simply exploding directly rather than retrying the request. 