### PR TITLE
encode_uri/1 should html encode with uppercase to handle special chars such as +

### DIFF
--- a/src/aws_util.erl
+++ b/src/aws_util.erl
@@ -72,7 +72,7 @@ uri_encode_path_byte(Byte)
 uri_encode_path_byte(Byte) ->
     H = Byte band 16#F0 bsr 4,
     L = Byte band 16#0F,
-    <<"%", (hex(H)), (hex(L))>>.
+    <<"%", (hex(H, upper)), (hex(L, upper))>>.
 
 %% @doc Encode the map's key/value pairs as a querystring.
 encode_query(List) when is_list(List) ->
@@ -191,11 +191,17 @@ content_to_map(X, Acc) when is_map(X), is_binary(Acc) ->
 
 %% @doc Convert an integer in the 0-16 range to a hexadecimal byte
 %% representation.
-hex(N) when N >= 0, N < 10 ->
-    N + $0;
-hex(N) when N < 16 ->
-    N - 10 + $a.
+hex(N) ->
+  hex(N, lower).
 
+hex(N, upper) ->
+  hex(N, $A);
+hex(N, lower) ->
+  hex(N, $a);
+hex(N, _Char) when N >= 0, N < 10 ->
+  N + $0;
+hex(N, Char) when N < 16 ->
+  N - 10 + Char.
 binary_join([], Acc, _) ->
     Acc;
 binary_join([H|T], Acc, Sep) ->
@@ -354,6 +360,11 @@ encode_uri_test() ->
 encode_uri_parenthesis_test() ->
   Segment = <<"hello world(!)">>,
   ?assertEqual(<<"hello%20world%28%21%29">>, encode_uri(Segment)).
+
+encode_uri_special_chars_test() ->
+  Segment = <<"file_!-_.(*)&=;:+ ,?{^}%]>[~<#`|.content">>,
+  ?assertEqual(<<"file_%21-_.%28%2A%29%26%3D%3B%3A%2B%20%2C%3F%7B%5E%7D%25%5D%3E%5B~%3C%23%60%7C.content">>,
+               encode_uri(Segment)).
 
 %% encode_multi_segment_uri correctly encode each segment of an URI
 encode_multi_segment_uri_test() ->


### PR DESCRIPTION
##### Description:
encode_uri/1 should html encode with uppercase to handle special chars such as +
- Preserve old behavior for aws_util:base16/1

This is essentially the same code as can be seen in `aws_signature`: [aws_signature_utils.erl#L44](https://github.com/aws-beam/aws_signature/blob/dfc6c60d4fac859037bc477a1794911211fcf055/src/aws_signature_utils.erl#L44)

Certain special characters such as `+` would still lead to SignatureDoesNotMatch errors even after #73 since the signature would uppercase encoded characters whereas the encoded uri would not. Leading to SignatureDoesNotMatch errors since the signature would be signed with an uppercase html encoded char whereas the url that would be called would have the lowercased version.

```erlang
1> s3_wrapper:write(Bucket, <<"file(+1)">>, <<>>).
ok
2> s3_wrapper:read(Bucket, <<"file(+1)">>).
{ok,<<>>}
3> s3_wrapper:list_objects(Bucket, <<"file">>).
[<<"file(+1)">>]
4> s3_wrapper:delete(Bucket, <<"file(+1)">>).
ok
5> s3_wrapper:write(Bucket, <<"file%#&(+1)">>, <<>>).
ok
6> s3_wrapper:read(Bucket, <<"file%#&(+1)">>).
{ok,<<>>}
7> s3_wrapper:delete(Bucket, <<"file%#&(+1)">>).
ok
```

Added a unit test with the most screwed up filename possible:
```erlang
1> s3_wrapper:write(Bucket, <<"file_!-_.(*)&=;:+ ,?{^}%]>[~<#`|.content">>, <<"content">>).
ok
2> s3_wrapper:read(Bucket, <<"file_!-_.(*)&=;:+ ,?{^}%]>[~<#`|.content">>).
{ok,<<"content">>}
3> s3_wrapper:list_objects(Bucket, <<"file">>).
[<<"file_!-_.(*)&=;:+ ,?{^}%]>[~<#`|.content">>]
4> s3_wrapper:delete(Bucket, <<"file_!-_.(*)&=;:+ ,?{^}%]>[~<#`|.content">>).
ok
```