### PR TITLE
Bump version in README.md from 0.3.0 -> 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ how to upload a file to _S3_ and how to fetch it back:
 Simply add the library to your `rebar.config`:
 
 ```erlang
-{deps, [{aws, "0.3.0", {pkg, aws_erlang}}]}.
+{deps, [{aws, "1.0.0", {pkg, aws_erlang}}]}.
 ```
 
 ## Obtaining Credentials


### PR DESCRIPTION
https://github.com/aws-beam/aws-erlang/commit/9df09869174fe80e4db85b0bf10c7dea6773632c should be tagged as 1.0.0 and subsequently pushed to hex prior to this merge.