### PR TITLE
Ensure that the URL and CanonicalRequest use the same url and sorting of query parameters

### DIFF
--- a/src/aws_request.erl
+++ b/src/aws_request.erl
@@ -80,7 +80,7 @@ build_custom_headers(ParamsCustomHeadersMapping, Params0)
 %% @doc Add querystring to url is there are any parameters in the list
 -spec add_query(binary(), [{binary(), any()}]) -> binary().
 add_query(Url0, Query0) ->
-  Url = hd(string:split(Url0, <<"?">>)),
+  [Url | _] = string:split(Url0, <<"?">>),
   HackneyUrl = hackney_url:parse_url(Url0),
   Query = hackney_url:parse_qs(HackneyUrl#hackney_url.qs) ++ Query0,
   QueryString = iolist_to_binary(aws_util:encode_query(Query)),
@@ -449,6 +449,11 @@ add_query_without_query_string_test() ->
 add_query_sorted_test() ->
   ?assertEqual(<<"https://example.com/index?one=1&two=2">>,
                add_query(<<"https://example.com/index">>, [{<<"two">>, <<"2">>}, {<<"one">>, <<"1">>}])).
+
+add_query_sorted_with_existing_query_test() ->
+  ?assertEqual(<<"https://example.com/index?one=1&two=2&x=y">>,
+               add_query(<<"https://example.com/index?x=y">>, [{<<"two">>, <<"2">>}, {<<"one">>, <<"1">>}])).
+
 
 %% canonical_headers/1 returns a newline-delimited list of trimmed and
 %% lowecase headers, sorted in alphabetical order, and with a trailing


### PR DESCRIPTION
The meat of this change is to make sure that URLs such as `https://localhost:443/bucket/key/?list-type=2` with query params: `prefix=foo&delimiter=/` are the same **both both in encoding and sorting** when creating in the CanonicalRequest and the request url that is sent off to hackney. Failing to do so, leads to the dreaded (read: un-debuggable) `SignatureDoesNotMatch` error. 

Rather than patching in two places, I'm now ensuring that anything that comes into `aws_request:split_url/1` is already fully encoded and ready to rock and roll so there's no need for the good old `aws_request:fix_qs/1` as that is now handled by `aws_request:add_query/2` instead. 

Tested change on `list_objects_v2` as well as `list_objects` whereas in particular `list_objects_v2` turned out to be the problematic one. Tried a few random s3 endpoints (which are easiest for me to test) which all worked fine :-) 

I haven't looked at the aws-elixir code yet but my best guess would be that `aws-signature` handles this more gracefully and hence doesn't fail. Pointing to even more reason to migrate to `aws-signature` as part of https://github.com/aws-beam/aws-erlang/issues/63