### PR TITLE
Retry requests when getting timeout from hackney.

### DIFF
--- a/src/aws_request.erl
+++ b/src/aws_request.erl
@@ -275,6 +275,8 @@ classify_response({error, closed}) ->
   retriable;
 classify_response({error, connect_timeout}) ->
   retriable;
+classify_response({error, timeout}) ->
+  retriable;
 classify_response({error, checkout_timeout}) ->
   retriable;
 classify_response({error, _}) ->


### PR DESCRIPTION
When looking at https://github.com/benoitc/hackney/blob/master/src/hackney_pool.erl#L104 it seems hackney can return `{error, timeout}` when calling hackney:request/5. 

hackney:request/5 -> hackney:send_request/2 -> hackney_connect:maybe_connect/1 -> hackney_connect:connect/4 -> hackney_connect:socket_from_pool/4 -> hackney_pool:checkout/4.

This should be a retriable error.