### PR TITLE
Avoid case-clause of undefined when checking if sha256 content hash header has to be set

### DIFF
--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -842,7 +842,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_account.erl
+++ b/src/aws_account.erl
@@ -206,7 +206,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_amp.erl
+++ b/src/aws_amp.erl
@@ -592,7 +592,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -1034,7 +1034,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_amplifybackend.erl
+++ b/src/aws_amplifybackend.erl
@@ -822,7 +822,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_amplifyuibuilder.erl
+++ b/src/aws_amplifyuibuilder.erl
@@ -655,7 +655,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -3313,7 +3313,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -125,7 +125,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_apigatewayv2.erl
+++ b/src/aws_apigatewayv2.erl
@@ -1946,7 +1946,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -1213,7 +1213,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -1439,7 +1439,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_appconfigdata.erl
+++ b/src/aws_appconfigdata.erl
@@ -178,7 +178,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -715,7 +715,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_appintegrations.erl
+++ b/src/aws_appintegrations.erl
@@ -489,7 +489,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_applicationcostprofiler.erl
+++ b/src/aws_applicationcostprofiler.erl
@@ -221,7 +221,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -1422,7 +1422,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_arc_zonal_shift.erl
+++ b/src/aws_arc_zonal_shift.erl
@@ -276,7 +276,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_auditmanager.erl
+++ b/src/aws_auditmanager.erl
@@ -1926,7 +1926,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -2198,7 +2198,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_backupstorage.erl
+++ b/src/aws_backupstorage.erl
@@ -339,7 +339,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -834,7 +834,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_billingconductor.erl
+++ b/src/aws_billingconductor.erl
@@ -889,7 +889,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -390,7 +390,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -5757,7 +5757,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime_sdk_identity.erl
+++ b/src/aws_chime_sdk_identity.erl
@@ -717,7 +717,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime_sdk_media_pipelines.erl
+++ b/src/aws_chime_sdk_media_pipelines.erl
@@ -368,7 +368,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime_sdk_meetings.erl
+++ b/src/aws_chime_sdk_meetings.erl
@@ -577,7 +577,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime_sdk_messaging.erl
+++ b/src/aws_chime_sdk_messaging.erl
@@ -1748,7 +1748,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_chime_sdk_voice.erl
+++ b/src/aws_chime_sdk_voice.erl
@@ -1977,7 +1977,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -1982,7 +1982,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -4533,7 +4533,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_cloudsearch_domain.erl
+++ b/src/aws_cloudsearch_domain.erl
@@ -213,7 +213,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -1490,7 +1490,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -493,7 +493,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -809,7 +809,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -438,7 +438,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_cognito_sync.erl
+++ b/src/aws_cognito_sync.erl
@@ -617,7 +617,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -5174,7 +5174,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_connect_contact_lens.erl
+++ b/src/aws_connect_contact_lens.erl
@@ -78,7 +78,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_connectcampaigns.erl
+++ b/src/aws_connectcampaigns.erl
@@ -611,7 +611,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_connectcases.erl
+++ b/src/aws_connectcases.erl
@@ -863,7 +863,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -342,7 +342,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_controltower.erl
+++ b/src/aws_controltower.erl
@@ -214,7 +214,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_customer_profiles.erl
+++ b/src/aws_customer_profiles.erl
@@ -1270,7 +1270,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -1253,7 +1253,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -851,7 +851,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_detective.erl
+++ b/src/aws_detective.erl
@@ -900,7 +900,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_devops_guru.erl
+++ b/src/aws_devops_guru.erl
@@ -986,7 +986,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -277,7 +277,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_docdb_elastic.erl
+++ b/src/aws_docdb_elastic.erl
@@ -389,7 +389,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_drs.erl
+++ b/src/aws_drs.erl
@@ -1007,7 +1007,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -301,7 +301,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_efs.erl
+++ b/src/aws_efs.erl
@@ -1405,7 +1405,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_eks.erl
+++ b/src/aws_eks.erl
@@ -1238,7 +1238,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_elastic_inference.erl
+++ b/src/aws_elastic_inference.erl
@@ -198,7 +198,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_elastic_transcoder.erl
+++ b/src/aws_elastic_transcoder.erl
@@ -570,7 +570,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -1460,7 +1460,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_emr_containers.erl
+++ b/src/aws_emr_containers.erl
@@ -668,7 +668,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_emr_serverless.erl
+++ b/src/aws_emr_serverless.erl
@@ -477,7 +477,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_evidently.erl
+++ b/src/aws_evidently.erl
@@ -1270,7 +1270,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_finspace.erl
+++ b/src/aws_finspace.erl
@@ -252,7 +252,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_finspace_data.erl
+++ b/src/aws_finspace_data.erl
@@ -900,7 +900,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_fis.erl
+++ b/src/aws_fis.erl
@@ -492,7 +492,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_gamesparks.erl
+++ b/src/aws_gamesparks.erl
@@ -968,7 +968,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -1768,7 +1768,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_grafana.erl
+++ b/src/aws_grafana.erl
@@ -577,7 +577,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -2648,7 +2648,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_greengrassv2.erl
+++ b/src/aws_greengrassv2.erl
@@ -1090,7 +1090,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -862,7 +862,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -1849,7 +1849,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_honeycode.erl
+++ b/src/aws_honeycode.erl
@@ -495,7 +495,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -1477,7 +1477,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_inspector2.erl
+++ b/src/aws_inspector2.erl
@@ -866,7 +866,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -7437,7 +7437,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_1click_devices.erl
+++ b/src/aws_iot_1click_devices.erl
@@ -422,7 +422,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_1click_projects.erl
+++ b/src/aws_iot_1click_projects.erl
@@ -482,7 +482,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -308,7 +308,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_events.erl
+++ b/src/aws_iot_events.erl
@@ -800,7 +800,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -396,7 +396,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -168,7 +168,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_roborunner.erl
+++ b/src/aws_iot_roborunner.erl
@@ -592,7 +592,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iot_wireless.erl
+++ b/src/aws_iot_wireless.erl
@@ -2818,7 +2818,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iotanalytics.erl
+++ b/src/aws_iotanalytics.erl
@@ -1019,7 +1019,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iotdeviceadvisor.erl
+++ b/src/aws_iotdeviceadvisor.erl
@@ -464,7 +464,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iotfleethub.erl
+++ b/src/aws_iotfleethub.erl
@@ -285,7 +285,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -2363,7 +2363,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_iottwinmaker.erl
+++ b/src/aws_iottwinmaker.erl
@@ -922,7 +922,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -1055,7 +1055,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ivschat.erl
+++ b/src/aws_ivschat.erl
@@ -670,7 +670,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -1030,7 +1030,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kafkaconnect.erl
+++ b/src/aws_kafkaconnect.erl
@@ -372,7 +372,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -920,7 +920,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -583,7 +583,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -124,7 +124,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -119,7 +119,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_kinesis_video_webrtc_storage.erl
+++ b/src/aws_kinesis_video_webrtc_storage.erl
@@ -89,7 +89,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lakeformation.erl
+++ b/src/aws_lakeformation.erl
@@ -1320,7 +1320,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -2304,7 +2304,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lex_model_building.erl
+++ b/src/aws_lex_model_building.erl
@@ -1567,7 +1567,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lex_models_v2.erl
+++ b/src/aws_lex_models_v2.erl
@@ -2031,7 +2031,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -365,7 +365,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lex_runtime_v2.erl
+++ b/src/aws_lex_runtime_v2.erl
@@ -387,7 +387,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_license_manager_linux_subscriptions.erl
+++ b/src/aws_license_manager_linux_subscriptions.erl
@@ -147,7 +147,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_license_manager_user_subscriptions.erl
+++ b/src/aws_license_manager_user_subscriptions.erl
@@ -338,7 +338,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_location.erl
+++ b/src/aws_location.erl
@@ -1692,7 +1692,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lookoutmetrics.erl
+++ b/src/aws_lookoutmetrics.erl
@@ -829,7 +829,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_lookoutvision.erl
+++ b/src/aws_lookoutvision.erl
@@ -888,7 +888,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_m2.erl
+++ b/src/aws_m2.erl
@@ -965,7 +965,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -2175,7 +2175,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -924,7 +924,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -318,7 +318,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -886,7 +886,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -828,7 +828,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -1664,7 +1664,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -547,7 +547,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -502,7 +502,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -237,7 +237,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -1247,7 +1247,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mgn.erl
+++ b/src/aws_mgn.erl
@@ -1495,7 +1495,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_migration_hub_refactor_spaces.erl
+++ b/src/aws_migration_hub_refactor_spaces.erl
@@ -820,7 +820,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_migrationhuborchestrator.erl
+++ b/src/aws_migrationhuborchestrator.erl
@@ -833,7 +833,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_migrationhubstrategy.erl
+++ b/src/aws_migrationhubstrategy.erl
@@ -607,7 +607,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mobile.erl
+++ b/src/aws_mobile.erl
@@ -301,7 +301,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mobile_analytics.erl
+++ b/src/aws_mobile_analytics.erl
@@ -75,7 +75,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -689,7 +689,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -388,7 +388,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -2502,7 +2502,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_nimble.erl
+++ b/src/aws_nimble.erl
@@ -1498,7 +1498,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_oam.erl
+++ b/src/aws_oam.erl
@@ -536,7 +536,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_omics.erl
+++ b/src/aws_omics.erl
@@ -1794,7 +1794,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_opensearch.erl
+++ b/src/aws_opensearch.erl
@@ -1477,7 +1477,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_outposts.erl
+++ b/src/aws_outposts.erl
@@ -817,7 +817,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_panorama.erl
+++ b/src/aws_panorama.erl
@@ -1000,7 +1000,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -127,7 +127,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -114,7 +114,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -3315,7 +3315,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -1395,7 +1395,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -259,7 +259,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_pipes.erl
+++ b/src/aws_pipes.erl
@@ -353,7 +353,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -375,7 +375,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_privatenetworks.erl
+++ b/src/aws_privatenetworks.erl
@@ -723,7 +723,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_qldb.erl
+++ b/src/aws_qldb.erl
@@ -694,7 +694,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -3908,7 +3908,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -759,7 +759,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_rbin.erl
+++ b/src/aws_rbin.erl
@@ -329,7 +329,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -247,7 +247,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_resiliencehub.erl
+++ b/src/aws_resiliencehub.erl
@@ -1119,7 +1119,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_resource_explorer_2.erl
+++ b/src/aws_resource_explorer_2.erl
@@ -737,7 +737,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -662,7 +662,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_robomaker.erl
+++ b/src/aws_robomaker.erl
@@ -1558,7 +1558,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_rolesanywhere.erl
+++ b/src/aws_rolesanywhere.erl
@@ -851,7 +851,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -3045,7 +3045,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_route53_recovery_control_config.erl
+++ b/src/aws_route53_recovery_control_config.erl
@@ -723,7 +723,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_route53_recovery_readiness.erl
+++ b/src/aws_route53_recovery_readiness.erl
@@ -956,7 +956,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_rum.erl
+++ b/src/aws_rum.erl
@@ -619,7 +619,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -7887,7 +7887,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -3069,7 +3069,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -194,7 +194,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -219,7 +219,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_edge.erl
+++ b/src/aws_sagemaker_edge.erl
@@ -119,7 +119,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_featurestore_runtime.erl
+++ b/src/aws_sagemaker_featurestore_runtime.erl
@@ -181,7 +181,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_geospatial.erl
+++ b/src/aws_sagemaker_geospatial.erl
@@ -550,7 +550,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_metrics.erl
+++ b/src/aws_sagemaker_metrics.erl
@@ -78,7 +78,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sagemaker_runtime.erl
+++ b/src/aws_sagemaker_runtime.erl
@@ -179,7 +179,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -273,7 +273,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_scheduler.erl
+++ b/src/aws_scheduler.erl
@@ -398,7 +398,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -890,7 +890,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -1921,7 +1921,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_securitylake.erl
+++ b/src/aws_securitylake.erl
@@ -982,7 +982,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -472,7 +472,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -748,7 +748,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -2685,7 +2685,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -602,7 +602,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_simspaceweaver.erl
+++ b/src/aws_simspaceweaver.erl
@@ -482,7 +482,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_snow_device_management.erl
+++ b/src/aws_snow_device_management.erl
@@ -416,7 +416,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ssm_incidents.erl
+++ b/src/aws_ssm_incidents.erl
@@ -837,7 +837,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_ssm_sap.erl
+++ b/src/aws_ssm_sap.erl
@@ -468,7 +468,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -216,7 +216,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -163,7 +163,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_support_app.erl
+++ b/src/aws_support_app.erl
@@ -401,7 +401,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -737,7 +737,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -314,7 +314,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_wellarchitected.erl
+++ b/src/aws_wellarchitected.erl
@@ -1329,7 +1329,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_wisdom.erl
+++ b/src/aws_wisdom.erl
@@ -925,7 +925,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -1492,7 +1492,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_worklink.erl
+++ b/src/aws_worklink.erl
@@ -906,7 +906,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -106,7 +106,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_workspaces_web.erl
+++ b/src/aws_workspaces_web.erl
@@ -1415,7 +1415,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -907,7 +907,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
         false ->
           encode_payload(Input)
       end,
-    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options) of
+    AdditionalHeaders = case proplists:get_value(append_sha256_content_hash, Options, false) of
                           true ->
                             add_checksum_hash_header(AdditionalHeaders1, Payload);
                           false ->


### PR DESCRIPTION
Normally I'd wait for the nightly release but due to the criticality of this bug, I'd like to roll this out right away. 