### PR TITLE
Fix correct license in aws.app.src

### DIFF
--- a/src/aws.app.src
+++ b/src/aws.app.src
@@ -14,7 +14,7 @@
  , {env,[]}
  , {modules, []}
  , {pkg_name, "aws_erlang"}
- , {licenses, ["Apache 2.0"]}
+ , {licenses, ["Apache-2.0"]}
  , {build_tools, ["rebar3"]}
  , {links, [{"GitHub", "https://github.com/aws-beam/aws-erlang"}]}
  ]}.


### PR DESCRIPTION
Possible fix for: https://github.com/aws-beam/aws-erlang/actions/runs/4024073521/jobs/6915680062