### PR TITLE
Add service_unavailable as retriable error

### DIFF
--- a/src/aws_request.erl
+++ b/src/aws_request.erl
@@ -273,6 +273,8 @@ classify_response({error, timeout}) ->
   retriable;
 classify_response({error, checkout_timeout}) ->
   retriable;
+classify_response({error, service_unavailable}) ->
+  retriable;
 classify_response({error, _}) ->
   error;
 classify_response({ok, {_, _}}) ->


### PR DESCRIPTION
Can be merged as is but will require: https://github.com/aws-beam/aws-codegen/pull/96 in order to take effect. 

The combination of this PR as well as the `aws-codegen` one will fix: https://github.com/aws-beam/aws-erlang/issues/123