### PR TITLE
Add basic skeleton for aws_s3 testing towards a mocked S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
         image: amazon/dynamodb-local:1.21.0
         ports:
           - 8000:8000
+      s3mock:
+        image: adobe/s3mock:2.11.0
+        ports:
+          - 9090:9090
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -45,6 +49,7 @@ jobs:
       run: rebar3 ct
       env:
         DYNAMODB_HOST: ddb
+        S3MOCK_HOST: s3mock
     - name: Create Cover Reports
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,15 +22,7 @@
 
 Here is an example of listing Amazon Kinesis streams. First of all,
 start a shell with `rebar3 shell`, then:
-
-```erlang
-> Client = aws_client:make_client(<<"my-access-key-id">>, <<"my-secret-access-key">>, <<"eu-west-1">>),
-[...]
-> {ok, Result, _Response} = aws_kinesis:list_streams(Client, #{}),
-[...]
-> io:format("~p~n", [Result]).
-#{<<"HasMoreStreams">> => false,<<"StreamNames">> => []}
-```
+### aws_s3
 
 Here is another example, this time using a _temporary_ client, showing
 how to upload a file to _S3_ and how to fetch it back:
@@ -47,12 +39,35 @@ how to upload a file to _S3_ and how to fetch it back:
 > Content = maps:get(<<"Body">>, Response).
 ```
 
+Support for creating [Presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html) is provided
+through the `aws_s3_presigned_url` module.
+
+### aws_kinesis
+
+```erlang
+> Client = aws_client:make_client(<<"my-access-key-id">>, <<"my-secret-access-key">>, <<"eu-west-1">>),
+[...]
+> {ok, Result, _Response} = aws_kinesis:list_streams(Client, #{}),
+[...]
+> io:format("~p~n", [Result]).
+#{<<"HasMoreStreams">> => false,<<"StreamNames">> => []}
+```
+
+### retry options
+
+Each API which takes `Options` allows a `retry_options` key and can allow for automatic retries.
+Simple provide the following:
+
+`[{retry_options, {exponential_with_jitter, {MaxAttempts, BaseSleepTime, CapSleepTime}}} | <other_options>]`
+
+This implementation is based on [AWS: Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/).
+
 ## Installation
 
 Simply add the library to your `rebar.config`:
 
 ```erlang
-{deps, [{aws, "0.5.0", {pkg, aws_erlang}}]}.
+{deps, [{aws, "1.0.0", {pkg, aws_erlang}}]}.
 ```
 
 ## Obtaining Credentials
@@ -79,7 +94,7 @@ Here is an example on how to obtain credentials:
 The `aws_credentials` application can be installed by adding the following to your `rebar.config`:
 
 ```erlang
-{deps, [{aws_credentials, "0.1.0"}]}.
+{deps, [{aws_credentials, "0.1.10"}]}.
 ```
 
 ## Development
@@ -96,16 +111,8 @@ The rest of the code is manually written and used as support for the generated c
 
 ### Build it locally
 
-Add the [rebar3_docs](https://github.com/jfacorro/rebar3_docs) plugin to your global _rebar3_ config in `~/.config/rebar3/rebar.config`:
-
-```
-{plugins, [rebar3_docs]}.
-```
-
-Then simply:
-
 ```bash
-$ rebar3 docs
+$ rebar3 ex_doc
 ```
 
 The docs will be available in `./doc`.
@@ -114,6 +121,12 @@ The docs will be available in `./doc`.
 
 ```bash
 $ rebar3 eunit
+```
+
+```bash
+$ docker-compose -f test/docker/docker-compose.yml up -d
+$ rebar3 ct
+$ docker-compose -f test/docker/docker-compose.yml down
 ```
 
 ## License

--- a/test/aws_s3_SUITE.erl
+++ b/test/aws_s3_SUITE.erl
@@ -1,0 +1,115 @@
+-module(aws_s3_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%% Test server callbacks
+-export([suite/0, all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2,
+         end_per_testcase/2]).
+%% Test cases
+-export([bucket_exists/1, create_delete_bucket/1, delete/1, exists/1, list_objects/1,
+         delete_objects/1, read/1, write/1]).
+
+%%--------------------------------------------------------------------
+%% Common test callback functions
+suite() ->
+  [{timetrap, {minutes, 1}}].
+
+init_per_suite(Config) ->
+  application:ensure_all_started(aws),
+  Bucket = <<"test-bucket">>,
+  ok = aws_s3_util:create_bucket(client(), Bucket, []),
+  [{bucket, Bucket} | Config].
+
+end_per_suite(Config) ->
+  Bucket = ?config(bucket, Config),
+  ok = aws_s3_util:delete_bucket(client(), Bucket, []),
+  ok.
+
+init_per_testcase(_Case, Config) ->
+  Config.
+
+end_per_testcase(_Case, Config) ->
+  Bucket = ?config(bucket, Config),
+  cleanup_keys(Bucket),
+  ok.
+
+all() ->
+  [write, read, exists, delete, delete_objects, list_objects, create_delete_bucket].
+
+%%--------------------------------------------------------------------
+%% Test cases
+write(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key = unique_key(),
+  ?assertEqual(ok, aws_s3_util:write(client(), Bucket, Key, <<"data">>, [])),
+  ok.
+
+read(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key = unique_key(),
+  ok = aws_s3_util:write(client(), Bucket, Key, <<"data">>, []),
+  ?assertEqual({ok, <<"data">>}, aws_s3_util:read(client(), Bucket, Key, [])),
+  ok.
+
+exists(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key = unique_key(),
+  ?assertNot(aws_s3_util:exists(client(), Bucket, Key, [])),
+  ok = aws_s3_util:write(client(), Bucket, Key, <<"data">>, []),
+  ?assert(aws_s3_util:exists(client(), Bucket, Key, [])),
+  ?assert(aws_s3_util:exists_min_size(client(), Bucket, Key, 1, [])),
+  ok.
+
+delete(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key = unique_key(),
+  ok = aws_s3_util:write(client(), Bucket, Key, <<"data">>, []),
+  ?assertEqual(ok, aws_s3_util:delete(client(), Bucket, Key, [])),
+  ok.
+
+delete_objects(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key1 = unique_key(),
+  Key2 = unique_key(),
+  ok = aws_s3_util:write(client(), Bucket, Key1, <<"data">>, []),
+  ok = aws_s3_util:write(client(), Bucket, Key2, <<"data">>, []),
+  ?assertEqual({ok, []}, aws_s3_util:delete_objects(client(), Bucket, [Key1, Key2], [])),
+  ok.
+
+list_objects(Config) ->
+  Bucket = ?config(bucket, Config),
+  Key1 = <<"test-key-1">>,
+  Key2 = <<"test-key-2">>,
+  ok = aws_s3_util:write(client(), Bucket, Key1, <<"data">>, []),
+  ok = aws_s3_util:write(client(), Bucket, Key2, <<"data">>, []),
+  ?assertEqual([Key1, Key2],
+               lists:sort(aws_s3_util:list_objects(client(), Bucket, <<"test-key">>, []))),
+  ok.
+
+create_delete_bucket(_Config) ->
+  Bucket = unique_key(),
+  ?assertEqual(ok, aws_s3_util:create_bucket(client(), Bucket, [])),
+  ?assertEqual(ok, aws_s3_util:delete_bucket(client(), Bucket, [])),
+  ok.
+
+bucket_exists(Config) ->
+  Bucket = ?config(bucket, Config),
+  ?assert(aws_s3_util:bucket_exists(client(), Bucket, [])),
+  ?assertNot(aws_s3_util:bucket_exists(client(), unique_key(), [])),
+  ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+client() ->
+  aws_client:make_local_client(<<"AccessKeyID">>,
+                               <<"SecretAccessKey">>,
+                               <<"9090">>,
+                               list_to_binary(os:getenv("S3MOCK_HOST", "localhost"))).
+
+cleanup_keys(Bucket) ->
+  Keys = aws_s3_util:list_objects(client(), Bucket, <<"">>, []),
+  {ok, []} = aws_s3_util:delete_objects(client(), Bucket, Keys, []).
+
+unique_key() ->
+  <<"test-key-", (integer_to_binary(erlang:unique_integer([positive])))/binary>>.

--- a/test/aws_s3_util.erl
+++ b/test/aws_s3_util.erl
@@ -1,0 +1,177 @@
+-module(aws_s3_util).
+
+-export([bucket_exists/3, create_bucket/3, delete_bucket/3, list_objects/4, delete/4,
+         delete_objects/4, exists/4, exists_min_size/5, read/4, write/5]).
+
+-type client() :: map().
+-type bucket() :: binary().
+-type key() :: binary().
+-type prefix() :: binary().
+-type options() :: proplists:proplist().
+
+%%--------------------------------------------------------------------
+%% API
+-spec bucket_exists(client(), bucket(), options()) -> boolean() | {error, term()}.
+bucket_exists(Client, Bucket, Options) ->
+  case aws_s3:head_bucket(Client, Bucket, #{}, Options) of
+    {ok, {200, _Headers}} ->
+      true;
+    {error, {404, _Headers}} ->
+      false;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec create_bucket(client(), bucket(), options()) -> ok | {error, term()}.
+create_bucket(Client, Bucket, Options) ->
+  case aws_s3:create_bucket(Client, Bucket, #{}, Options) of
+    {ok, _, {200, _Headers, _}} ->
+      ok;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec delete_bucket(client(), bucket(), options()) -> ok | {error, not_found | term()}.
+delete_bucket(Client, Bucket, Options) ->
+  case aws_s3:delete_bucket(Client, Bucket, #{}, Options) of
+    {ok, _Body, {204, _Headers, _Ref}} ->
+      ok;
+    {error, _Body, {404, _Headers, _Ref}} ->
+      {error, not_found};
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec list_objects(client(), bucket(), prefix(), options()) -> [key()].
+list_objects(Client, Bucket, Prefix, Options) ->
+  list_objects(Client, Bucket, Prefix, Options, undefined, []).
+
+-spec delete(client(), bucket(), key(), options()) -> ok | {error, term()}.
+delete(Client, Bucket, Key, Options) ->
+  case aws_s3:delete_object(Client, Bucket, Key, #{}, Options) of
+    {ok, _Body, {204, _Header, _Ref}} ->
+      ok;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec delete_objects(client(), bucket(), [key()], options()) ->
+                    {ok, [] | [term()]} | {error, term()}.
+delete_objects(_Client, _Bucket, [] = _Keys, _Options) ->
+  {ok, []};
+delete_objects(Client, Bucket, Keys, Options) ->
+  Input = #{<<"Delete">> => #{<<"Object">> => [#{<<"Key">> => Key} || Key <- Keys]}},
+  case aws_s3:delete_objects(Client, Bucket, Input, Options) of
+    {ok, #{<<"DeleteResult">> := none}, {200, _Headers, _Ref}} ->
+      %% Everything went well
+      {ok, []};
+    {ok, #{<<"DeleteResult">> := Result}, {200, _Headers, _Ref}} ->
+      %% Result may contain a single error-map or multiple.
+      Failed =
+        lists:map(fun(#{<<"Key">> := Key, <<"Code">> := Code}) -> {Key, Code} end,
+                  force_list(maps:get(<<"Error">>, Result, []))),
+      {ok, Failed};
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec exists(client(), bucket(), key(), options()) -> boolean() | {error, term()}.
+exists(Client, Bucket, Key, Options) ->
+  case aws_s3:head_object(Client, Bucket, Key, #{}, Options) of
+    {ok, _, {200, _Headers}} ->
+      true;
+    {error, {404, _Header}} ->
+      false;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec exists_min_size(client(), bucket(), key(), non_neg_integer(), options()) ->
+                       boolean() | {error, term()}.
+exists_min_size(Client, Bucket, Key, Size, Options) ->
+  case aws_s3:head_object(Client, Bucket, Key, #{}, Options) of
+    {ok, _, {200, Headers}} ->
+      Length = binary_to_integer(proplists:get_value(<<"Content-Length">>, Headers)),
+      Length >= Size;
+    {error, {404, _Header}} ->
+      false;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec read(client(), bucket(), key(), options()) ->
+            {ok, binary()} | {error, not_found | term()}.
+read(Client, Bucket, Key, Options) ->
+  case aws_s3:get_object(Client, Bucket, Key, #{}, #{}, Options) of
+    {error, _Desc, {404, _Headers, _Ref}} ->
+      {error, not_found};
+    {ok, #{<<"Body">> := Data}, {200, _Headers, _Ref}} ->
+      {ok, Data};
+    {ok, #{<<"ContentLength">> := <<"0">>}, {200, _Headers, _Ref}} ->
+      {ok, <<>>};
+    {error, Error} ->
+      {error, Error}
+  end.
+
+-spec write(client(), bucket(), key(), binary(), options()) ->
+             ok | {error, no_such_bucket | term()}.
+write(Client, Bucket, Key, Data, Options) ->
+  DateTime =
+    calendar:now_to_datetime(
+      erlang:timestamp()),
+  GTime = calendar:datetime_to_gregorian_seconds(DateTime),
+  Input =
+    #{<<"Body">> => Data,
+      <<"Metadata">> => #{<<"modified-gtime">> => integer_to_binary(GTime)}},
+  case aws_s3:put_object(Client, Bucket, Key, Input, Options) of
+    {ok, _RespBody, {200, _Headers, _Ref}} ->
+      ok;
+    {ok, {_, 404, _Headers}, _Ref} ->
+      {error, no_such_bucket};
+    {error, Error} ->
+      {error, Error}
+  end.
+
+%%--------------------------------------------------------------------
+%% Internal
+list_objects(Client, Bucket, Prefix, Options, Marker, Acc) ->
+  Query0 = #{<<"prefix">> => Prefix},
+  Query =
+    case Marker of
+      undefined ->
+        Query0;
+      _ ->
+        Query0#{<<"marker">> => Marker}
+    end,
+  case aws_s3:list_objects(Client, Bucket, Query, #{}, Options) of
+    {ok,
+     #{<<"ListBucketResult">> := #{<<"IsTruncated">> := IsTruncated} = Res},
+     {200, _Headers, _Ref}} ->
+      case maps:get(<<"Contents">>, Res, []) of
+        Contents when is_list(Contents) ->
+          Keys = lists:map(fun(#{<<"Key">> := Path}) -> Path end, Contents),
+          NewAcc = Acc ++ Keys,
+          case to_boolean(IsTruncated) of
+            true ->
+              NewMarker = lists:last(Keys),
+              list_objects(Client, Bucket, Prefix, Options, NewMarker, NewAcc);
+            false ->
+              NewAcc
+          end;
+        Content ->
+          Path = maps:get(<<"Key">>, Content),
+          [Path | Acc]
+      end;
+    {error, Error} ->
+      {error, Error}
+  end.
+
+force_list(Maps) when is_list(Maps) ->
+  Maps;
+force_list(Map) when is_map(Map) ->
+  [Map].
+
+to_boolean(<<"true">>) ->
+  true;
+to_boolean(<<"false">>) ->
+  false.

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.6"
+
+services:
+  ddb:
+    image: amazon/dynamodb-local:1.21.0
+    ports:
+      - 8000:8000
+
+  s3mock:
+    image: adobe/s3mock:2.11.0
+    ports:
+      - 9090:9090
+    environment:
+      retainFilesOnExit: 'false'


### PR DESCRIPTION
`aws_s3_util` sits under `/test` for the time being as I'd like to get some mileage on it when we're ready to start the testing towards a real AWS instance. It's heavily based on a module we use at $DAYJOB so in theory it should work but don't want to commit to it being available to the outside world until it's been properly tested. 

Furthermore I touched up the README a bit here and there and included a mention of `aws_s3_presigned_url` as it's additional functionality we provide that wasn't totally clear (got a question on Erlanger slack on whether that should be considered "legacy" and want to make it clear in the README that it is not :+1: :smile: 