### PR TITLE
Do not uriencode path twice

### DIFF
--- a/src/aws_request.erl
+++ b/src/aws_request.erl
@@ -32,7 +32,7 @@ sign_request(Client, Method, URL, Headers0, Body) ->
                 undefined -> Headers0;
                 _ -> [{<<"X-Amz-Security-Token">>, Token}|Headers0]
               end,
-    aws_signature:sign_v4(AccessKeyID, SecretAccessKey, Region, Service, calendar:universal_time(), Method, URL, Headers, Body).
+    aws_signature:sign_v4(AccessKeyID, SecretAccessKey, Region, Service, calendar:universal_time(), Method, URL, Headers, Body, [{uri_encode_path, false}]).
 
 %% @doc Include additions only if they don't already exist in the provided list.
 add_headers([], Headers) ->


### PR DESCRIPTION
See the same behavior in aws-elixir: https://github.com/aws-beam/aws-elixir/blob/master/lib/aws/signature.ex#L32

This breaks whenever special characters such as `@` are used in the s3 filepath for example. 