### PR TITLE
Do not remove any non-erlang files such as those from aws-codegen. Only delete auto-generated files in src/*.erl

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -85,7 +85,7 @@ jobs:
           ERLANG_OUTPUT_PATH: ../../src
         run: |
           # Remove any previously generated files
-          find . -type f -exec grep -l "DO NOT EDIT, AUTO-GENERATED CODE" {} \; | xargs rm -f
+          find src -type f -name "*.erl" -exec grep -l "DO NOT EDIT, AUTO-GENERATED CODE" {} \; | xargs rm -f
 
           # Jump to the codegen
           cd tmp/aws-codegen


### PR DESCRIPTION
The nightly build has been broken and has gone unnoticed. Will follow up on how to notify us AWS-Beamers about such failing jobs