### PR TITLE
Fix s3 presigning of urls when path contains special characters

### DIFF
--- a/src/aws_s3_presigned_url.erl
+++ b/src/aws_s3_presigned_url.erl
@@ -36,6 +36,7 @@ make_presigned_v4_url(Client0, Method, ExpireSeconds, Bucket, Key, Style) ->
     Now = calendar:universal_time(),
     Options0 = [ {ttl, ExpireSeconds}
                , {body_digest, <<"UNSIGNED-PAYLOAD">>}
+               , {uri_encode_path, false} %% We already encode in build_path/4
                ],
     Options = case SecurityToken of
                 undefined ->


### PR DESCRIPTION
Fixes the Erlang implementation of the same bug reported in: https://github.com/aws-beam/aws_signature/issues/27 

See explanation at: https://github.com/aws-beam/aws_signature/issues/27#issuecomment-1962971322