### PR TITLE
Respect aws endpoint url

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [nowarn_unused_type, debug_info, {d, maps_support}]}.
 {deps, [{hackney, "1.25.0"},
         {jsx, "3.0.0"},
-        {aws_beam_core, "1.1.1"}
-       ]}.
+        {aws_beam_core, "1.2.0"}
+           ]}.
 {project_plugins, [rebar3_hex, rebar3_ex_doc, rebar3_check_app_calls]}.
 {hex, [{doc, #{provider => ex_doc}}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,5 @@
 {"1.2.0",
-[{<<"aws_beam_core">>,{pkg,<<"aws_beam_core">>,<<"1.1.1">>},0},
+[{<<"aws_beam_core">>,{pkg,<<"aws_beam_core">>,<<"1.2.0">>},0},
  {<<"aws_credentials">>,{pkg,<<"aws_credentials">>,<<"1.0.3">>},1},
  {<<"aws_signature">>,{pkg,<<"aws_signature">>,<<"0.4.2">>},1},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.15.0">>},1},
@@ -15,7 +15,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.1">>},1}]}.
 [
 {pkg_hash,[
- {<<"aws_beam_core">>, <<"3D70444AE1F1A31E3F7FAC2BE5826258CA9BB1C05D054D58251B6C0B3B429775">>},
+ {<<"aws_beam_core">>, <<"EA9C7289EEEE2C42F97E4208D7447DF2074084C2E000F3F2B132FF6DB626D56F">>},
  {<<"aws_credentials">>, <<"7CDAA99D0ED11C3B93A5F80E5673969F1E4379EDBB4907EB13D161CF2DE0826E">>},
  {<<"aws_signature">>, <<"1B35482C89FF5B91F5EAD647A2BBC0D9620877479B44800915DE92BACF9F1476">>},
  {<<"certifi">>, <<"0E6E882FCDAAA0A5A9F2B3DB55B1394DBA07E8D6D9BCAD08318FB604C6839712">>},
@@ -30,7 +30,7 @@
  {<<"ssl_verify_fun">>, <<"354C321CF377240C7B8716899E182CE4890C5938111A1296ADD3EC74CF1715DF">>},
  {<<"unicode_util_compat">>, <<"A48703A25C170EEDADCA83B11E88985AF08D35F37C6F664D6DCFB106A97782FC">>}]},
 {pkg_hash_ext,[
- {<<"aws_beam_core">>, <<"3B73C54B0831F82915EF47E230FF18E86A47045DBDCD3BC5B33A4DFC355DF5D6">>},
+ {<<"aws_beam_core">>, <<"C61C637B9AFDCB01AE00BCB881C477F8C0BE1B27C28A5C6BB886CD029C91466D">>},
  {<<"aws_credentials">>, <<"D3ACC14D953C7F00BF544FE81A3A8D9C30C073A7526EA3CC2D6220D9468FF6D3">>},
  {<<"aws_signature">>, <<"1DF4A2D1DFF200C7BDFA8F9F935EFC71A51273ADFC6DD39A9F2CC937E01BAA01">>},
  {<<"certifi">>, <<"B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60">>},

--- a/src/aws_accessanalyzer.erl
+++ b/src/aws_accessanalyzer.erl
@@ -3341,9 +3341,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"access-analyzer">>},
-    Host = build_host(<<"access-analyzer">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"access-analyzer">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ACCESSANALYZER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3427,7 +3429,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_account.erl
+++ b/src/aws_account.erl
@@ -1041,9 +1041,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"account">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"account">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"account">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ACCOUNT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1127,7 +1129,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_acm.erl
+++ b/src/aws_acm.erl
@@ -1211,8 +1211,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"acm">>},
-    Host = build_host(<<"acm">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"acm">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ACM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_acm_pca.erl
+++ b/src/aws_acm_pca.erl
@@ -1799,8 +1799,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"acm-pca">>},
-    Host = build_host(<<"acm-pca">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"acm-pca">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ACM_PCA">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_aiops.erl
+++ b/src/aws_aiops.erl
@@ -844,9 +844,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aiops">>},
-    Host = build_host(<<"aiops">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"aiops">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AIOPS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -930,7 +932,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_amp.erl
+++ b/src/aws_amp.erl
@@ -3232,9 +3232,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aps">>},
-    Host = build_host(<<"aps">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"aps">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AMP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3318,7 +3320,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_amplify.erl
+++ b/src/aws_amplify.erl
@@ -2673,9 +2673,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"amplify">>},
-    Host = build_host(<<"amplify">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"amplify">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AMPLIFY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2759,7 +2761,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_amplifybackend.erl
+++ b/src/aws_amplifybackend.erl
@@ -2253,9 +2253,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"amplifybackend">>},
-    Host = build_host(<<"amplifybackend">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"amplifybackend">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AMPLIFYBACKEND">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2339,7 +2341,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_amplifyuibuilder.erl
+++ b/src/aws_amplifyuibuilder.erl
@@ -2393,9 +2393,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"amplifyuibuilder">>},
-    Host = build_host(<<"amplifyuibuilder">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"amplifyuibuilder">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AMPLIFYUIBUILDER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2479,7 +2481,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_api_gateway.erl
+++ b/src/aws_api_gateway.erl
@@ -7505,9 +7505,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"apigateway">>},
-    Host = build_host(<<"apigateway">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"apigateway">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_API_GATEWAY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7591,7 +7593,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_apigatewaymanagementapi.erl
+++ b/src/aws_apigatewaymanagementapi.erl
@@ -221,9 +221,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"execute-api">>},
-    Host = build_host(<<"execute-api">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"execute-api">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APIGATEWAYMANAGEMENTAPI">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -307,7 +309,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{api_id := ApiId, region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([ApiId, EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_apigatewayv2.erl
+++ b/src/aws_apigatewayv2.erl
@@ -6957,9 +6957,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"apigateway">>},
-    Host = build_host(<<"apigateway">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"apigateway">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APIGATEWAYV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7043,7 +7045,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_app_mesh.erl
+++ b/src/aws_app_mesh.erl
@@ -3777,9 +3777,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appmesh">>},
-    Host = build_host(<<"appmesh">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appmesh">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APP_MESH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3863,7 +3865,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_appconfig.erl
+++ b/src/aws_appconfig.erl
@@ -3237,9 +3237,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appconfig">>},
-    Host = build_host(<<"appconfig">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appconfig">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPCONFIG">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3323,7 +3325,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_appconfigdata.erl
+++ b/src/aws_appconfigdata.erl
@@ -320,9 +320,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appconfig">>},
-    Host = build_host(<<"appconfigdata">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appconfigdata">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPCONFIGDATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -406,7 +408,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_appfabric.erl
+++ b/src/aws_appfabric.erl
@@ -1874,9 +1874,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appfabric">>},
-    Host = build_host(<<"appfabric">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appfabric">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPFABRIC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1960,7 +1962,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_appflow.erl
+++ b/src/aws_appflow.erl
@@ -3144,9 +3144,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appflow">>},
-    Host = build_host(<<"appflow">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appflow">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPFLOW">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3230,7 +3232,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_appintegrations.erl
+++ b/src/aws_appintegrations.erl
@@ -1786,9 +1786,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"app-integrations">>},
-    Host = build_host(<<"app-integrations">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"app-integrations">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPINTEGRATIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1872,7 +1874,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_application_auto_scaling.erl
+++ b/src/aws_application_auto_scaling.erl
@@ -1256,8 +1256,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"application-autoscaling">>},
-    Host = build_host(<<"application-autoscaling">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"application-autoscaling">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_APPLICATION_AUTO_SCALING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_application_discovery.erl
+++ b/src/aws_application_discovery.erl
@@ -1790,8 +1790,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"discovery">>},
-    Host = build_host(<<"discovery">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"discovery">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_APPLICATION_DISCOVERY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_application_insights.erl
+++ b/src/aws_application_insights.erl
@@ -1626,8 +1626,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"applicationinsights">>},
-    Host = build_host(<<"applicationinsights">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"applicationinsights">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_APPLICATION_INSIGHTS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_application_signals.erl
+++ b/src/aws_application_signals.erl
@@ -2204,9 +2204,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"application-signals">>},
-    Host = build_host(<<"application-signals">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"application-signals">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPLICATION_SIGNALS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2290,7 +2292,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_applicationcostprofiler.erl
+++ b/src/aws_applicationcostprofiler.erl
@@ -487,9 +487,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"application-cost-profiler">>},
-    Host = build_host(<<"application-cost-profiler">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"application-cost-profiler">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPLICATIONCOSTPROFILER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -573,7 +575,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_apprunner.erl
+++ b/src/aws_apprunner.erl
@@ -2042,8 +2042,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"apprunner">>},
-    Host = build_host(<<"apprunner">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"apprunner">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_APPRUNNER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_appstream.erl
+++ b/src/aws_appstream.erl
@@ -4528,8 +4528,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"appstream">>},
-    Host = build_host(<<"appstream2">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"appstream2">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_APPSTREAM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_appsync.erl
+++ b/src/aws_appsync.erl
@@ -5273,9 +5273,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"appsync">>},
-    Host = build_host(<<"appsync">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"appsync">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_APPSYNC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5359,7 +5361,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_arc_region_switch.erl
+++ b/src/aws_arc_region_switch.erl
@@ -1382,8 +1382,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"arc-region-switch">>},
-    Host = build_host(<<"arc-region-switch">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"arc-region-switch">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ARC_REGION_SWITCH">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_arc_zonal_shift.erl
+++ b/src/aws_arc_zonal_shift.erl
@@ -1239,9 +1239,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"arc-zonal-shift">>},
-    Host = build_host(<<"arc-zonal-shift">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"arc-zonal-shift">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ARC_ZONAL_SHIFT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1325,7 +1327,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_artifact.erl
+++ b/src/aws_artifact.erl
@@ -715,9 +715,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"artifact">>},
-    Host = build_host(<<"artifact">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"artifact">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ARTIFACT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -801,7 +803,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_athena.erl
+++ b/src/aws_athena.erl
@@ -3650,8 +3650,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"athena">>},
-    Host = build_host(<<"athena">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"athena">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ATHENA">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_auditmanager.erl
+++ b/src/aws_auditmanager.erl
@@ -4798,9 +4798,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"auditmanager">>},
-    Host = build_host(<<"auditmanager">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"auditmanager">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_AUDITMANAGER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4884,7 +4886,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_auto_scaling.erl
+++ b/src/aws_auto_scaling.erl
@@ -4446,8 +4446,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"autoscaling">>},
-    Host = build_host(<<"autoscaling">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"autoscaling">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_AUTO_SCALING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_auto_scaling_plans.erl
+++ b/src/aws_auto_scaling_plans.erl
@@ -483,8 +483,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"autoscaling-plans">>},
-    Host = build_host(<<"autoscaling-plans">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"autoscaling-plans">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_AUTO_SCALING_PLANS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_b2bi.erl
+++ b/src/aws_b2bi.erl
@@ -1838,8 +1838,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"b2bi">>},
-    Host = build_host(<<"b2bi">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"b2bi">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_B2BI">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_backup.erl
+++ b/src/aws_backup.erl
@@ -8269,9 +8269,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"backup">>},
-    Host = build_host(<<"backup">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"backup">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BACKUP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8355,7 +8357,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_backup_gateway.erl
+++ b/src/aws_backup_gateway.erl
@@ -1145,8 +1145,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"backup-gateway">>},
-    Host = build_host(<<"backup-gateway">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"backup-gateway">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BACKUP_GATEWAY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_backupsearch.erl
+++ b/src/aws_backupsearch.erl
@@ -1004,9 +1004,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"backup-search">>},
-    Host = build_host(<<"backup-search">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"backup-search">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BACKUPSEARCH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1090,7 +1092,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_batch.erl
+++ b/src/aws_batch.erl
@@ -4272,9 +4272,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"batch">>},
-    Host = build_host(<<"batch">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"batch">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BATCH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4358,7 +4360,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bcm_dashboards.erl
+++ b/src/aws_bcm_dashboards.erl
@@ -932,8 +932,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"bcm-dashboards">>},
-    Host = build_host(<<"bcm-dashboards">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"bcm-dashboards">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BCM_DASHBOARDS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_bcm_data_exports.erl
+++ b/src/aws_bcm_data_exports.erl
@@ -702,8 +702,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"bcm-data-exports">>},
-    Host = build_host(<<"bcm-data-exports">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"bcm-data-exports">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BCM_DATA_EXPORTS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_bcm_pricing_calculator.erl
+++ b/src/aws_bcm_pricing_calculator.erl
@@ -2112,8 +2112,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"bcm-pricing-calculator">>},
-    Host = build_host(<<"bcm-pricing-calculator">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"bcm-pricing-calculator">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BCM_PRICING_CALCULATOR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_bcm_recommended_actions.erl
+++ b/src/aws_bcm_recommended_actions.erl
@@ -135,8 +135,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"bcm-recommended-actions">>},
-    Host = build_host(<<"bcm-recommended-actions">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"bcm-recommended-actions">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BCM_RECOMMENDED_ACTIONS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_bedrock.erl
+++ b/src/aws_bedrock.erl
@@ -9398,9 +9398,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -9484,7 +9486,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_agent.erl
+++ b/src/aws_bedrock_agent.erl
@@ -6777,9 +6777,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock-agent">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-agent">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_AGENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6863,7 +6865,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_agent_runtime.erl
+++ b/src/aws_bedrock_agent_runtime.erl
@@ -4167,9 +4167,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock-agent-runtime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-agent-runtime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_AGENT_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4253,7 +4255,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_agentcore.erl
+++ b/src/aws_bedrock_agentcore.erl
@@ -6432,9 +6432,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock-agentcore">>},
-    Host = build_host(<<"bedrock-agentcore">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-agentcore">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_AGENTCORE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6518,7 +6520,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_agentcore_control.erl
+++ b/src/aws_bedrock_agentcore_control.erl
@@ -8128,9 +8128,9 @@ delete_configuration_bundle(Client, BundleId, Input0, Options0) ->
 %% Asynchronous 202.
 %%
 %% **State transitions:**
-%% - If `datasetVersion` is absent (full delete): status transitions to
+%% - If `datasetVersion' is absent (full delete): status transitions to
 %% DELETING immediately.
-%% - If `datasetVersion` is provided (version-specific delete): status
+%% - If `datasetVersion' is provided (version-specific delete): status
 %% transitions to UPDATING.
 %%
 %% **State guard (full delete):** Returns ConflictException
@@ -8155,9 +8155,9 @@ delete_configuration_bundle(Client, BundleId, Input0, Options0) ->
 %% (idempotent retry path).
 %%
 %% **Version parameter:**
-%% - If `datasetVersion` is absent: deletes ALL versions and the Dataset
+%% - If `datasetVersion' is absent: deletes ALL versions and the Dataset
 %% record itself.
-%% - If `datasetVersion` is provided: deletes only that specific
+%% - If `datasetVersion' is provided: deletes only that specific
 %% DatasetVersion.
 %% Returns ResourceNotFoundException if the specified version does not exist.
 -spec delete_dataset(aws_client:aws_client(), binary() | list(), delete_dataset_request()) ->
@@ -9178,11 +9178,11 @@ get_configuration_bundle_version(Client, BundleId, VersionId, QueryMap, HeadersM
 %% draftStatus is
 %% MODIFIED because the DRAFT has content that has never been published.
 %%
-%% **Default version behavior:** When `datasetVersion` is omitted, the
+%% **Default version behavior:** When `datasetVersion' is omitted, the
 %% operation
 %% returns the DRAFT working copy. To retrieve a specific published version,
 %% pass
-%% the version number as a string (e.g. `?datasetVersion=1`).
+%% the version number as a string (e.g. `?datasetVersion=1').
 %%
 %% **State guard:** Allowed for all statuses including DELETING. Returns the
 %% dataset
@@ -10413,12 +10413,12 @@ list_configuration_bundles(Client, Input0, Options0) ->
 %% @doc Returns paginated examples from the dataset.
 %%
 %% **Version-pinned pagination:** The server embeds the resolved version in
-%% the `nextToken`.
+%% the `nextToken'.
 %% Once pagination begins, all subsequent pages are pinned to that version
 %% regardless of
-%% concurrent mutations or whether `datasetVersion` is passed on subsequent
-%% requests. The `datasetVersion`
-%% query parameter is only used for the first request (when `nextToken` is
+%% concurrent mutations or whether `datasetVersion' is passed on subsequent
+%% requests. The `datasetVersion'
+%% query parameter is only used for the first request (when `nextToken' is
 %% absent); if omitted,
 %% defaults to DRAFT.
 %%

--- a/src/aws_bedrock_agentcore_control.erl
+++ b/src/aws_bedrock_agentcore_control.erl
@@ -12638,9 +12638,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock-agentcore">>},
-    Host = build_host(<<"bedrock-agentcore-control">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-agentcore-control">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_AGENTCORE_CONTROL">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -12724,7 +12726,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_data_automation.erl
+++ b/src/aws_bedrock_data_automation.erl
@@ -2299,9 +2299,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock-data-automation">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-data-automation">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_DATA_AUTOMATION">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2385,7 +2387,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_bedrock_data_automation_runtime.erl
+++ b/src/aws_bedrock_data_automation_runtime.erl
@@ -410,8 +410,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock-data-automation-runtime">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"bedrock-data-automation-runtime">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_DATA_AUTOMATION_RUNTIME">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_bedrock_runtime.erl
+++ b/src/aws_bedrock_runtime.erl
@@ -1968,9 +1968,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"bedrock">>},
-    Host = build_host(<<"bedrock-runtime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"bedrock-runtime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BEDROCK_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2054,7 +2056,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_billing.erl
+++ b/src/aws_billing.erl
@@ -705,8 +705,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"billing">>},
-    Host = build_host(<<"billing">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"billing">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BILLING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_billingconductor.erl
+++ b/src/aws_billingconductor.erl
@@ -2589,9 +2589,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"billingconductor">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"billingconductor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"billingconductor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BILLINGCONDUCTOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2675,7 +2677,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_braket.erl
+++ b/src/aws_braket.erl
@@ -1474,9 +1474,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"braket">>},
-    Host = build_host(<<"">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_BRAKET">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1560,7 +1562,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_budgets.erl
+++ b/src/aws_budgets.erl
@@ -1586,8 +1586,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"budgets">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"budgets">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"budgets">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_BUDGETS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_chatbot.erl
+++ b/src/aws_chatbot.erl
@@ -2385,9 +2385,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chatbot">>},
-    Host = build_host(<<"chatbot">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"chatbot">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHATBOT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2471,7 +2473,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime.erl
+++ b/src/aws_chime.erl
@@ -4456,9 +4456,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4542,7 +4544,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime_sdk_identity.erl
+++ b/src/aws_chime_sdk_identity.erl
@@ -2169,9 +2169,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
-    Host = build_host(<<"identity-chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"identity-chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME_SDK_IDENTITY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2255,7 +2257,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime_sdk_media_pipelines.erl
+++ b/src/aws_chime_sdk_media_pipelines.erl
@@ -2766,9 +2766,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
-    Host = build_host(<<"media-pipelines-chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"media-pipelines-chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME_SDK_MEDIA_PIPELINES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2852,7 +2854,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime_sdk_meetings.erl
+++ b/src/aws_chime_sdk_meetings.erl
@@ -1546,9 +1546,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
-    Host = build_host(<<"meetings-chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"meetings-chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME_SDK_MEETINGS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1632,7 +1634,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime_sdk_messaging.erl
+++ b/src/aws_chime_sdk_messaging.erl
@@ -4217,9 +4217,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
-    Host = build_host(<<"messaging-chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"messaging-chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME_SDK_MESSAGING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4303,7 +4305,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_chime_sdk_voice.erl
+++ b/src/aws_chime_sdk_voice.erl
@@ -6619,9 +6619,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"chime">>},
-    Host = build_host(<<"voice-chime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"voice-chime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CHIME_SDK_VOICE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6705,7 +6707,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cleanrooms.erl
+++ b/src/aws_cleanrooms.erl
@@ -7146,9 +7146,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cleanrooms">>},
-    Host = build_host(<<"cleanrooms">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cleanrooms">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLEANROOMS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7232,7 +7234,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cleanroomsml.erl
+++ b/src/aws_cleanroomsml.erl
@@ -4494,9 +4494,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cleanrooms-ml">>},
-    Host = build_host(<<"cleanrooms-ml">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cleanrooms-ml">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLEANROOMSML">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4580,7 +4582,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloud9.erl
+++ b/src/aws_cloud9.erl
@@ -803,8 +803,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloud9">>},
-    Host = build_host(<<"cloud9">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloud9">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUD9">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cloudcontrol.erl
+++ b/src/aws_cloudcontrol.erl
@@ -672,8 +672,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudcontrolapi">>},
-    Host = build_host(<<"cloudcontrolapi">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudcontrolapi">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDCONTROL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_clouddirectory.erl
+++ b/src/aws_clouddirectory.erl
@@ -5569,9 +5569,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"clouddirectory">>},
-    Host = build_host(<<"clouddirectory">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"clouddirectory">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLOUDDIRECTORY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5655,7 +5657,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloudformation.erl
+++ b/src/aws_cloudformation.erl
@@ -5603,8 +5603,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudformation">>},
-    Host = build_host(<<"cloudformation">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudformation">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDFORMATION">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_cloudfront.erl
+++ b/src/aws_cloudfront.erl
@@ -15744,9 +15744,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudfront">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"cloudfront">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cloudfront">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLOUDFRONT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"text/xml">>}
                          ],
@@ -15830,7 +15832,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloudfront_keyvaluestore.erl
+++ b/src/aws_cloudfront_keyvaluestore.erl
@@ -548,9 +548,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudfront-keyvaluestore">>},
-    Host = build_host(<<"cloudfront-keyvaluestore">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cloudfront-keyvaluestore">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLOUDFRONT_KEYVALUESTORE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -634,7 +636,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloudhsm.erl
+++ b/src/aws_cloudhsm.erl
@@ -1258,8 +1258,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
-    Host = build_host(<<"cloudhsm">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudhsm">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDHSM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cloudhsm_v2.erl
+++ b/src/aws_cloudhsm_v2.erl
@@ -1040,8 +1040,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
-    Host = build_host(<<"cloudhsmv2">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudhsmv2">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDHSM_V2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cloudsearch.erl
+++ b/src/aws_cloudsearch.erl
@@ -1539,8 +1539,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudsearch">>},
-    Host = build_host(<<"cloudsearch">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudsearch">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDSEARCH">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_cloudsearch_domain.erl
+++ b/src/aws_cloudsearch_domain.erl
@@ -435,9 +435,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudsearch">>},
-    Host = build_host(<<"cloudsearchdomain">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cloudsearchdomain">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLOUDSEARCH_DOMAIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -521,7 +523,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloudtrail.erl
+++ b/src/aws_cloudtrail.erl
@@ -4469,8 +4469,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cloudtrail">>},
-    Host = build_host(<<"cloudtrail">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cloudtrail">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDTRAIL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cloudtrail_data.erl
+++ b/src/aws_cloudtrail_data.erl
@@ -184,9 +184,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cloudtrail-data">>},
-    Host = build_host(<<"cloudtrail-data">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cloudtrail-data">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CLOUDTRAIL_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -270,7 +272,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cloudwatch.erl
+++ b/src/aws_cloudwatch.erl
@@ -3180,8 +3180,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"monitoring">>},
-    Host = build_host(<<"monitoring">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"monitoring">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDWATCH">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_cloudwatch_events.erl
+++ b/src/aws_cloudwatch_events.erl
@@ -3171,8 +3171,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"events">>},
-    Host = build_host(<<"events">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"events">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDWATCH_EVENTS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cloudwatch_logs.erl
+++ b/src/aws_cloudwatch_logs.erl
@@ -8019,8 +8019,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"logs">>},
-    Host = build_host(<<"logs">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"logs">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CLOUDWATCH_LOGS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_codeartifact.erl
+++ b/src/aws_codeartifact.erl
@@ -4332,9 +4332,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeartifact">>},
-    Host = build_host(<<"codeartifact">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codeartifact">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODEARTIFACT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4418,7 +4420,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_codebuild.erl
+++ b/src/aws_codebuild.erl
@@ -3251,8 +3251,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codebuild">>},
-    Host = build_host(<<"codebuild">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codebuild">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODEBUILD">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_codecatalyst.erl
+++ b/src/aws_codecatalyst.erl
@@ -2517,9 +2517,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codecatalyst">>,
                       region => <<"">>},
-    Host = build_host(<<"codecatalyst">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codecatalyst">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODECATALYST">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2603,7 +2605,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_codecommit.erl
+++ b/src/aws_codecommit.erl
@@ -6157,8 +6157,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codecommit">>},
-    Host = build_host(<<"codecommit">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codecommit">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODECOMMIT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_codeconnections.erl
+++ b/src/aws_codeconnections.erl
@@ -1487,8 +1487,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codeconnections">>},
-    Host = build_host(<<"codeconnections">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codeconnections">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODECONNECTIONS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_codedeploy.erl
+++ b/src/aws_codedeploy.erl
@@ -3355,8 +3355,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codedeploy">>},
-    Host = build_host(<<"codedeploy">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codedeploy">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODEDEPLOY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_codeguru_reviewer.erl
+++ b/src/aws_codeguru_reviewer.erl
@@ -1319,9 +1319,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeguru-reviewer">>},
-    Host = build_host(<<"codeguru-reviewer">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codeguru-reviewer">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODEGURU_REVIEWER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1405,7 +1407,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_codeguru_security.erl
+++ b/src/aws_codeguru_security.erl
@@ -1110,9 +1110,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeguru-security">>},
-    Host = build_host(<<"codeguru-security">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codeguru-security">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODEGURU_SECURITY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1196,7 +1198,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_codeguruprofiler.erl
+++ b/src/aws_codeguruprofiler.erl
@@ -1872,9 +1872,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codeguru-profiler">>},
-    Host = build_host(<<"codeguru-profiler">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codeguru-profiler">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODEGURUPROFILER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1958,7 +1960,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_codepipeline.erl
+++ b/src/aws_codepipeline.erl
@@ -3314,8 +3314,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codepipeline">>},
-    Host = build_host(<<"codepipeline">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codepipeline">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODEPIPELINE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_codestar_connections.erl
+++ b/src/aws_codestar_connections.erl
@@ -1485,8 +1485,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"codestar-connections">>},
-    Host = build_host(<<"codestar-connections">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"codestar-connections">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CODESTAR_CONNECTIONS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_codestar_notifications.erl
+++ b/src/aws_codestar_notifications.erl
@@ -972,9 +972,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"codestar-notifications">>},
-    Host = build_host(<<"codestar-notifications">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"codestar-notifications">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CODESTAR_NOTIFICATIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1058,7 +1060,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cognito_identity.erl
+++ b/src/aws_cognito_identity.erl
@@ -1313,8 +1313,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cognito-identity">>},
-    Host = build_host(<<"cognito-identity">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cognito-identity">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COGNITO_IDENTITY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cognito_identity_provider.erl
+++ b/src/aws_cognito_identity_provider.erl
@@ -9474,8 +9474,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cognito-idp">>},
-    Host = build_host(<<"cognito-idp">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cognito-idp">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COGNITO_IDENTITY_PROVIDER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cognito_sync.erl
+++ b/src/aws_cognito_sync.erl
@@ -1851,9 +1851,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cognito-sync">>},
-    Host = build_host(<<"cognito-sync">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cognito-sync">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_COGNITO_SYNC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1937,7 +1939,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_comprehend.erl
+++ b/src/aws_comprehend.erl
@@ -5068,8 +5068,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"comprehend">>},
-    Host = build_host(<<"comprehend">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"comprehend">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COMPREHEND">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_comprehendmedical.erl
+++ b/src/aws_comprehendmedical.erl
@@ -1440,8 +1440,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"comprehendmedical">>},
-    Host = build_host(<<"comprehendmedical">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"comprehendmedical">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COMPREHENDMEDICAL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_compute_optimizer.erl
+++ b/src/aws_compute_optimizer.erl
@@ -2613,8 +2613,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"compute-optimizer">>},
-    Host = build_host(<<"compute-optimizer">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"compute-optimizer">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COMPUTE_OPTIMIZER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_compute_optimizer_automation.erl
+++ b/src/aws_compute_optimizer_automation.erl
@@ -1533,8 +1533,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aco-automation">>},
-    Host = build_host(<<"aco-automation">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"aco-automation">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COMPUTE_OPTIMIZER_AUTOMATION">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -6378,8 +6378,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"config">>},
-    Host = build_host(<<"config">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"config">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_CONFIG">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_connect.erl
+++ b/src/aws_connect.erl
@@ -29900,9 +29900,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect">>},
-    Host = build_host(<<"connect">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"connect">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -29986,7 +29988,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connect_contact_lens.erl
+++ b/src/aws_connect_contact_lens.erl
@@ -225,9 +225,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect">>},
-    Host = build_host(<<"contact-lens">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"contact-lens">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECT_CONTACT_LENS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -311,7 +313,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connectcampaigns.erl
+++ b/src/aws_connectcampaigns.erl
@@ -1446,9 +1446,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect-campaigns">>},
-    Host = build_host(<<"connect-campaigns">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"connect-campaigns">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECTCAMPAIGNS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1532,7 +1534,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connectcampaignsv2.erl
+++ b/src/aws_connectcampaignsv2.erl
@@ -2591,9 +2591,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"connect-campaigns">>},
-    Host = build_host(<<"connect-campaigns">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"connect-campaigns">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECTCAMPAIGNSV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2677,7 +2679,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connectcases.erl
+++ b/src/aws_connectcases.erl
@@ -3529,9 +3529,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"cases">>},
-    Host = build_host(<<"cases">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"cases">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECTCASES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3615,7 +3617,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connecthealth.erl
+++ b/src/aws_connecthealth.erl
@@ -1329,9 +1329,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"health-agent">>},
-    Host = build_host(<<"health-agent">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"health-agent">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECTHEALTH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1415,7 +1417,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_connectparticipant.erl
+++ b/src/aws_connectparticipant.erl
@@ -1205,9 +1205,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"execute-api">>},
-    Host = build_host(<<"participant.connect">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"participant.connect">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONNECTPARTICIPANT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1291,7 +1293,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_controlcatalog.erl
+++ b/src/aws_controlcatalog.erl
@@ -682,9 +682,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"controlcatalog">>},
-    Host = build_host(<<"controlcatalog">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"controlcatalog">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONTROLCATALOG">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -768,7 +770,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_controltower.erl
+++ b/src/aws_controltower.erl
@@ -2437,9 +2437,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"controltower">>},
-    Host = build_host(<<"controltower">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"controltower">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CONTROLTOWER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2523,7 +2525,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_cost_and_usage_report.erl
+++ b/src/aws_cost_and_usage_report.erl
@@ -371,8 +371,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cur">>},
-    Host = build_host(<<"cur">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cur">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COST_AND_USAGE_REPORT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cost_explorer.erl
+++ b/src/aws_cost_explorer.erl
@@ -3388,8 +3388,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ce">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"ce">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ce">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COST_EXPLORER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_cost_optimization_hub.erl
+++ b/src/aws_cost_optimization_hub.erl
@@ -1036,8 +1036,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cost-optimization-hub">>},
-    Host = build_host(<<"cost-optimization-hub">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cost-optimization-hub">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_COST_OPTIMIZATION_HUB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_customer_profiles.erl
+++ b/src/aws_customer_profiles.erl
@@ -8640,9 +8640,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"profile">>},
-    Host = build_host(<<"profile">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"profile">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_CUSTOMER_PROFILES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8726,7 +8728,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -1739,8 +1739,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"datapipeline">>},
-    Host = build_host(<<"datapipeline">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"datapipeline">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DATA_PIPELINE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_database_migration.erl
+++ b/src/aws_database_migration.erl
@@ -7001,8 +7001,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dms">>},
-    Host = build_host(<<"dms">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"dms">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DATABASE_MIGRATION">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_databrew.erl
+++ b/src/aws_databrew.erl
@@ -3286,9 +3286,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"databrew">>},
-    Host = build_host(<<"databrew">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"databrew">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DATABREW">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3372,7 +3374,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_dataexchange.erl
+++ b/src/aws_dataexchange.erl
@@ -3106,9 +3106,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"dataexchange">>},
-    Host = build_host(<<"dataexchange">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"dataexchange">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DATAEXCHANGE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3192,7 +3194,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_datasync.erl
+++ b/src/aws_datasync.erl
@@ -2925,8 +2925,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"datasync">>},
-    Host = build_host(<<"datasync">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"datasync">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DATASYNC">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_datazone.erl
+++ b/src/aws_datazone.erl
@@ -16450,9 +16450,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"datazone">>},
-    Host = build_host(<<"datazone">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"datazone">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DATAZONE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -16536,7 +16538,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_dax.erl
+++ b/src/aws_dax.erl
@@ -1302,8 +1302,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dax">>},
-    Host = build_host(<<"dax">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"dax">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DAX">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_deadline.erl
+++ b/src/aws_deadline.erl
@@ -9732,9 +9732,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"deadline">>},
-    Host = build_host(<<"deadline">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"deadline">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DEADLINE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -9818,7 +9820,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_detective.erl
+++ b/src/aws_detective.erl
@@ -2268,9 +2268,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"detective">>},
-    Host = build_host(<<"api.detective">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"api.detective">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DETECTIVE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2354,7 +2356,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_device_farm.erl
+++ b/src/aws_device_farm.erl
@@ -3845,8 +3845,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"devicefarm">>},
-    Host = build_host(<<"devicefarm">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"devicefarm">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DEVICE_FARM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_devops_agent.erl
+++ b/src/aws_devops_agent.erl
@@ -3617,9 +3617,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aidevops">>},
-    Host = build_host(<<"aidevops">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"aidevops">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DEVOPS_AGENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3703,7 +3705,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_devops_guru.erl
+++ b/src/aws_devops_guru.erl
@@ -2986,9 +2986,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"devops-guru">>},
-    Host = build_host(<<"devops-guru">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"devops-guru">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DEVOPS_GURU">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3072,7 +3074,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -3248,8 +3248,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"directconnect">>},
-    Host = build_host(<<"directconnect">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"directconnect">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DIRECT_CONNECT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_directory.erl
+++ b/src/aws_directory.erl
@@ -4505,8 +4505,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ds">>},
-    Host = build_host(<<"ds">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ds">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DIRECTORY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_directory_service_data.erl
+++ b/src/aws_directory_service_data.erl
@@ -1401,9 +1401,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ds-data">>},
-    Host = build_host(<<"ds-data">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ds-data">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DIRECTORY_SERVICE_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1487,7 +1489,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_dlm.erl
+++ b/src/aws_dlm.erl
@@ -845,9 +845,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"dlm">>},
-    Host = build_host(<<"dlm">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"dlm">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DLM">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -931,7 +933,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_docdb.erl
+++ b/src/aws_docdb.erl
@@ -3311,8 +3311,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
-    Host = build_host(<<"rds">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"rds">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DOCDB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_docdb_elastic.erl
+++ b/src/aws_docdb_elastic.erl
@@ -1368,9 +1368,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"docdb-elastic">>},
-    Host = build_host(<<"docdb-elastic">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"docdb-elastic">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DOCDB_ELASTIC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1454,7 +1456,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_drs.erl
+++ b/src/aws_drs.erl
@@ -3762,9 +3762,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"drs">>},
-    Host = build_host(<<"drs">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"drs">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DRS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3848,7 +3850,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_dsql.erl
+++ b/src/aws_dsql.erl
@@ -1242,9 +1242,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"dsql">>},
-    Host = build_host(<<"dsql">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"dsql">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_DSQL">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1328,7 +1330,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_dynamodb.erl
+++ b/src/aws_dynamodb.erl
@@ -4973,8 +4973,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
-    Host = build_host(<<"dynamodb">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"dynamodb">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DYNAMODB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_dynamodb_streams.erl
+++ b/src/aws_dynamodb_streams.erl
@@ -351,8 +351,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
-    Host = build_host(<<"streams.dynamodb">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"streams.dynamodb">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_DYNAMODB_STREAMS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_ebs.erl
+++ b/src/aws_ebs.erl
@@ -694,9 +694,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ebs">>},
-    Host = build_host(<<"ebs">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ebs">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EBS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -780,7 +782,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ec2.erl
+++ b/src/aws_ec2.erl
@@ -41644,8 +41644,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, _Action, Input0, Options) ->
     Client1 = Client#{service => <<"ec2">>},
-    Host = build_host(<<"ec2">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ec2">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_EC2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_ec2_instance_connect.erl
+++ b/src/aws_ec2_instance_connect.erl
@@ -225,8 +225,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ec2-instance-connect">>},
-    Host = build_host(<<"ec2-instance-connect">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ec2-instance-connect">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_EC2_INSTANCE_CONNECT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ecr.erl
+++ b/src/aws_ecr.erl
@@ -3540,8 +3540,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecr">>},
-    Host = build_host(<<"api.ecr">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"api.ecr">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ECR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ecr_public.erl
+++ b/src/aws_ecr_public.erl
@@ -1392,8 +1392,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecr-public">>},
-    Host = build_host(<<"api.ecr-public">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"api.ecr-public">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ECR_PUBLIC">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -6597,8 +6597,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ecs">>},
-    Host = build_host(<<"ecs">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ecs">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ECS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_efs.erl
+++ b/src/aws_efs.erl
@@ -2912,9 +2912,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"elasticfilesystem">>},
-    Host = build_host(<<"elasticfilesystem">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"elasticfilesystem">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EFS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2998,7 +3000,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_eks.erl
+++ b/src/aws_eks.erl
@@ -5869,9 +5869,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"eks">>},
-    Host = build_host(<<"eks">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"eks">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EKS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5955,7 +5957,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_eks_auth.erl
+++ b/src/aws_eks_auth.erl
@@ -207,9 +207,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"eks-auth">>},
-    Host = build_host(<<"eks-auth">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"eks-auth">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EKS_AUTH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -293,7 +295,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_elastic_beanstalk.erl
+++ b/src/aws_elastic_beanstalk.erl
@@ -2574,8 +2574,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticbeanstalk">>},
-    Host = build_host(<<"elasticbeanstalk">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"elasticbeanstalk">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ELASTIC_BEANSTALK">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_elastic_load_balancing.erl
+++ b/src/aws_elastic_load_balancing.erl
@@ -1767,8 +1767,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticloadbalancing">>},
-    Host = build_host(<<"elasticloadbalancing">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"elasticloadbalancing">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ELASTIC_LOAD_BALANCING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_elastic_load_balancing_v2.erl
+++ b/src/aws_elastic_load_balancing_v2.erl
@@ -3272,8 +3272,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticloadbalancing">>},
-    Host = build_host(<<"elasticloadbalancing">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"elasticloadbalancing">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ELASTIC_LOAD_BALANCING_V2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_elasticache.erl
+++ b/src/aws_elasticache.erl
@@ -5104,8 +5104,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticache">>},
-    Host = build_host(<<"elasticache">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"elasticache">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ELASTICACHE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_elasticsearch.erl
+++ b/src/aws_elasticsearch.erl
@@ -4119,9 +4119,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"es">>},
-    Host = build_host(<<"es">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"es">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ELASTICSEARCH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4205,7 +4207,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_elementalinference.erl
+++ b/src/aws_elementalinference.erl
@@ -1233,9 +1233,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"elemental-inference">>},
-    Host = build_host(<<"elemental-inference">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"elemental-inference">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ELEMENTALINFERENCE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1319,7 +1321,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -3660,8 +3660,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"elasticmapreduce">>},
-    Host = build_host(<<"elasticmapreduce">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"elasticmapreduce">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_EMR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_emr_containers.erl
+++ b/src/aws_emr_containers.erl
@@ -1942,9 +1942,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"emr-containers">>},
-    Host = build_host(<<"emr-containers">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"emr-containers">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EMR_CONTAINERS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2028,7 +2030,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_emr_serverless.erl
+++ b/src/aws_emr_serverless.erl
@@ -1903,9 +1903,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"emr-serverless">>},
-    Host = build_host(<<"emr-serverless">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"emr-serverless">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_EMR_SERVERLESS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1989,7 +1991,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_entityresolution.erl
+++ b/src/aws_entityresolution.erl
@@ -3027,9 +3027,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"entityresolution">>},
-    Host = build_host(<<"entityresolution">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"entityresolution">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ENTITYRESOLUTION">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3113,7 +3115,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_eventbridge.erl
+++ b/src/aws_eventbridge.erl
@@ -3663,8 +3663,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"events">>},
-    Host = build_host(<<"events">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"events">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_EVENTBRIDGE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_evs.erl
+++ b/src/aws_evs.erl
@@ -1259,8 +1259,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"evs">>},
-    Host = build_host(<<"evs">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"evs">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_EVS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_finspace.erl
+++ b/src/aws_finspace.erl
@@ -3883,9 +3883,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"finspace">>},
-    Host = build_host(<<"finspace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"finspace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_FINSPACE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3969,7 +3971,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_finspace_data.erl
+++ b/src/aws_finspace_data.erl
@@ -2293,9 +2293,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"finspace-api">>},
-    Host = build_host(<<"finspace-api">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"finspace-api">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_FINSPACE_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2379,7 +2381,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_firehose.erl
+++ b/src/aws_firehose.erl
@@ -2164,8 +2164,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"firehose">>},
-    Host = build_host(<<"firehose">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"firehose">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FIREHOSE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_fis.erl
+++ b/src/aws_fis.erl
@@ -2241,9 +2241,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"fis">>},
-    Host = build_host(<<"fis">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"fis">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_FIS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2327,7 +2329,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_fms.erl
+++ b/src/aws_fms.erl
@@ -2660,8 +2660,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"fms">>},
-    Host = build_host(<<"fms">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"fms">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FMS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_forecast.erl
+++ b/src/aws_forecast.erl
@@ -3994,8 +3994,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"forecast">>},
-    Host = build_host(<<"forecast">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"forecast">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FORECAST">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_forecastquery.erl
+++ b/src/aws_forecastquery.erl
@@ -175,8 +175,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"forecast">>},
-    Host = build_host(<<"forecastquery">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"forecastquery">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FORECASTQUERY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_frauddetector.erl
+++ b/src/aws_frauddetector.erl
@@ -4028,8 +4028,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"frauddetector">>},
-    Host = build_host(<<"frauddetector">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"frauddetector">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FRAUDDETECTOR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_freetier.erl
+++ b/src/aws_freetier.erl
@@ -331,8 +331,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"freetier">>},
-    Host = build_host(<<"freetier">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"freetier">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FREETIER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_fsx.erl
+++ b/src/aws_fsx.erl
@@ -4413,8 +4413,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"fsx">>},
-    Host = build_host(<<"fsx">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"fsx">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_FSX">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_gamelift.erl
+++ b/src/aws_gamelift.erl
@@ -10255,8 +10255,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"gamelift">>},
-    Host = build_host(<<"gamelift">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"gamelift">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_GAMELIFT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_gameliftstreams.erl
+++ b/src/aws_gameliftstreams.erl
@@ -2199,9 +2199,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"gameliftstreams">>},
-    Host = build_host(<<"gameliftstreams">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"gameliftstreams">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GAMELIFTSTREAMS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2285,7 +2287,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_geo_maps.erl
+++ b/src/aws_geo_maps.erl
@@ -580,9 +580,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"geo-maps">>},
-    Host = build_host(<<"geo-maps">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"geo-maps">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GEO_MAPS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -666,7 +668,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_geo_places.erl
+++ b/src/aws_geo_places.erl
@@ -1422,9 +1422,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"geo-places">>},
-    Host = build_host(<<"geo-places">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"geo-places">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GEO_PLACES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1508,7 +1510,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_geo_routes.erl
+++ b/src/aws_geo_routes.erl
@@ -2369,9 +2369,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"geo-routes">>},
-    Host = build_host(<<"geo-routes">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"geo-routes">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GEO_ROUTES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2455,7 +2457,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_glacier.erl
+++ b/src/aws_glacier.erl
@@ -3435,9 +3435,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"glacier">>},
-    Host = build_host(<<"glacier">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"glacier">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GLACIER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3521,7 +3523,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_global_accelerator.erl
+++ b/src/aws_global_accelerator.erl
@@ -3033,8 +3033,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"globalaccelerator">>},
-    Host = build_host(<<"globalaccelerator">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"globalaccelerator">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_GLOBAL_ACCELERATOR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_glue.erl
+++ b/src/aws_glue.erl
@@ -16536,8 +16536,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"glue">>},
-    Host = build_host(<<"glue">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"glue">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_GLUE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_grafana.erl
+++ b/src/aws_grafana.erl
@@ -1982,9 +1982,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"grafana">>},
-    Host = build_host(<<"grafana">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"grafana">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GRAFANA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2068,7 +2070,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_greengrass.erl
+++ b/src/aws_greengrass.erl
@@ -5847,9 +5847,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"greengrass">>},
-    Host = build_host(<<"greengrass">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"greengrass">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GREENGRASS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5933,7 +5935,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_greengrassv2.erl
+++ b/src/aws_greengrassv2.erl
@@ -2603,9 +2603,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"greengrass">>},
-    Host = build_host(<<"greengrass">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"greengrass">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GREENGRASSV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2689,7 +2691,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_groundstation.erl
+++ b/src/aws_groundstation.erl
@@ -3173,9 +3173,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"groundstation">>},
-    Host = build_host(<<"groundstation">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"groundstation">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GROUNDSTATION">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3259,7 +3261,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_guardduty.erl
+++ b/src/aws_guardduty.erl
@@ -7885,9 +7885,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"guardduty">>},
-    Host = build_host(<<"guardduty">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"guardduty">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_GUARDDUTY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7971,7 +7973,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_health.erl
+++ b/src/aws_health.erl
@@ -1110,8 +1110,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"health">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"health">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"health">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_HEALTH">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_healthlake.erl
+++ b/src/aws_healthlake.erl
@@ -725,8 +725,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"healthlake">>},
-    Host = build_host(<<"healthlake">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"healthlake">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_HEALTHLAKE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_iam.erl
+++ b/src/aws_iam.erl
@@ -10410,8 +10410,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"iam">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"iam">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"iam">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_IAM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_identitystore.erl
+++ b/src/aws_identitystore.erl
@@ -1118,8 +1118,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"identitystore">>},
-    Host = build_host(<<"identitystore">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"identitystore">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_IDENTITYSTORE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_imagebuilder.erl
+++ b/src/aws_imagebuilder.erl
@@ -6648,9 +6648,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"imagebuilder">>},
-    Host = build_host(<<"imagebuilder">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"imagebuilder">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IMAGEBUILDER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6734,7 +6736,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_inspector.erl
+++ b/src/aws_inspector.erl
@@ -1948,8 +1948,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"inspector">>},
-    Host = build_host(<<"inspector">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"inspector">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_INSPECTOR">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_inspector2.erl
+++ b/src/aws_inspector2.erl
@@ -6429,9 +6429,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"inspector2">>},
-    Host = build_host(<<"inspector2">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"inspector2">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_INSPECTOR2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6515,7 +6517,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_inspector_scan.erl
+++ b/src/aws_inspector_scan.erl
@@ -144,9 +144,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"inspector-scan">>},
-    Host = build_host(<<"inspector-scan">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"inspector-scan">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_INSPECTOR_SCAN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -230,7 +232,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_interconnect.erl
+++ b/src/aws_interconnect.erl
@@ -595,8 +595,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"interconnect">>},
-    Host = build_host(<<"interconnect">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"interconnect">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_INTERCONNECT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_internetmonitor.erl
+++ b/src/aws_internetmonitor.erl
@@ -1490,9 +1490,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"internetmonitor">>},
-    Host = build_host(<<"internetmonitor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"internetmonitor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_INTERNETMONITOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1576,7 +1578,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_invoicing.erl
+++ b/src/aws_invoicing.erl
@@ -1236,8 +1236,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"invoicing">>},
-    Host = build_host(<<"invoicing">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"invoicing">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_INVOICING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_iot.erl
+++ b/src/aws_iot.erl
@@ -21105,9 +21105,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iot">>},
-    Host = build_host(<<"iot">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"iot">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -21191,7 +21193,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_data_plane.erl
+++ b/src/aws_iot_data_plane.erl
@@ -1006,9 +1006,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotdata">>},
-    Host = build_host(<<"data-ats.iot">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data-ats.iot">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_DATA_PLANE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1092,7 +1094,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_events.erl
+++ b/src/aws_iot_events.erl
@@ -2334,9 +2334,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotevents">>},
-    Host = build_host(<<"iotevents">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"iotevents">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_EVENTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2420,7 +2422,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_events_data.erl
+++ b/src/aws_iot_events_data.erl
@@ -1149,9 +1149,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ioteventsdata">>},
-    Host = build_host(<<"data.iotevents">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data.iotevents">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_EVENTS_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1235,7 +1237,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_jobs_data_plane.erl
+++ b/src/aws_iot_jobs_data_plane.erl
@@ -536,9 +536,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iot-jobs-data">>},
-    Host = build_host(<<"data.jobs.iot">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data.jobs.iot">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_JOBS_DATA_PLANE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -622,7 +624,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_managed_integrations.erl
+++ b/src/aws_iot_managed_integrations.erl
@@ -5915,9 +5915,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotmanagedintegrations">>},
-    Host = build_host(<<"api.iotmanagedintegrations">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"api.iotmanagedintegrations">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_MANAGED_INTEGRATIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6001,7 +6003,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iot_wireless.erl
+++ b/src/aws_iot_wireless.erl
@@ -8261,9 +8261,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotwireless">>},
-    Host = build_host(<<"api.iotwireless">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"api.iotwireless">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOT_WIRELESS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8347,7 +8349,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iotdeviceadvisor.erl
+++ b/src/aws_iotdeviceadvisor.erl
@@ -1070,9 +1070,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotdeviceadvisor">>},
-    Host = build_host(<<"api.iotdeviceadvisor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"api.iotdeviceadvisor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOTDEVICEADVISOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1156,7 +1158,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iotfleetwise.erl
+++ b/src/aws_iotfleetwise.erl
@@ -3362,8 +3362,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"iotfleetwise">>},
-    Host = build_host(<<"iotfleetwise">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"iotfleetwise">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_IOTFLEETWISE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_iotsecuretunneling.erl
+++ b/src/aws_iotsecuretunneling.erl
@@ -422,8 +422,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"IoTSecuredTunneling">>},
-    Host = build_host(<<"api.tunneling.iot">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"api.tunneling.iot">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_IOTSECURETUNNELING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_iotsitewise.erl
+++ b/src/aws_iotsitewise.erl
@@ -8880,9 +8880,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iotsitewise">>},
-    Host = build_host(<<"iotsitewise">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"iotsitewise">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOTSITEWISE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8966,7 +8968,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_iotthingsgraph.erl
+++ b/src/aws_iotthingsgraph.erl
@@ -1781,8 +1781,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"iotthingsgraph">>},
-    Host = build_host(<<"iotthingsgraph">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"iotthingsgraph">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_IOTTHINGSGRAPH">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_iottwinmaker.erl
+++ b/src/aws_iottwinmaker.erl
@@ -3234,9 +3234,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"iottwinmaker">>},
-    Host = build_host(<<"iottwinmaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"iottwinmaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IOTTWINMAKER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3320,7 +3322,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ivs.erl
+++ b/src/aws_ivs.erl
@@ -3121,9 +3121,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ivs">>},
-    Host = build_host(<<"ivs">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ivs">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IVS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3207,7 +3209,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ivs_realtime.erl
+++ b/src/aws_ivs_realtime.erl
@@ -3055,9 +3055,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ivs">>},
-    Host = build_host(<<"ivsrealtime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ivsrealtime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IVS_REALTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3141,7 +3143,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ivschat.erl
+++ b/src/aws_ivschat.erl
@@ -1362,9 +1362,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ivschat">>},
-    Host = build_host(<<"ivschat">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ivschat">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_IVSCHAT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1448,7 +1450,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kafka.erl
+++ b/src/aws_kafka.erl
@@ -4877,9 +4877,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kafka">>},
-    Host = build_host(<<"kafka">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kafka">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KAFKA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4963,7 +4965,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kafkaconnect.erl
+++ b/src/aws_kafkaconnect.erl
@@ -1766,9 +1766,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kafkaconnect">>},
-    Host = build_host(<<"kafkaconnect">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kafkaconnect">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KAFKACONNECT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1852,7 +1854,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kendra.erl
+++ b/src/aws_kendra.erl
@@ -4918,8 +4918,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kendra">>},
-    Host = build_host(<<"kendra">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kendra">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KENDRA">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_kendra_ranking.erl
+++ b/src/aws_kendra_ranking.erl
@@ -526,8 +526,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kendra-ranking">>},
-    Host = build_host(<<"kendra-ranking">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kendra-ranking">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KENDRA_RANKING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_keyspaces.erl
+++ b/src/aws_keyspaces.erl
@@ -1373,8 +1373,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cassandra">>},
-    Host = build_host(<<"cassandra">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cassandra">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KEYSPACES">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_keyspacesstreams.erl
+++ b/src/aws_keyspacesstreams.erl
@@ -356,8 +356,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"cassandra">>},
-    Host = build_host(<<"cassandra-streams">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"cassandra-streams">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KEYSPACESSTREAMS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_kinesis.erl
+++ b/src/aws_kinesis.erl
@@ -2953,8 +2953,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesis">>},
-    Host = build_host(<<"kinesis">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kinesis">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KINESIS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_kinesis_analytics.erl
+++ b/src/aws_kinesis_analytics.erl
@@ -1692,8 +1692,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesisanalytics">>},
-    Host = build_host(<<"kinesisanalytics">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kinesisanalytics">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KINESIS_ANALYTICS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_kinesis_analytics_v2.erl
+++ b/src/aws_kinesis_analytics_v2.erl
@@ -2709,8 +2709,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kinesisanalytics">>},
-    Host = build_host(<<"kinesisanalytics">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kinesisanalytics">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KINESIS_ANALYTICS_V2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_kinesis_video.erl
+++ b/src/aws_kinesis_video.erl
@@ -2513,9 +2513,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
-    Host = build_host(<<"kinesisvideo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kinesisvideo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KINESIS_VIDEO">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2599,7 +2601,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kinesis_video_archived_media.erl
+++ b/src/aws_kinesis_video_archived_media.erl
@@ -1095,9 +1095,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
-    Host = build_host(<<"kinesisvideo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kinesisvideo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KINESIS_VIDEO_ARCHIVED_MEDIA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1181,7 +1183,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kinesis_video_media.erl
+++ b/src/aws_kinesis_video_media.erl
@@ -214,9 +214,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
-    Host = build_host(<<"kinesisvideo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kinesisvideo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KINESIS_VIDEO_MEDIA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -300,7 +302,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kinesis_video_signaling.erl
+++ b/src/aws_kinesis_video_signaling.erl
@@ -249,9 +249,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
-    Host = build_host(<<"kinesisvideo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kinesisvideo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KINESIS_VIDEO_SIGNALING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -335,7 +337,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kinesis_video_webrtc_storage.erl
+++ b/src/aws_kinesis_video_webrtc_storage.erl
@@ -242,9 +242,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"kinesisvideo">>},
-    Host = build_host(<<"kinesisvideo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"kinesisvideo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_KINESIS_VIDEO_WEBRTC_STORAGE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -328,7 +330,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_kms.erl
+++ b/src/aws_kms.erl
@@ -7078,8 +7078,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"kms">>},
-    Host = build_host(<<"kms">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"kms">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_KMS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_lakeformation.erl
+++ b/src/aws_lakeformation.erl
@@ -4483,9 +4483,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lakeformation">>},
-    Host = build_host(<<"lakeformation">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"lakeformation">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LAKEFORMATION">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4569,7 +4571,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lambda.erl
+++ b/src/aws_lambda.erl
@@ -7530,9 +7530,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lambda">>},
-    Host = build_host(<<"lambda">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"lambda">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LAMBDA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7616,7 +7618,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_launch_wizard.erl
+++ b/src/aws_launch_wizard.erl
@@ -1079,9 +1079,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"launchwizard">>},
-    Host = build_host(<<"launchwizard">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"launchwizard">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LAUNCH_WIZARD">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1165,7 +1167,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lex_model_building.erl
+++ b/src/aws_lex_model_building.erl
@@ -3552,9 +3552,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
-    Host = build_host(<<"models.lex">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"models.lex">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LEX_MODEL_BUILDING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3638,7 +3640,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lex_models_v2.erl
+++ b/src/aws_lex_models_v2.erl
@@ -9796,9 +9796,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
-    Host = build_host(<<"models-v2-lex">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"models-v2-lex">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LEX_MODELS_V2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -9882,7 +9884,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lex_runtime.erl
+++ b/src/aws_lex_runtime.erl
@@ -784,9 +784,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
-    Host = build_host(<<"runtime.lex">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"runtime.lex">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LEX_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -870,7 +872,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lex_runtime_v2.erl
+++ b/src/aws_lex_runtime_v2.erl
@@ -980,9 +980,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"lex">>},
-    Host = build_host(<<"runtime-v2-lex">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"runtime-v2-lex">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LEX_RUNTIME_V2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1066,7 +1068,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_license_manager.erl
+++ b/src/aws_license_manager.erl
@@ -3448,8 +3448,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"license-manager">>},
-    Host = build_host(<<"license-manager">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"license-manager">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_LICENSE_MANAGER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_license_manager_linux_subscriptions.erl
+++ b/src/aws_license_manager_linux_subscriptions.erl
@@ -762,9 +762,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"license-manager-linux-subscriptions">>},
-    Host = build_host(<<"license-manager-linux-subscriptions">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"license-manager-linux-subscriptions">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LICENSE_MANAGER_LINUX_SUBSCRIPTIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -848,7 +850,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_license_manager_user_subscriptions.erl
+++ b/src/aws_license_manager_user_subscriptions.erl
@@ -1302,9 +1302,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"license-manager-user-subscriptions">>},
-    Host = build_host(<<"license-manager-user-subscriptions">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"license-manager-user-subscriptions">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LICENSE_MANAGER_USER_SUBSCRIPTIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1388,7 +1390,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lightsail.erl
+++ b/src/aws_lightsail.erl
@@ -9553,8 +9553,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"lightsail">>},
-    Host = build_host(<<"lightsail">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"lightsail">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_LIGHTSAIL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_location.erl
+++ b/src/aws_location.erl
@@ -5672,9 +5672,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"geo">>},
-    Host = build_host(<<"geo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"geo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_LOCATION">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5758,7 +5760,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_lookoutequipment.erl
+++ b/src/aws_lookoutequipment.erl
@@ -2652,8 +2652,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"lookoutequipment">>},
-    Host = build_host(<<"lookoutequipment">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"lookoutequipment">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_LOOKOUTEQUIPMENT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_m2.erl
+++ b/src/aws_m2.erl
@@ -2938,9 +2938,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"m2">>},
-    Host = build_host(<<"m2">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"m2">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_M2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3024,7 +3026,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_machine_learning.erl
+++ b/src/aws_machine_learning.erl
@@ -1700,8 +1700,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"machinelearning">>},
-    Host = build_host(<<"machinelearning">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"machinelearning">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MACHINE_LEARNING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_macie2.erl
+++ b/src/aws_macie2.erl
@@ -6406,9 +6406,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"macie2">>},
-    Host = build_host(<<"macie2">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"macie2">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MACIE2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6492,7 +6494,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mailmanager.erl
+++ b/src/aws_mailmanager.erl
@@ -2954,8 +2954,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ses">>},
-    Host = build_host(<<"mail-manager">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"mail-manager">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MAILMANAGER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_managedblockchain.erl
+++ b/src/aws_managedblockchain.erl
@@ -2257,9 +2257,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"managedblockchain">>},
-    Host = build_host(<<"managedblockchain">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"managedblockchain">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MANAGEDBLOCKCHAIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2343,7 +2345,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_managedblockchain_query.erl
+++ b/src/aws_managedblockchain_query.erl
@@ -932,9 +932,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"managedblockchain-query">>},
-    Host = build_host(<<"managedblockchain-query">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"managedblockchain-query">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MANAGEDBLOCKCHAIN_QUERY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1018,7 +1020,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_marketplace_agreement.erl
+++ b/src/aws_marketplace_agreement.erl
@@ -1979,8 +1979,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"agreement-marketplace">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"agreement-marketplace">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_AGREEMENT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_marketplace_catalog.erl
+++ b/src/aws_marketplace_catalog.erl
@@ -1826,9 +1826,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"catalog.marketplace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"catalog.marketplace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_CATALOG">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1912,7 +1914,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_marketplace_commerce_analytics.erl
+++ b/src/aws_marketplace_commerce_analytics.erl
@@ -145,8 +145,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"marketplacecommerceanalytics">>},
-    Host = build_host(<<"marketplacecommerceanalytics">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"marketplacecommerceanalytics">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_COMMERCE_ANALYTICS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_marketplace_deployment.erl
+++ b/src/aws_marketplace_deployment.erl
@@ -339,9 +339,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"deployment-marketplace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"deployment-marketplace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_DEPLOYMENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -425,7 +427,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_marketplace_discovery.erl
+++ b/src/aws_marketplace_discovery.erl
@@ -1324,9 +1324,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"discovery-marketplace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"discovery-marketplace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_DISCOVERY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1410,7 +1412,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_marketplace_entitlement.erl
+++ b/src/aws_marketplace_entitlement.erl
@@ -128,8 +128,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"entitlement.marketplace">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"entitlement.marketplace">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_ENTITLEMENT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_marketplace_metering.erl
+++ b/src/aws_marketplace_metering.erl
@@ -678,8 +678,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"metering.marketplace">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"metering.marketplace">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_METERING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_marketplace_reporting.erl
+++ b/src/aws_marketplace_reporting.erl
@@ -213,9 +213,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"aws-marketplace">>},
-    Host = build_host(<<"reporting-marketplace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"reporting-marketplace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MARKETPLACE_REPORTING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -299,7 +301,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediaconnect.erl
+++ b/src/aws_mediaconnect.erl
@@ -6831,9 +6831,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediaconnect">>},
-    Host = build_host(<<"mediaconnect">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mediaconnect">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIACONNECT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6917,7 +6919,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediaconvert.erl
+++ b/src/aws_mediaconvert.erl
@@ -4910,9 +4910,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediaconvert">>},
-    Host = build_host(<<"mediaconvert">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mediaconvert">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIACONVERT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4996,7 +4998,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_medialive.erl
+++ b/src/aws_medialive.erl
@@ -11988,9 +11988,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"medialive">>},
-    Host = build_host(<<"medialive">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"medialive">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIALIVE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -12074,7 +12076,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediapackage.erl
+++ b/src/aws_mediapackage.erl
@@ -1569,9 +1569,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediapackage">>},
-    Host = build_host(<<"mediapackage">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mediapackage">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIAPACKAGE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1655,7 +1657,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediapackage_vod.erl
+++ b/src/aws_mediapackage_vod.erl
@@ -1324,9 +1324,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediapackage-vod">>},
-    Host = build_host(<<"mediapackage-vod">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mediapackage-vod">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIAPACKAGE_VOD">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1410,7 +1412,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediapackagev2.erl
+++ b/src/aws_mediapackagev2.erl
@@ -2618,9 +2618,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediapackagev2">>},
-    Host = build_host(<<"mediapackagev2">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mediapackagev2">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIAPACKAGEV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2704,7 +2706,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediastore.erl
+++ b/src/aws_mediastore.erl
@@ -1004,8 +1004,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mediastore">>},
-    Host = build_host(<<"mediastore">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"mediastore">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MEDIASTORE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_mediastore_data.erl
+++ b/src/aws_mediastore_data.erl
@@ -439,9 +439,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediastore">>},
-    Host = build_host(<<"data.mediastore">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data.mediastore">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIASTORE_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -525,7 +527,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mediatailor.erl
+++ b/src/aws_mediatailor.erl
@@ -3408,9 +3408,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mediatailor">>},
-    Host = build_host(<<"api.mediatailor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"api.mediatailor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDIATAILOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3494,7 +3496,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_medical_imaging.erl
+++ b/src/aws_medical_imaging.erl
@@ -1524,9 +1524,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"medical-imaging">>},
-    Host = build_host(<<"medical-imaging">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"medical-imaging">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MEDICAL_IMAGING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1610,7 +1612,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_memorydb.erl
+++ b/src/aws_memorydb.erl
@@ -2834,8 +2834,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"memorydb">>},
-    Host = build_host(<<"memory-db">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"memory-db">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MEMORYDB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_mgn.erl
+++ b/src/aws_mgn.erl
@@ -6752,9 +6752,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mgn">>},
-    Host = build_host(<<"mgn">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mgn">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MGN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6838,7 +6840,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_migration_hub.erl
+++ b/src/aws_migration_hub.erl
@@ -1265,8 +1265,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mgh">>},
-    Host = build_host(<<"mgh">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"mgh">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MIGRATION_HUB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_migration_hub_refactor_spaces.erl
+++ b/src/aws_migration_hub_refactor_spaces.erl
@@ -2111,9 +2111,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"refactor-spaces">>},
-    Host = build_host(<<"refactor-spaces">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"refactor-spaces">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MIGRATION_HUB_REFACTOR_SPACES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2197,7 +2199,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_migrationhub_config.erl
+++ b/src/aws_migrationhub_config.erl
@@ -283,8 +283,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mgh">>},
-    Host = build_host(<<"migrationhub-config">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"migrationhub-config">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MIGRATIONHUB_CONFIG">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_migrationhuborchestrator.erl
+++ b/src/aws_migrationhuborchestrator.erl
@@ -2293,9 +2293,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"migrationhub-orchestrator">>},
-    Host = build_host(<<"migrationhub-orchestrator">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"migrationhub-orchestrator">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MIGRATIONHUBORCHESTRATOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2379,7 +2381,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_migrationhubstrategy.erl
+++ b/src/aws_migrationhubstrategy.erl
@@ -1911,9 +1911,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"migrationhub-strategy">>},
-    Host = build_host(<<"migrationhub-strategy">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"migrationhub-strategy">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MIGRATIONHUBSTRATEGY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1997,7 +1999,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mpa.erl
+++ b/src/aws_mpa.erl
@@ -1727,9 +1727,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mpa">>},
-    Host = build_host(<<"mpa">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mpa">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MPA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1813,7 +1815,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mq.erl
+++ b/src/aws_mq.erl
@@ -1889,9 +1889,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mq">>},
-    Host = build_host(<<"mq">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"mq">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MQ">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1975,7 +1977,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mturk.erl
+++ b/src/aws_mturk.erl
@@ -2163,8 +2163,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"mturk-requester">>,
                       region => <<"">>},
-    Host = build_host(<<"mturk-requester">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"mturk-requester">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MTURK">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_mwaa.erl
+++ b/src/aws_mwaa.erl
@@ -1015,9 +1015,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"airflow">>},
-    Host = build_host(<<"airflow">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"airflow">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_MWAA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1101,7 +1103,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_mwaa_serverless.erl
+++ b/src/aws_mwaa_serverless.erl
@@ -948,8 +948,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"airflow-serverless">>},
-    Host = build_host(<<"airflow-serverless">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"airflow-serverless">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_MWAA_SERVERLESS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_neptune.erl
+++ b/src/aws_neptune.erl
@@ -4381,8 +4381,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
-    Host = build_host(<<"rds">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"rds">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_NEPTUNE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_neptune_graph.erl
+++ b/src/aws_neptune_graph.erl
@@ -2573,9 +2573,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"neptune-graph">>},
-    Host = build_host(<<"neptune-graph">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"neptune-graph">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NEPTUNE_GRAPH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2659,7 +2661,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_neptunedata.erl
+++ b/src/aws_neptunedata.erl
@@ -4220,9 +4220,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"neptune-db">>},
-    Host = build_host(<<"neptune-db">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"neptune-db">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NEPTUNEDATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4306,7 +4308,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_network_firewall.erl
+++ b/src/aws_network_firewall.erl
@@ -4886,8 +4886,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"network-firewall">>},
-    Host = build_host(<<"network-firewall">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"network-firewall">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_NETWORK_FIREWALL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_networkflowmonitor.erl
+++ b/src/aws_networkflowmonitor.erl
@@ -1963,9 +1963,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"networkflowmonitor">>},
-    Host = build_host(<<"networkflowmonitor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"networkflowmonitor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NETWORKFLOWMONITOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2049,7 +2051,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_networkmanager.erl
+++ b/src/aws_networkmanager.erl
@@ -7041,9 +7041,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"networkmanager">>,
                       region => <<"us-west-2">>},
-    Host = build_host(<<"networkmanager">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"networkmanager">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NETWORKMANAGER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7127,7 +7129,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_networkmonitor.erl
+++ b/src/aws_networkmonitor.erl
@@ -1000,9 +1000,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"networkmonitor">>},
-    Host = build_host(<<"networkmonitor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"networkmonitor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NETWORKMONITOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1086,7 +1088,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_notifications.erl
+++ b/src/aws_notifications.erl
@@ -3010,9 +3010,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"notifications">>},
-    Host = build_host(<<"notifications">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"notifications">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NOTIFICATIONS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3096,7 +3098,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_notificationscontacts.erl
+++ b/src/aws_notificationscontacts.erl
@@ -653,9 +653,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"notifications-contacts">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"notifications-contacts">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"notifications-contacts">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NOTIFICATIONSCONTACTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -739,7 +741,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_nova_act.erl
+++ b/src/aws_nova_act.erl
@@ -1227,9 +1227,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"nova-act">>},
-    Host = build_host(<<"nova-act">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"nova-act">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_NOVA_ACT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1313,7 +1315,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_oam.erl
+++ b/src/aws_oam.erl
@@ -1178,9 +1178,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"oam">>},
-    Host = build_host(<<"oam">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"oam">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OAM">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1264,7 +1266,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_observabilityadmin.erl
+++ b/src/aws_observabilityadmin.erl
@@ -2899,9 +2899,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"observabilityadmin">>},
-    Host = build_host(<<"observabilityadmin">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"observabilityadmin">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OBSERVABILITYADMIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2985,7 +2987,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_odb.erl
+++ b/src/aws_odb.erl
@@ -2671,8 +2671,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"odb">>},
-    Host = build_host(<<"odb">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"odb">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ODB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_omics.erl
+++ b/src/aws_omics.erl
@@ -8781,9 +8781,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"omics">>},
-    Host = build_host(<<"omics">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"omics">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OMICS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8867,7 +8869,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_opensearch.erl
+++ b/src/aws_opensearch.erl
@@ -7310,9 +7310,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"es">>},
-    Host = build_host(<<"es">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"es">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OPENSEARCH">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -7396,7 +7398,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_opensearchserverless.erl
+++ b/src/aws_opensearchserverless.erl
@@ -2550,8 +2550,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"aoss">>},
-    Host = build_host(<<"aoss">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"aoss">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_OPENSEARCHSERVERLESS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_organizations.erl
+++ b/src/aws_organizations.erl
@@ -4555,8 +4555,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"organizations">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"organizations">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"organizations">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ORGANIZATIONS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_osis.erl
+++ b/src/aws_osis.erl
@@ -1697,9 +1697,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"osis">>},
-    Host = build_host(<<"osis">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"osis">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OSIS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1783,7 +1785,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_outposts.erl
+++ b/src/aws_outposts.erl
@@ -2802,9 +2802,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"outposts">>},
-    Host = build_host(<<"outposts">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"outposts">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_OUTPOSTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2888,7 +2890,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_panorama.erl
+++ b/src/aws_panorama.erl
@@ -2652,9 +2652,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"panorama">>},
-    Host = build_host(<<"panorama">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"panorama">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PANORAMA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2738,7 +2740,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_partnercentral_account.erl
+++ b/src/aws_partnercentral_account.erl
@@ -1632,8 +1632,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"partnercentral-account">>},
-    Host = build_host(<<"partnercentral-account">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"partnercentral-account">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PARTNERCENTRAL_ACCOUNT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_partnercentral_benefits.erl
+++ b/src/aws_partnercentral_benefits.erl
@@ -1024,8 +1024,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"partnercentral-benefits">>},
-    Host = build_host(<<"partnercentral-benefits">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"partnercentral-benefits">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PARTNERCENTRAL_BENEFITS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_partnercentral_channel.erl
+++ b/src/aws_partnercentral_channel.erl
@@ -1074,8 +1074,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"partnercentral-channel">>},
-    Host = build_host(<<"partnercentral-channel">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"partnercentral-channel">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PARTNERCENTRAL_CHANNEL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_partnercentral_selling.erl
+++ b/src/aws_partnercentral_selling.erl
@@ -2924,8 +2924,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"partnercentral-selling">>},
-    Host = build_host(<<"partnercentral-selling">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"partnercentral-selling">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PARTNERCENTRAL_SELLING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_payment_cryptography.erl
+++ b/src/aws_payment_cryptography.erl
@@ -2773,8 +2773,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"payment-cryptography">>},
-    Host = build_host(<<"controlplane.payment-cryptography">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"controlplane.payment-cryptography">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PAYMENT_CRYPTOGRAPHY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_payment_cryptography_data.erl
+++ b/src/aws_payment_cryptography_data.erl
@@ -2143,9 +2143,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"payment-cryptography">>},
-    Host = build_host(<<"dataplane.payment-cryptography">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"dataplane.payment-cryptography">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PAYMENT_CRYPTOGRAPHY_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2229,7 +2231,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pca_connector_ad.erl
+++ b/src/aws_pca_connector_ad.erl
@@ -2026,9 +2026,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"pca-connector-ad">>},
-    Host = build_host(<<"pca-connector-ad">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"pca-connector-ad">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PCA_CONNECTOR_AD">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2112,7 +2114,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pca_connector_scep.erl
+++ b/src/aws_pca_connector_scep.erl
@@ -911,9 +911,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"pca-connector-scep">>},
-    Host = build_host(<<"pca-connector-scep">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"pca-connector-scep">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PCA_CONNECTOR_SCEP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -997,7 +999,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pcs.erl
+++ b/src/aws_pcs.erl
@@ -1300,8 +1300,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"pcs">>},
-    Host = build_host(<<"pcs">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"pcs">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PCS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_personalize.erl
+++ b/src/aws_personalize.erl
@@ -4461,8 +4461,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"personalize">>},
-    Host = build_host(<<"personalize">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"personalize">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PERSONALIZE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_personalize_events.erl
+++ b/src/aws_personalize_events.erl
@@ -396,9 +396,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"personalize">>},
-    Host = build_host(<<"personalize-events">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"personalize-events">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PERSONALIZE_EVENTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -482,7 +484,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_personalize_runtime.erl
+++ b/src/aws_personalize_runtime.erl
@@ -299,9 +299,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"personalize">>},
-    Host = build_host(<<"personalize-runtime">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"personalize-runtime">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PERSONALIZE_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -385,7 +387,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pi.erl
+++ b/src/aws_pi.erl
@@ -865,8 +865,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"pi">>},
-    Host = build_host(<<"pi">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"pi">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PI">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_pinpoint.erl
+++ b/src/aws_pinpoint.erl
@@ -10051,9 +10051,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"mobiletargeting">>},
-    Host = build_host(<<"pinpoint">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"pinpoint">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PINPOINT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -10137,7 +10139,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pinpoint_email.erl
+++ b/src/aws_pinpoint_email.erl
@@ -3180,9 +3180,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ses">>},
-    Host = build_host(<<"email">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"email">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PINPOINT_EMAIL">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3266,7 +3268,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pinpoint_sms_voice.erl
+++ b/src/aws_pinpoint_sms_voice.erl
@@ -613,9 +613,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sms-voice">>},
-    Host = build_host(<<"sms-voice.pinpoint">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"sms-voice.pinpoint">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PINPOINT_SMS_VOICE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -699,7 +701,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pinpoint_sms_voice_v2.erl
+++ b/src/aws_pinpoint_sms_voice_v2.erl
@@ -5964,8 +5964,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sms-voice">>},
-    Host = build_host(<<"sms-voice">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"sms-voice">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PINPOINT_SMS_VOICE_V2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_pipes.erl
+++ b/src/aws_pipes.erl
@@ -1463,9 +1463,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"pipes">>},
-    Host = build_host(<<"pipes">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"pipes">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_PIPES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1549,7 +1551,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_polly.erl
+++ b/src/aws_polly.erl
@@ -1056,9 +1056,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"polly">>},
-    Host = build_host(<<"polly">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"polly">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_POLLY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1142,7 +1144,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_pricing.erl
+++ b/src/aws_pricing.erl
@@ -397,8 +397,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"pricing">>},
-    Host = build_host(<<"api.pricing">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"api.pricing">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PRICING">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_proton.erl
+++ b/src/aws_proton.erl
@@ -5014,8 +5014,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"proton">>},
-    Host = build_host(<<"proton">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"proton">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_PROTON">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_qapps.erl
+++ b/src/aws_qapps.erl
@@ -2840,9 +2840,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"qapps">>},
-    Host = build_host(<<"data.qapps">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data.qapps">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_QAPPS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2926,7 +2928,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_qbusiness.erl
+++ b/src/aws_qbusiness.erl
@@ -6798,9 +6798,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"qbusiness">>},
-    Host = build_host(<<"qbusiness">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"qbusiness">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_QBUSINESS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -6884,7 +6886,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_qconnect.erl
+++ b/src/aws_qconnect.erl
@@ -8020,9 +8020,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wisdom">>},
-    Host = build_host(<<"wisdom">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"wisdom">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_QCONNECT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8106,7 +8108,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_quicksight.erl
+++ b/src/aws_quicksight.erl
@@ -26814,9 +26814,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"quicksight">>},
-    Host = build_host(<<"quicksight">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"quicksight">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_QUICKSIGHT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -26900,7 +26902,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ram.erl
+++ b/src/aws_ram.erl
@@ -2985,9 +2985,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ram">>},
-    Host = build_host(<<"ram">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ram">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RAM">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3071,7 +3073,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_rbin.erl
+++ b/src/aws_rbin.erl
@@ -806,9 +806,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rbin">>},
-    Host = build_host(<<"rbin">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"rbin">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RBIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -892,7 +894,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_rds.erl
+++ b/src/aws_rds.erl
@@ -11115,8 +11115,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rds">>},
-    Host = build_host(<<"rds">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"rds">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_RDS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_rds_data.erl
+++ b/src/aws_rds_data.erl
@@ -714,9 +714,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rds-data">>},
-    Host = build_host(<<"rds-data">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"rds-data">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RDS_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -800,7 +802,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_redshift.erl
+++ b/src/aws_redshift.erl
@@ -8332,8 +8332,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"redshift">>},
-    Host = build_host(<<"redshift">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"redshift">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_REDSHIFT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_redshift_data.erl
+++ b/src/aws_redshift_data.erl
@@ -968,8 +968,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"redshift-data">>},
-    Host = build_host(<<"redshift-data">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"redshift-data">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_REDSHIFT_DATA">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_redshift_serverless.erl
+++ b/src/aws_redshift_serverless.erl
@@ -3159,8 +3159,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"redshift-serverless">>},
-    Host = build_host(<<"redshift-serverless">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"redshift-serverless">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_REDSHIFT_SERVERLESS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_rekognition.erl
+++ b/src/aws_rekognition.erl
@@ -6953,8 +6953,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"rekognition">>},
-    Host = build_host(<<"rekognition">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"rekognition">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_REKOGNITION">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_repostspace.erl
+++ b/src/aws_repostspace.erl
@@ -1307,9 +1307,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"repostspace">>},
-    Host = build_host(<<"repostspace">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"repostspace">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_REPOSTSPACE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1393,7 +1395,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_resiliencehub.erl
+++ b/src/aws_resiliencehub.erl
@@ -4915,9 +4915,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"resiliencehub">>},
-    Host = build_host(<<"resiliencehub">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"resiliencehub">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RESILIENCEHUB">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5001,7 +5003,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_resiliencehubv2.erl
+++ b/src/aws_resiliencehubv2.erl
@@ -4205,9 +4205,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"resiliencehub">>},
-    Host = build_host(<<"resiliencehub">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"resiliencehub">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RESILIENCEHUBV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4291,7 +4293,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_resource_explorer_2.erl
+++ b/src/aws_resource_explorer_2.erl
@@ -2403,9 +2403,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"resource-explorer-2">>},
-    Host = build_host(<<"resource-explorer-2">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"resource-explorer-2">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RESOURCE_EXPLORER_2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2489,7 +2491,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_resource_groups.erl
+++ b/src/aws_resource_groups.erl
@@ -1942,9 +1942,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"resource-groups">>},
-    Host = build_host(<<"resource-groups">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"resource-groups">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RESOURCE_GROUPS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2028,7 +2030,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_resource_groups_tagging_api.erl
+++ b/src/aws_resource_groups_tagging_api.erl
@@ -713,8 +713,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"tagging">>},
-    Host = build_host(<<"tagging">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"tagging">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_RESOURCE_GROUPS_TAGGING_API">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_rolesanywhere.erl
+++ b/src/aws_rolesanywhere.erl
@@ -1874,9 +1874,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rolesanywhere">>},
-    Host = build_host(<<"rolesanywhere">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"rolesanywhere">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROLESANYWHERE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1960,7 +1962,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53.erl
+++ b/src/aws_route53.erl
@@ -6664,9 +6664,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"route53">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"route53">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROUTE53">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"text/xml">>}
                          ],
@@ -6750,7 +6752,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53_domains.erl
+++ b/src/aws_route53_domains.erl
@@ -1964,8 +1964,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53domains">>},
-    Host = build_host(<<"route53domains">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"route53domains">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ROUTE53_DOMAINS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_route53_recovery_cluster.erl
+++ b/src/aws_route53_recovery_cluster.erl
@@ -502,8 +502,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53-recovery-cluster">>},
-    Host = build_host(<<"route53-recovery-cluster">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"route53-recovery-cluster">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ROUTE53_RECOVERY_CLUSTER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_route53_recovery_control_config.erl
+++ b/src/aws_route53_recovery_control_config.erl
@@ -1759,9 +1759,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53-recovery-control-config">>},
-    Host = build_host(<<"route53-recovery-control-config">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"route53-recovery-control-config">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROUTE53_RECOVERY_CONTROL_CONFIG">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1845,7 +1847,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53_recovery_readiness.erl
+++ b/src/aws_route53_recovery_readiness.erl
@@ -2197,9 +2197,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53-recovery-readiness">>},
-    Host = build_host(<<"route53-recovery-readiness">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"route53-recovery-readiness">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROUTE53_RECOVERY_READINESS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2283,7 +2285,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53globalresolver.erl
+++ b/src/aws_route53globalresolver.erl
@@ -3878,9 +3878,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53globalresolver">>},
-    Host = build_host(<<"route53globalresolver">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"route53globalresolver">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROUTE53GLOBALRESOLVER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3964,7 +3966,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53profiles.erl
+++ b/src/aws_route53profiles.erl
@@ -1169,9 +1169,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"route53profiles">>},
-    Host = build_host(<<"route53profiles">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"route53profiles">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_ROUTE53PROFILES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1255,7 +1257,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_route53resolver.erl
+++ b/src/aws_route53resolver.erl
@@ -3802,8 +3802,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"route53resolver">>},
-    Host = build_host(<<"route53resolver">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"route53resolver">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_ROUTE53RESOLVER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_rtbfabric.erl
+++ b/src/aws_rtbfabric.erl
@@ -2651,9 +2651,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rtbfabric">>},
-    Host = build_host(<<"rtbfabric">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"rtbfabric">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RTBFABRIC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2737,7 +2739,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_rum.erl
+++ b/src/aws_rum.erl
@@ -1668,9 +1668,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"rum">>},
-    Host = build_host(<<"rum">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"rum">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_RUM">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1754,7 +1756,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -17591,9 +17591,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode, Bucket) ->
     Client1 = Client#{service => <<"s3">>},
-    Host = build_host(<<"s3">>, Client1, Bucket),
-    URL0 = build_url(Host, Path, Client1, Bucket),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"s3">>, Client1, Bucket),
+    URL0 = build_url(DefaultHost, Path, Client1, Bucket),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"text/xml">>}
                          ],
@@ -17684,7 +17686,6 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}, undefined)
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>);
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}, Bucket) ->
     aws_util:binary_join([Bucket, EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host0, Path0, Client, Bucket) ->
     Proto = aws_client:proto(Client),
     %% Mocks are notoriously bad with host-style requests, just skip it and use path-style for anything local

--- a/src/aws_s3_control.erl
+++ b/src/aws_s3_control.erl
@@ -9096,9 +9096,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3">>},
     AccountId = proplists:get_value(<<"x-amz-account-id">>, Headers0),
-    Host = build_host(AccountId, <<"s3-control">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(AccountId, <<"s3-control">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3_CONTROL">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"text/xml">>}
                          ],
@@ -9185,7 +9187,6 @@ build_host(undefined, _EndpointPrefix, _Client) ->
 build_host(AccountId, EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([AccountId, EndpointPrefix, Region, Endpoint],
                          <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_s3files.erl
+++ b/src/aws_s3files.erl
@@ -1478,9 +1478,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3files">>},
-    Host = build_host(<<"s3files">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"s3files">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3FILES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1564,7 +1566,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_s3outposts.erl
+++ b/src/aws_s3outposts.erl
@@ -492,9 +492,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3-outposts">>},
-    Host = build_host(<<"s3-outposts">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"s3-outposts">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3OUTPOSTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -578,7 +580,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_s3tables.erl
+++ b/src/aws_s3tables.erl
@@ -3693,9 +3693,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3tables">>},
-    Host = build_host(<<"s3tables">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"s3tables">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3TABLES">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3779,7 +3781,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_s3vectors.erl
+++ b/src/aws_s3vectors.erl
@@ -1516,9 +1516,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"s3vectors">>},
-    Host = build_host(<<"s3vectors">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"s3vectors">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_S3VECTORS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1602,7 +1604,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker.erl
+++ b/src/aws_sagemaker.erl
@@ -23884,8 +23884,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"api.sagemaker">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"api.sagemaker">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_sagemaker_a2i_runtime.erl
+++ b/src/aws_sagemaker_a2i_runtime.erl
@@ -467,9 +467,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"a2i-runtime.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"a2i-runtime.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_A2I_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -553,7 +555,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_edge.erl
+++ b/src/aws_sagemaker_edge.erl
@@ -279,9 +279,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"edge.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"edge.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_EDGE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -365,7 +367,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_featurestore_runtime.erl
+++ b/src/aws_sagemaker_featurestore_runtime.erl
@@ -442,9 +442,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"featurestore-runtime.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"featurestore-runtime.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_FEATURESTORE_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -528,7 +530,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_geospatial.erl
+++ b/src/aws_sagemaker_geospatial.erl
@@ -1745,9 +1745,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker-geospatial">>},
-    Host = build_host(<<"sagemaker-geospatial">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"sagemaker-geospatial">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_GEOSPATIAL">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1831,7 +1833,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_metrics.erl
+++ b/src/aws_sagemaker_metrics.erl
@@ -184,9 +184,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"metrics.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"metrics.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_METRICS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -270,7 +272,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_runtime.erl
+++ b/src/aws_sagemaker_runtime.erl
@@ -495,9 +495,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"runtime.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"runtime.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_RUNTIME">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -581,7 +583,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sagemaker_runtime_http2.erl
+++ b/src/aws_sagemaker_runtime_http2.erl
@@ -219,9 +219,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sagemaker">>},
-    Host = build_host(<<"runtime.sagemaker">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"runtime.sagemaker">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAGEMAKER_RUNTIME_HTTP2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -305,7 +307,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_savingsplans.erl
+++ b/src/aws_savingsplans.erl
@@ -796,9 +796,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"savingsplans">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"savingsplans">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"savingsplans">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SAVINGSPLANS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -882,7 +884,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_scheduler.erl
+++ b/src/aws_scheduler.erl
@@ -1040,9 +1040,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"scheduler">>},
-    Host = build_host(<<"scheduler">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"scheduler">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SCHEDULER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1126,7 +1128,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_schemas.erl
+++ b/src/aws_schemas.erl
@@ -2093,9 +2093,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"schemas">>},
-    Host = build_host(<<"schemas">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"schemas">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SCHEMAS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2179,7 +2181,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_secrets_manager.erl
+++ b/src/aws_secrets_manager.erl
@@ -2038,8 +2038,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"secretsmanager">>},
-    Host = build_host(<<"secretsmanager">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"secretsmanager">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SECRETS_MANAGER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_security_ir.erl
+++ b/src/aws_security_ir.erl
@@ -1564,9 +1564,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"security-ir">>},
-    Host = build_host(<<"security-ir">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"security-ir">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SECURITY_IR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1650,7 +1652,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_securityagent.erl
+++ b/src/aws_securityagent.erl
@@ -4111,9 +4111,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"securityagent">>},
-    Host = build_host(<<"securityagent">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"securityagent">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SECURITYAGENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -4197,7 +4199,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_securityhub.erl
+++ b/src/aws_securityhub.erl
@@ -15377,9 +15377,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"securityhub">>},
-    Host = build_host(<<"securityhub">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"securityhub">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SECURITYHUB">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -15463,7 +15465,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_securitylake.erl
+++ b/src/aws_securitylake.erl
@@ -2414,9 +2414,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"securitylake">>},
-    Host = build_host(<<"securitylake">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"securitylake">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SECURITYLAKE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2500,7 +2502,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_serverlessapplicationrepository.erl
+++ b/src/aws_serverlessapplicationrepository.erl
@@ -1160,9 +1160,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"serverlessrepo">>},
-    Host = build_host(<<"serverlessrepo">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"serverlessrepo">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SERVERLESSAPPLICATIONREPOSITORY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1246,7 +1248,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_service_catalog.erl
+++ b/src/aws_service_catalog.erl
@@ -4681,8 +4681,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicecatalog">>},
-    Host = build_host(<<"servicecatalog">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"servicecatalog">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SERVICE_CATALOG">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_service_catalog_appregistry.erl
+++ b/src/aws_service_catalog_appregistry.erl
@@ -1792,9 +1792,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"servicecatalog">>},
-    Host = build_host(<<"servicecatalog-appregistry">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"servicecatalog-appregistry">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SERVICE_CATALOG_APPREGISTRY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1878,7 +1880,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_service_quotas.erl
+++ b/src/aws_service_quotas.erl
@@ -1472,8 +1472,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicequotas">>},
-    Host = build_host(<<"servicequotas">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"servicequotas">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SERVICE_QUOTAS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_servicediscovery.erl
+++ b/src/aws_servicediscovery.erl
@@ -1787,8 +1787,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"servicediscovery">>},
-    Host = build_host(<<"servicediscovery">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"servicediscovery">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SERVICEDISCOVERY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ses.erl
+++ b/src/aws_ses.erl
@@ -3955,8 +3955,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ses">>},
-    Host = build_host(<<"email">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"email">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SES">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_sesv2.erl
+++ b/src/aws_sesv2.erl
@@ -8193,9 +8193,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ses">>},
-    Host = build_host(<<"email">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"email">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SESV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -8279,7 +8281,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sfn.erl
+++ b/src/aws_sfn.erl
@@ -3196,8 +3196,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"states">>},
-    Host = build_host(<<"states">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"states">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SFN">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_shield.erl
+++ b/src/aws_shield.erl
@@ -1939,8 +1939,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"shield">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"shield">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"shield">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SHIELD">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_signer.erl
+++ b/src/aws_signer.erl
@@ -1655,9 +1655,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"signer">>},
-    Host = build_host(<<"signer">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"signer">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SIGNER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1741,7 +1743,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_signer_data.erl
+++ b/src/aws_signer_data.erl
@@ -141,9 +141,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"signer">>},
-    Host = build_host(<<"data-signer">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"data-signer">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SIGNER_DATA">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -227,7 +229,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_signin.erl
+++ b/src/aws_signin.erl
@@ -202,9 +202,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"signin">>},
-    Host = build_host(<<"signin">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"signin">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SIGNIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -288,7 +290,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_simpledbv2.erl
+++ b/src/aws_simpledbv2.erl
@@ -306,9 +306,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sdb">>},
-    Host = build_host(<<"sdb">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"sdb">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SIMPLEDBV2">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -392,7 +394,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_simspaceweaver.erl
+++ b/src/aws_simspaceweaver.erl
@@ -1251,9 +1251,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"simspaceweaver">>},
-    Host = build_host(<<"simspaceweaver">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"simspaceweaver">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SIMSPACEWEAVER">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1337,7 +1339,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_snow_device_management.erl
+++ b/src/aws_snow_device_management.erl
@@ -1038,9 +1038,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"snow-device-management">>},
-    Host = build_host(<<"snow-device-management">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"snow-device-management">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SNOW_DEVICE_MANAGEMENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1124,7 +1126,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_snowball.erl
+++ b/src/aws_snowball.erl
@@ -1683,8 +1683,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"snowball">>},
-    Host = build_host(<<"snowball">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"snowball">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SNOWBALL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_sns.erl
+++ b/src/aws_sns.erl
@@ -2437,8 +2437,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sns">>},
-    Host = build_host(<<"sns">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"sns">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SNS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_socialmessaging.erl
+++ b/src/aws_socialmessaging.erl
@@ -1710,9 +1710,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"social-messaging">>},
-    Host = build_host(<<"social-messaging">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"social-messaging">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SOCIALMESSAGING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1796,7 +1798,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sqs.erl
+++ b/src/aws_sqs.erl
@@ -1861,8 +1861,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sqs">>},
-    Host = build_host(<<"sqs">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"sqs">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SQS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_ssm.erl
+++ b/src/aws_ssm.erl
@@ -10129,8 +10129,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ssm">>},
-    Host = build_host(<<"ssm">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ssm">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SSM">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ssm_contacts.erl
+++ b/src/aws_ssm_contacts.erl
@@ -2032,8 +2032,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"ssm-contacts">>},
-    Host = build_host(<<"ssm-contacts">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ssm-contacts">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SSM_CONTACTS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_ssm_guiconnect.erl
+++ b/src/aws_ssm_guiconnect.erl
@@ -309,9 +309,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ssm-guiconnect">>},
-    Host = build_host(<<"ssm-guiconnect">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ssm-guiconnect">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSM_GUICONNECT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -395,7 +397,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ssm_incidents.erl
+++ b/src/aws_ssm_incidents.erl
@@ -2295,9 +2295,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ssm-incidents">>},
-    Host = build_host(<<"ssm-incidents">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ssm-incidents">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSM_INCIDENTS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2381,7 +2383,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ssm_quicksetup.erl
+++ b/src/aws_ssm_quicksetup.erl
@@ -979,9 +979,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ssm-quicksetup">>},
-    Host = build_host(<<"ssm-quicksetup">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ssm-quicksetup">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSM_QUICKSETUP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1065,7 +1067,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_ssm_sap.erl
+++ b/src/aws_ssm_sap.erl
@@ -1924,9 +1924,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"ssm-sap">>},
-    Host = build_host(<<"ssm-sap">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"ssm-sap">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSM_SAP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2010,7 +2012,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sso.erl
+++ b/src/aws_sso.erl
@@ -416,9 +416,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"awsssoportal">>},
-    Host = build_host(<<"portal.sso">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"portal.sso">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSO">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -502,7 +504,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sso_admin.erl
+++ b/src/aws_sso_admin.erl
@@ -4001,8 +4001,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sso">>},
-    Host = build_host(<<"sso">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"sso">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SSO_ADMIN">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_sso_oidc.erl
+++ b/src/aws_sso_oidc.erl
@@ -536,9 +536,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sso-oauth">>},
-    Host = build_host(<<"oidc">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"oidc">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SSO_OIDC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -622,7 +624,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_storage_gateway.erl
+++ b/src/aws_storage_gateway.erl
@@ -5424,8 +5424,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"storagegateway">>},
-    Host = build_host(<<"storagegateway">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"storagegateway">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_STORAGE_GATEWAY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_sts.erl
+++ b/src/aws_sts.erl
@@ -1536,8 +1536,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"sts">>},
-    Host = build_host(<<"sts">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"sts">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_STS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}

--- a/src/aws_supplychain.erl
+++ b/src/aws_supplychain.erl
@@ -2316,9 +2316,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"scn">>},
-    Host = build_host(<<"scn">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"scn">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SUPPLYCHAIN">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2402,7 +2404,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -1344,8 +1344,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"support">>},
-    Host = build_host(<<"support">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"support">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SUPPORT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_support_app.erl
+++ b/src/aws_support_app.erl
@@ -792,9 +792,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"supportapp">>},
-    Host = build_host(<<"supportapp">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"supportapp">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SUPPORT_APP">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -878,7 +880,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_sustainability.erl
+++ b/src/aws_sustainability.erl
@@ -270,9 +270,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"sustainability">>},
-    Host = build_host(<<"sustainability">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"sustainability">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SUSTAINABILITY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -356,7 +358,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_swf.erl
+++ b/src/aws_swf.erl
@@ -3824,8 +3824,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"swf">>},
-    Host = build_host(<<"swf">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"swf">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_SWF">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_synthetics.erl
+++ b/src/aws_synthetics.erl
@@ -1921,9 +1921,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"synthetics">>},
-    Host = build_host(<<"synthetics">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"synthetics">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_SYNTHETICS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2007,7 +2009,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_taxsettings.erl
+++ b/src/aws_taxsettings.erl
@@ -1861,9 +1861,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"tax">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"tax">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"tax">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_TAXSETTINGS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1947,7 +1949,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_textract.erl
+++ b/src/aws_textract.erl
@@ -2137,8 +2137,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"textract">>},
-    Host = build_host(<<"textract">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"textract">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TEXTRACT">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_timestream_influxdb.erl
+++ b/src/aws_timestream_influxdb.erl
@@ -1250,8 +1250,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"timestream-influxdb">>},
-    Host = build_host(<<"timestream-influxdb">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"timestream-influxdb">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TIMESTREAM_INFLUXDB">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_timestream_query.erl
+++ b/src/aws_timestream_query.erl
@@ -1147,8 +1147,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"timestream">>},
-    Host = build_host(<<"query.timestream">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"query.timestream">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TIMESTREAM_QUERY">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_timestream_write.erl
+++ b/src/aws_timestream_write.erl
@@ -1376,8 +1376,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"timestream">>},
-    Host = build_host(<<"ingest.timestream">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"ingest.timestream">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TIMESTREAM_WRITE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_tnb.erl
+++ b/src/aws_tnb.erl
@@ -2724,9 +2724,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"tnb">>},
-    Host = build_host(<<"tnb">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"tnb">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_TNB">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -2810,7 +2812,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_transcribe.erl
+++ b/src/aws_transcribe.erl
@@ -2718,8 +2718,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"transcribe">>},
-    Host = build_host(<<"transcribe">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"transcribe">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TRANSCRIBE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_transcribe_streaming.erl
+++ b/src/aws_transcribe_streaming.erl
@@ -1176,9 +1176,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"transcribe">>},
-    Host = build_host(<<"transcribestreaming">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"transcribestreaming">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_TRANSCRIBE_STREAMING">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1262,7 +1264,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_transfer.erl
+++ b/src/aws_transfer.erl
@@ -3986,8 +3986,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"transfer">>},
-    Host = build_host(<<"transfer">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"transfer">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TRANSFER">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_translate.erl
+++ b/src/aws_translate.erl
@@ -1172,8 +1172,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"translate">>},
-    Host = build_host(<<"translate">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"translate">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_TRANSLATE">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_trustedadvisor.erl
+++ b/src/aws_trustedadvisor.erl
@@ -1071,9 +1071,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"trustedadvisor">>},
-    Host = build_host(<<"trustedadvisor">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"trustedadvisor">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_TRUSTEDADVISOR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1157,7 +1159,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_uxc.erl
+++ b/src/aws_uxc.erl
@@ -308,9 +308,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"uxc">>},
-    Host = build_host(<<"uxc">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"uxc">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_UXC">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -394,7 +396,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_verifiedpermissions.erl
+++ b/src/aws_verifiedpermissions.erl
@@ -2260,8 +2260,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"verifiedpermissions">>},
-    Host = build_host(<<"verifiedpermissions">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"verifiedpermissions">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_VERIFIEDPERMISSIONS">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_voice_id.erl
+++ b/src/aws_voice_id.erl
@@ -1580,8 +1580,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"voiceid">>},
-    Host = build_host(<<"voiceid">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"voiceid">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_VOICE_ID">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_vpc_lattice.erl
+++ b/src/aws_vpc_lattice.erl
@@ -5417,9 +5417,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"vpc-lattice">>},
-    Host = build_host(<<"vpc-lattice">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"vpc-lattice">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_VPC_LATTICE">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5503,7 +5505,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_waf.erl
+++ b/src/aws_waf.erl
@@ -6053,8 +6053,8 @@ request(Client, Action, Input, Options) ->
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"waf">>,
                       region => <<"us-east-1">>},
-    Host = build_host(<<"waf">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"waf">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WAF">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_waf_regional.erl
+++ b/src/aws_waf_regional.erl
@@ -6278,8 +6278,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"waf-regional">>},
-    Host = build_host(<<"waf-regional">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"waf-regional">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WAF_REGIONAL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_wafv2.erl
+++ b/src/aws_wafv2.erl
@@ -4302,8 +4302,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"wafv2">>},
-    Host = build_host(<<"wafv2">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"wafv2">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WAFV2">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_wellarchitected.erl
+++ b/src/aws_wellarchitected.erl
@@ -5588,9 +5588,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wellarchitected">>},
-    Host = build_host(<<"wellarchitected">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"wellarchitected">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WELLARCHITECTED">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5674,7 +5676,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_wickr.erl
+++ b/src/aws_wickr.erl
@@ -3534,9 +3534,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wickr">>},
-    Host = build_host(<<"admin.wickr">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"admin.wickr">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WICKR">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3620,7 +3622,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_wisdom.erl
+++ b/src/aws_wisdom.erl
@@ -3054,9 +3054,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"wisdom">>},
-    Host = build_host(<<"wisdom">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"wisdom">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WISDOM">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3140,7 +3142,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_workdocs.erl
+++ b/src/aws_workdocs.erl
@@ -3584,9 +3584,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"workdocs">>},
-    Host = build_host(<<"workdocs">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"workdocs">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WORKDOCS">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3670,7 +3672,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_workmail.erl
+++ b/src/aws_workmail.erl
@@ -4559,8 +4559,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"workmail">>},
-    Host = build_host(<<"workmail">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"workmail">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WORKMAIL">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_workmailmessageflow.erl
+++ b/src/aws_workmailmessageflow.erl
@@ -211,9 +211,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"workmailmessageflow">>},
-    Host = build_host(<<"workmailmessageflow">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"workmailmessageflow">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WORKMAILMESSAGEFLOW">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -297,7 +299,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -5059,8 +5059,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"workspaces">>},
-    Host = build_host(<<"workspaces">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"workspaces">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WORKSPACES">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},

--- a/src/aws_workspaces_instances.erl
+++ b/src/aws_workspaces_instances.erl
@@ -956,8 +956,8 @@ request(Client, Action, Input, Options) ->
 
 do_request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"workspaces-instances">>},
-    Host = build_host(<<"workspaces-instances">>, Client1),
-    URL = build_url(Host, Client1),
+    DefaultHost = build_host(<<"workspaces-instances">>, Client1),
+    {URL, Host} = aws_util:apply_endpoint_url_override(build_url(DefaultHost, Client1), DefaultHost, <<"/">>, <<"AWS_ENDPOINT_URL_AWS_WORKSPACES_INSTANCES">>),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},

--- a/src/aws_workspaces_thin_client.erl
+++ b/src/aws_workspaces_thin_client.erl
@@ -1224,9 +1224,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"thinclient">>},
-    Host = build_host(<<"thinclient">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"thinclient">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WORKSPACES_THIN_CLIENT">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -1310,7 +1312,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_workspaces_web.erl
+++ b/src/aws_workspaces_web.erl
@@ -5075,9 +5075,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"workspaces-web">>},
-    Host = build_host(<<"workspaces-web">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"workspaces-web">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_WORKSPACES_WEB">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -5161,7 +5163,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),

--- a/src/aws_xray.erl
+++ b/src/aws_xray.erl
@@ -3170,9 +3170,11 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
 
 do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"xray">>},
-    Host = build_host(<<"xray">>, Client1),
-    URL0 = build_url(Host, Path, Client1),
-    URL = aws_request:add_query(URL0, Query),
+    DefaultHost = build_host(<<"xray">>, Client1),
+    URL0 = build_url(DefaultHost, Path, Client1),
+    PathBin = erlang:iolist_to_binary(Path),
+    {URL1, Host} = aws_util:apply_endpoint_url_override(URL0, DefaultHost, PathBin, <<"AWS_ENDPOINT_URL_AWS_XRAY">>),
+    URL = aws_request:add_query(URL1, Query),
     AdditionalHeaders1 = [ {<<"Host">>, Host}
                          , {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
                          ],
@@ -3256,7 +3258,6 @@ build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
-
 build_url(Host, Path0, Client) ->
     Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),


### PR DESCRIPTION
Decided to explicitly merge in these changes just so I can move ahead with another PR rather than wait a day for codegen to pick up the latest changes. I anyways had to bump aws_beam_core so figured I'd release the latest changes as part of this. 

* [Bump aws_beam_core to 1.2.0 to include AWS_ENDPOIN_URL env var](https://github.com/aws-beam/aws-erlang/commit/10d4774a51b498c7d42f6c63668f196990c5cc25)
* [Generate code based on latest aws-codegen](https://github.com/aws-beam/aws-erlang/commit/d06c6d8558ce199c8aa1224c2ed1a1ae09af0580)